### PR TITLE
Modify start command to handle root execution

### DIFF
--- a/start_tool.js
+++ b/start_tool.js
@@ -92,7 +92,12 @@ try {
 
 console.log('Anwendung wird gestartet...');
 log('Starte Anwendung');
-run('npm start');
+// Wenn das Skript als root ausgeführt wird, muss Electron ohne Sandbox starten
+if (process.getuid && process.getuid() === 0) {
+    run('npm start -- --no-sandbox');
+} else {
+    run('npm start');
+}
 log('Anwendung beendet');
 
 console.log(`Log gespeichert unter ${LOGFILE}`);


### PR DESCRIPTION
## Summary
- run Electron without sandbox when executing as root
- add a German comment explaining the behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848179064b48327916e2abedc907c90