### PR TITLE
Ergaenze Tests fuer calculateProjectStats

### DIFF
--- a/tests/calculateProjectStats.test.js
+++ b/tests/calculateProjectStats.test.js
@@ -22,4 +22,53 @@ describe('calculateProjectStats', () => {
             totalFiles: 1
         });
     });
+
+    // Testfall: Nur EN-Texte vorhanden
+    test('only EN texts present', () => {
+        const result = calculateProjectStats({
+            files: [
+                { enText: 'EN1', deText: '', completed: false },
+                { enText: 'EN2', deText: '', completed: false },
+                { enText: 'EN3', deText: '', completed: false }
+            ]
+        });
+        expect(result).toEqual({
+            enPercent: 100,
+            dePercent: 0,
+            completedPercent: 0,
+            totalFiles: 3
+        });
+    });
+
+    // Testfall: Nur DE-Texte vorhanden
+    test('only DE texts present', () => {
+        const result = calculateProjectStats({
+            files: [
+                { enText: '', deText: 'DE1', completed: false },
+                { enText: '', deText: 'DE2', completed: false }
+            ]
+        });
+        expect(result).toEqual({
+            enPercent: 0,
+            dePercent: 100,
+            completedPercent: 0,
+            totalFiles: 2
+        });
+    });
+
+    // Testfall: Gleichmäßige Verteilung von EN- und DE-Texten
+    test('mixed ratio of 50% EN and 50% DE texts', () => {
+        const result = calculateProjectStats({
+            files: [
+                { enText: 'EN1', deText: '', completed: false },
+                { enText: '', deText: 'DE1', completed: false }
+            ]
+        });
+        expect(result).toEqual({
+            enPercent: 50,
+            dePercent: 50,
+            completedPercent: 0,
+            totalFiles: 2
+        });
+    });
 });


### PR DESCRIPTION
## Zusammenfassung
- neue Testfaelle fuer `calculateProjectStats` hinzugefuegt
- prueft nur EN-Texte, nur DE-Texte sowie ein 50/50-Mischverhaeltnis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684817a29fdc832790a5b19674bce30c