### PR TITLE
Verbesserte Startskripte

### DIFF
--- a/start_tool.js
+++ b/start_tool.js
@@ -54,15 +54,19 @@ try {
 }
 
 log('Repository-Pruefung');
-const repoPath = path.join(__dirname, 'hla_translation_tool');
-const gitFolder = path.join(repoPath, '.git');
-
-// Repository klonen, falls es noch nicht vorhanden ist
-if (!fs.existsSync(gitFolder)) {
-    if (!fs.existsSync(repoPath)) {
-        console.log('Repository wird geklont...');
-        log('Repository wird geklont');
-        run(`git clone https://github.com/Lumorn/hla_translation_tool "${repoPath}"`);
+// Standardpfad ist das Verzeichnis dieses Skripts
+let repoPath = __dirname;
+// Liegt hier kein Git-Repo, wird in den Unterordner gewechselt bzw. geklont
+if (!fs.existsSync(path.join(repoPath, '.git'))) {
+    repoPath = path.join(__dirname, 'hla_translation_tool');
+    const gitFolder = path.join(repoPath, '.git');
+    // Repository klonen, falls es noch nicht vorhanden ist
+    if (!fs.existsSync(gitFolder)) {
+        if (!fs.existsSync(repoPath)) {
+            console.log('Repository wird geklont...');
+            log('Repository wird geklont');
+            run(`git clone https://github.com/Lumorn/hla_translation_tool "${repoPath}"`);
+        }
     }
 }
 

--- a/start_tool.py
+++ b/start_tool.py
@@ -61,14 +61,16 @@ except subprocess.CalledProcessError:
     sys.exit(1)
 
 log("Repository-Pruefung")
-repo_path = os.path.join(BASE_DIR, "hla_translation_tool")
-
-# Repository klonen, falls nicht vorhanden
+# Standardpfad ist der Ordner dieses Skripts
+repo_path = BASE_DIR
+# Liegt hier kein Git-Repo, wird in den Unterordner gewechselt bzw. geklont
 if not os.path.exists(os.path.join(repo_path, ".git")):
-    if not os.path.exists(repo_path):
-        print("Repository wird geklont...")
-        log("Repository wird geklont")
-        run(f"git clone https://github.com/Lumorn/hla_translation_tool \"{repo_path}\"")
+    repo_path = os.path.join(BASE_DIR, "hla_translation_tool")
+    if not os.path.exists(os.path.join(repo_path, ".git")):
+        if not os.path.exists(repo_path):
+            print("Repository wird geklont...")
+            log("Repository wird geklont")
+            run(f"git clone https://github.com/Lumorn/hla_translation_tool \"{repo_path}\"")
     os.chdir(repo_path)
 else:
     os.chdir(repo_path)


### PR DESCRIPTION
## Zusammenfassung
- Startskripte erkennen jetzt, ob sie bereits im Repository liegen
- Klonen des Repositories erfolgt nur noch, wenn wirklich nötig

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68481a7bef1c83278fe8b92824bb8f37