### PR TITLE
Add DevTools button

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -65,6 +65,16 @@ app.whenReady().then(() => {
     };
   });
 
+  // DevTools per IPC ein-/ausblenden
+  ipcMain.on('toggle-devtools', (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (win.webContents.isDevToolsOpened()) {
+      win.webContents.closeDevTools();
+    } else {
+      win.webContents.openDevTools();
+    }
+  });
+
   createWindow();
 
   // Beim Beenden alle Shortcuts wieder freigeben

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,4 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   scanFolders: () => ipcRenderer.invoke('scan-folders'),
+  // Befehl an Hauptprozess senden, um DevTools umzuschalten
+  toggleDevTools: () => ipcRenderer.send('toggle-devtools'),
 });

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -1766,8 +1766,9 @@ th:nth-child(9) {
                 <button class="btn btn-secondary" onclick="backupData()">💾 Backup</button>
                 <button class="btn btn-secondary" onclick="restoreData()">📂 Restore</button>
                 <button class="btn btn-danger" onclick="resetFileDatabase()">🔄 Reset DB</button>
-				<button class="btn btn-secondary" onclick="updateAllFilePaths()">🔄 Projekte bereinigen</button>
-			<button class="btn btn-success" onclick="repairProjectFolders()">🔧 Ordner reparieren</button>
+                                <button class="btn btn-secondary" onclick="updateAllFilePaths()">🔄 Projekte bereinigen</button>
+                        <button class="btn btn-success" onclick="repairProjectFolders()">🔧 Ordner reparieren</button>
+                <button class="btn btn-secondary" onclick="toggleDevTools()">🐞 DevTools</button>
             </div>
 			
 <!-- =========================== PROJECT META BAR START =========================== -->
@@ -7574,6 +7575,13 @@ function executeCleanup(cleanupPlan, totalToDelete) {
             saveFolderCustomizations();
             updateStatus('Datei-Datenbank und Ordner-Anpassungen zurückgesetzt. Bitte Ordner neu scannen.');
         updateFileAccessStatus();
+        }
+
+        // Öffnet oder schließt die DevTools in der Desktop-Version
+        function toggleDevTools() {
+            if (window.electronAPI) {
+                window.electronAPI.toggleDevTools();
+            }
         }
 
 


### PR DESCRIPTION
## Summary
- expose toggleDevTools in preload
- allow main process to toggle DevTools via IPC
- add toolbar button for DevTools

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68489f3e95d483278298fec6435d710d