### PR TITLE
Disable auto-scan for electron

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -5373,6 +5373,10 @@ function calculateFolderCompletionStats() {
 
         // Auto-scan system for missing permissions
         function checkAndAutoScan(requiredFiles = [], functionName = 'Funktion') {
+            // Desktop-Version nutzt feste Ordnerpfade - kein automatischer Scan nötig
+            if (window.electronAPI) {
+                return null;
+            }
             let missingFiles = [];
             
             // Check if specific files are accessible


### PR DESCRIPTION
## Summary
- check if the app runs under Electron and skip the auto-scan prompt

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848438685b483278861f4bbe1671819