### PR TITLE
Ordnernamen in findDuplicates normalisieren

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -7287,7 +7287,9 @@ function findDuplicates() {
             const folderGroups = new Map();
             
             paths.forEach((pathInfo, index) => {
-                const folder = pathInfo.folder;
+                // Ordnername auf Kleinbuchstaben normalisieren, damit die
+                // Duplikatsuche nicht von Groß-/Kleinschreibung abhängt
+                const folder = pathInfo.folder.toLowerCase();
                 if (!folderGroups.has(folder)) {
                     folderGroups.set(folder, []);
                 }


### PR DESCRIPTION
## Summary
- Ordnernamen in `findDuplicates()` mittels `toLowerCase()` normalisiert
- deutsche Kommentare ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68488f6e33288327908005098f4298e8