### PR TITLE
Add debugging features

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **🔍 Debug‑Spalte:** Zeigt aufgelöste Pfade und Status
 * **📊 Datenquellen‑Analyse:** Console‑Logs für Entwickler
 * **🎯 Access‑Status:** Echtzeit‑Anzeige der Dateiberechtigungen
+* **🔧 Debug-Konsole:** Über das Dropdown "Debug-Konsole" können Sie Logs einsehen. In der Desktop-Version öffnen Sie mit `npm start -- --debug` oder über den Knopf "DevTools" die Entwicklerwerkzeuge.
 
 ### Performance‑Tipps
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,6 +1,12 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, globalShortcut } = require('electron');
 const path = require('path');
 const fs = require('fs');
+
+// Flag, ob die DevTools beim Start geöffnet werden sollen
+const isDebug = process.argv.includes('--debug');
+
+// Referenz auf das Hauptfenster speichern
+let mainWindow;
 
 // Pfade zu EN und DE relativ zur HTML-Datei
 
@@ -22,7 +28,7 @@ function readAudioFiles(dir) {
 }
 
 function createWindow() {
-  const win = new BrowserWindow({
+  mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
     webPreferences: {
@@ -30,7 +36,21 @@ function createWindow() {
     },
   });
 
-  win.loadFile(path.join(__dirname, '..', 'hla_translation_tool.html'));
+  mainWindow.loadFile(path.join(__dirname, '..', 'hla_translation_tool.html'));
+
+  // DevTools optional öffnen, wenn das Flag gesetzt ist
+  if (isDebug) {
+    mainWindow.webContents.openDevTools();
+  }
+
+  // Shortcut zum Ein- und Ausblenden der DevTools
+  globalShortcut.register('CommandOrControl+Shift+I', () => {
+    if (mainWindow.webContents.isDevToolsOpened()) {
+      mainWindow.webContents.closeDevTools();
+    } else {
+      mainWindow.webContents.openDevTools();
+    }
+  });
 }
 
 app.whenReady().then(() => {
@@ -48,7 +68,22 @@ app.whenReady().then(() => {
     };
   });
 
+  // DevTools auf Befehl aus dem Renderer umschalten
+  ipcMain.on('toggle-devtools', () => {
+    if (!mainWindow) return;
+    if (mainWindow.webContents.isDevToolsOpened()) {
+      mainWindow.webContents.closeDevTools();
+    } else {
+      mainWindow.webContents.openDevTools();
+    }
+  });
+
   createWindow();
+
+  // Beim Beenden alle Shortcuts wieder freigeben
+  app.on('will-quit', () => {
+    globalShortcut.unregisterAll();
+  });
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,4 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   scanFolders: () => ipcRenderer.invoke('scan-folders'),
+  // DevTools im Hauptprozess ein- oder ausschalten
+  toggleDevTools: () => ipcRenderer.send('toggle-devtools'),
 });

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -2045,6 +2045,12 @@ th:nth-child(9) {
     <audio id="audioPlayer"></audio>
     <input type="file" id="deUploadInput" style="display:none" accept=".mp3,.wav,.ogg" onchange="handleDeUpload(this)">
 
+    <!-- Umschaltbare Debug-Konsole -->
+    <details id="debugConsoleWrapper" style="margin:10px 0;">
+        <summary>🛠️ Debug-Konsole <button id="devToolsBtn" type="button">DevTools</button></summary>
+        <pre id="debugConsole" style="max-height:200px; overflow:auto; background:#000; color:#0f0; padding:5px;"></pre>
+    </details>
+
     <!-- JSZip Library -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
 
@@ -2080,9 +2086,30 @@ let displayOrder           = []; // Original-Dateireihenfolge
 // =========================== GLOBAL STATE END ===========================
 
 
+// =========================== DEBUG LOG START ===========================
+// Schreibt Meldungen in die Browser-Konsole und die Debug-Anzeige
+function debugLog(...args) {
+    console.log(...args);
+    const div = document.getElementById('debugConsole');
+    if (div) {
+        div.textContent += args.join(' ') + '\n';
+        div.scrollTop = div.scrollHeight;
+    }
+}
+// =========================== DEBUG LOG END ===========================
+
+
 // =========================== DOM READY INITIALISIERUNG ===========================
 document.addEventListener('DOMContentLoaded', async () => {
     loadProjects();
+
+    // Klick auf den DevTools-Knopf registrieren
+    const devBtn = document.getElementById('devToolsBtn');
+    if (devBtn && window.electronAPI) {
+        devBtn.addEventListener('click', () => {
+            window.electronAPI.toggleDevTools();
+        });
+    }
 
     // Desktop-Version: automatisch EN- und DE-Ordner einlesen
     if (window.electronAPI) {
@@ -4496,12 +4523,12 @@ function cleanupMissingFiles(scannedFiles) {
 // =========================== FINDAUDIOINFILEPATHCACHE START ===========================
 // Helper function to find audio file in cache with flexible matching
 function findAudioInFilePathCache(filename, folder) {
-    console.log(`[FINDAUDIO] Searching for: ${filename} in folder: ${folder}`);
+    debugLog(`[FINDAUDIO] Searching for: ${filename} in folder: ${folder}`);
     
     // 1. Versuche direkte Übereinstimmungen in filePathDatabase
     if (filePathDatabase[filename]) {
         const paths = filePathDatabase[filename];
-        console.log(`[FINDAUDIO] Found ${paths.length} paths in database`);
+        debugLog(`[FINDAUDIO] Found ${paths.length} paths in database`);
         
         // Sortiere Pfade nach Priorität mit Ordner-Präferenz
         const sortedPaths = paths.sort((a, b) => {
@@ -4532,11 +4559,12 @@ function findAudioInFilePathCache(filename, folder) {
         // Prüfe alle Pfade in sortierter Reihenfolge
         for (const pathInfo of sortedPaths) {
             if (audioFileCache[pathInfo.fullPath]) {
-                console.log(`[FINDAUDIO] Found audio in cache: ${pathInfo.fullPath} (folder: ${pathInfo.folder})`);
+                debugLog(`[FINDAUDIO] Found audio in cache: ${pathInfo.fullPath} (folder: ${pathInfo.folder})`);
                 
                 // WARNUNG: Wenn nicht exakte Ordner-Übereinstimmung
                 if (pathInfo.folder !== folder) {
                     console.warn(`[FINDAUDIO] Using different folder: requested "${folder}", using "${pathInfo.folder}"`);
+                    debugLog(`[FINDAUDIO] Using different folder: requested "${folder}", using "${pathInfo.folder}"`);
                 }
                 
                 return {
@@ -4550,7 +4578,7 @@ function findAudioInFilePathCache(filename, folder) {
     }
     
     // 2. Fallback: Durchsuche audioFileCache direkt mit flexiblem Matching
-    console.log(`[FINDAUDIO] No direct match, searching cache with flexible matching...`);
+    debugLog(`[FINDAUDIO] No direct match, searching cache with flexible matching...`);
     
     const normalizedFolder = normalizeFolderPath(folder);
     const possiblePaths = [];
@@ -4570,9 +4598,9 @@ function findAudioInFilePathCache(filename, folder) {
                 const cacheFolder = pathParts.slice(0, fileIndex).join('/');
                 const normalizedCacheFolder = normalizeFolderPath(cacheFolder);
                 
-                console.log(`[FINDAUDIO] Cache path: ${cachePath}`);
-                console.log(`[FINDAUDIO] Cache folder: ${cacheFolder} -> ${normalizedCacheFolder}`);
-                console.log(`[FINDAUDIO] Looking for: ${folder} -> ${normalizedFolder}`);
+                debugLog(`[FINDAUDIO] Cache path: ${cachePath}`);
+                debugLog(`[FINDAUDIO] Cache folder: ${cacheFolder} -> ${normalizedCacheFolder}`);
+                debugLog(`[FINDAUDIO] Looking for: ${folder} -> ${normalizedFolder}`);
                 
                 // Bewerte Übereinstimmung
                 let score = 0;
@@ -4612,10 +4640,11 @@ function findAudioInFilePathCache(filename, folder) {
     
     if (possiblePaths.length > 0) {
         const best = possiblePaths[0];
-        console.log(`[FINDAUDIO] Found via flexible matching: ${best.path} (score: ${best.score})`);
+        debugLog(`[FINDAUDIO] Found via flexible matching: ${best.path} (score: ${best.score})`);
         
         if (!best.isExactMatch) {
             console.warn(`[FINDAUDIO] Using approximate match: requested "${folder}", using "${best.folder}"`);
+            debugLog(`[FINDAUDIO] Using approximate match: requested "${folder}", using "${best.folder}"`);
         }
         
         return {
@@ -4626,7 +4655,7 @@ function findAudioInFilePathCache(filename, folder) {
         };
     }
     
-    console.log(`[FINDAUDIO] No audio found for ${filename} in ${folder}`);
+    debugLog(`[FINDAUDIO] No audio found for ${filename} in ${folder}`);
     return null;
 }
 // =========================== FINDAUDIOINFILEPATHCACHE END ===========================
@@ -4989,14 +5018,14 @@ function playAudio(fileId) {
 
     // Unter Electron spielen wir direkt aus dem sounds-Ordner ab
     
-    console.log(`[PLAYAUDIO] ====== Playing: ${file.filename} ======`);
-    console.log(`[PLAYAUDIO] File folder: ${file.folder}`);
+    debugLog(`[PLAYAUDIO] ====== Playing: ${file.filename} ======`);
+    debugLog(`[PLAYAUDIO] File folder: ${file.folder}`);
     
     // Nutze die neue Hilfsfunktion
     const audioResult = findAudioInFilePathCache(file.filename, file.folder);
     
     if (!audioResult) {
-        console.log(`[PLAYAUDIO] Audio not found, triggering auto-scan...`);
+        debugLog(`[PLAYAUDIO] Audio not found, triggering auto-scan...`);
         
         const scanResult = checkAndAutoScan([file], 'Audio-Wiedergabe');
         if (scanResult === true) {
@@ -5010,7 +5039,7 @@ function playAudio(fileId) {
         return;
     }
     
-    console.log(`[PLAYAUDIO] Audio found: ${audioResult.resolvedPath}`);
+    debugLog(`[PLAYAUDIO] Audio found: ${audioResult.resolvedPath}`);
     
     // Audio abspielen
     const audio = document.getElementById('audioPlayer');
@@ -5059,6 +5088,7 @@ function playAudio(fileId) {
         };
     }).catch(err => {
         console.error('[PLAYAUDIO] Playback failed:', err);
+        debugLog('[PLAYAUDIO] Playback failed:', err);
         updateStatus(`Fehler beim Abspielen: ${file.filename}`);
         if (url) URL.revokeObjectURL(url);
     });
@@ -8458,6 +8488,7 @@ function showSingleFileSelectionDialog(filename, paths, originalResult) {
 
 // =========================== playPreview START ===========================
 function playPreview(fullPath) {
+    debugLog(`[PREVIEW] Versuche ${fullPath} abzuspielen`);
     const audioPlayer = document.getElementById('audioPlayer');
     const fileObj = audioFileCache[fullPath];
     if (fileObj) {
@@ -8466,12 +8497,15 @@ function playPreview(fullPath) {
             const url = URL.createObjectURL(fileObj);
             audioPlayer.src = url;
             audioPlayer.play().catch(err => {
+                debugLog('[PREVIEW] Abspielen fehlgeschlagen:', err.message);
                 alert('Abspielen fehlgeschlagen: ' + err.message);
             });
         } catch (e) {
+            debugLog('[PREVIEW] Fehler beim Erzeugen der Audio-URL:', e.message);
             alert('Fehler beim Erzeugen der Audio-URL: ' + e.message);
         }
     } else {
+        debugLog(`[PREVIEW] Nicht im Cache: ${fullPath}`);
         alert('⚠️ Audio-Datei nicht im Cache verfügbar');
     }
 }


### PR DESCRIPTION
## Zusammenfassung
- DevTools lassen sich jetzt per Knopf in der Debug-Konsole umschalten
- Electron-Hauptfenster speichert Referenz und reagiert auf `toggle-devtools`
- Neuer IPC-Handler und preload-Funktion zum Umschalten der DevTools
- README weist auf den neuen DevTools-Knopf hin

## Testen
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68489bf3003c83279a067fe46beb5fcd