### PR TITLE
Implementiert leeren EN-Ordner

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -2032,6 +2032,7 @@ let isDirty                = false;
 
 let projektOrdnerHandle    = null; // Gewählter Projektordner
 let deOrdnerHandle         = null; // Handle für den DE-Ordner
+let enOrdnerHandle         = null; // Handle für den EN-Ordner
 let enDateien              = [];   // Gefundene EN-Audiodateien
 let aktuellerUploadPfad    = null; // Zielpfad für hochgeladene Dateien
 
@@ -7304,10 +7305,12 @@ async function waehleProjektOrdner() {
 
         // DE-Ordner anlegen oder öffnen
         deOrdnerHandle = await projektOrdnerHandle.getDirectoryHandle('DE', { create: true });
+        // EN-Ordner anlegen oder öffnen
+        enOrdnerHandle = await projektOrdnerHandle.getDirectoryHandle('EN', { create: true });
 
         enDateien = [];
 
-        // Rekursives Einlesen aller Unterordner
+        // Rekursives Einlesen aller Unterordner des EN-Ordners
         async function leseOrdner(handle, deHandle, pfad = '') {
             for await (const [name, child] of handle.entries()) {
                 if (name === 'DE') continue; // DE-Ordner überspringen
@@ -7323,7 +7326,7 @@ async function waehleProjektOrdner() {
             }
         }
 
-        await leseOrdner(projektOrdnerHandle, deOrdnerHandle);
+        await leseOrdner(enOrdnerHandle, deOrdnerHandle);
         updateStatus('Projektordner eingelesen');
     } catch (e) {
         console.error('Ordnerauswahl fehlgeschlagen:', e);


### PR DESCRIPTION
## Summary
- lege beim Wählen des Projektordners automatisch einen EN-Ordner an
- spiegle jetzt die EN-Ordnerstruktur direkt in den DE-Ordner

## Testing
- `npm test` *(scheitert: jest nicht gefunden)*

------
https://chatgpt.com/codex/tasks/task_e_684767c718448327adb47d107fe35ab0