### PR TITLE
Verbessertes Matching bei Ordner-Scan

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -5228,9 +5228,17 @@ function updateAllProjectsAfterScan() {
                 if (matchingPaths.length > 0) {
                     // Finde den besten Pfad (kürzester normalisierter Pfad hat Vorrang)
                     bestPath = matchingPaths.reduce((best, current) => {
+                        // Erst prüfen, ob einer der beiden Pfade bereits im Cache vorhanden ist.
+                        // Ist nur ein Pfad vorhanden, wird dieser bevorzugt.
+                        const bestCached    = !!audioFileCache[best.fullPath];
+                        const currentCached = !!audioFileCache[current.fullPath];
+                        if (bestCached !== currentCached) {
+                            return currentCached ? current : best;
+                        }
+
                         const bestNormalized = normalizeFolderPath(best.folder);
                         const currentNormalized = normalizeFolderPath(current.folder);
-                        
+
                         // Bevorzuge kürzere, normalisierte Pfade (vo/alyx statt sounds/vo/alyx)
                         if (currentNormalized.length < bestNormalized.length) {
                             return current;


### PR DESCRIPTION
## Summary
- berücksichtige vorhandene Audiodateien in `updateAllProjectsAfterScan`
- Vorzug eines Pfades, der im Cache vorhanden ist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68489a229a748327aaaa59576c382976