### PR TITLE
Fix geteuid on Windows

### DIFF
--- a/start_tool.py
+++ b/start_tool.py
@@ -98,7 +98,11 @@ except subprocess.CalledProcessError:
 print("Anwendung wird gestartet...")
 log("Starte Anwendung")
 
-if os.geteuid() == 0:
+# Unter Windows existiert os.geteuid nicht. Darum pruefen wir zuerst,
+# ob die Funktion vorhanden ist. Wenn sie vorhanden ist und einen
+# Root-User meldet, muss Electron ohne Sandbox gestartet werden.
+geteuid = getattr(os, "geteuid", None)
+if geteuid is not None and geteuid() == 0:
     run("npm start -- --no-sandbox")
 else:
     run("npm start")


### PR DESCRIPTION
## Summary
- avoid using `os.geteuid` on Windows in start script

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68481bbc94208327b55840d6721d84bb