### PR TITLE
Verbesserungen für Electron-Speicherfunktionen

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, globalShortcut } = require('electron');
+const { app, BrowserWindow, ipcMain, globalShortcut, dialog } = require('electron');
 const path = require('path');
 const fs = require('fs');
 
@@ -63,6 +63,16 @@ app.whenReady().then(() => {
       enFiles: readAudioFiles(enPath),
       deFiles: readAudioFiles(dePath),
     };
+  });
+
+  // Speichert eine Datei über einen Dialog auf der Festplatte
+  ipcMain.handle('save-file', async (event, { data, defaultPath }) => {
+    const { canceled, filePath } = await dialog.showSaveDialog({
+      defaultPath,
+    });
+    if (canceled || !filePath) return null;
+    fs.writeFileSync(filePath, Buffer.from(data));
+    return filePath;
   });
 
   // DevTools per IPC ein-/ausblenden

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -3,4 +3,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   scanFolders: () => ipcRenderer.invoke('scan-folders'),
   // Befehl an Hauptprozess senden, um DevTools umzuschalten
   toggleDevTools: () => ipcRenderer.send('toggle-devtools'),
+  // Datei speichern (z.B. ZIP oder Backup)
+  saveFile: (data, defaultPath) => ipcRenderer.invoke('save-file', { data, defaultPath }),
 });

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -7112,26 +7112,30 @@ async function startExport() {
             try {
                 document.getElementById('downloadBtn').disabled = true;
                 document.getElementById('downloadBtn').textContent = 'Erstelle Download...';
-                
+
+                // Unter Electron erzeugen wir ein Uint8Array, im Browser ein Blob
+                const exportType = window.electronAPI ? 'uint8array' : 'blob';
                 const content = await exportZip.generateAsync({
-                    type: "blob",
-                    compression: "DEFLATE",
-                    compressionOptions: {
-                        level: 6
-                    }
+                    type: exportType,
+                    compression: 'DEFLATE',
+                    compressionOptions: { level: 6 }
                 });
-                
-                const link = document.createElement('a');
-                link.href = URL.createObjectURL(content);
-                link.download = `${currentProject.name}_export_${new Date().toISOString().split('T')[0]}.zip`;
-                link.click();
-                
-                setTimeout(() => {
-                    URL.revokeObjectURL(link.href);
-                }, 1000);
-                
+
+                const filename = `${currentProject.name}_export_${new Date().toISOString().split('T')[0]}.zip`;
+
+                if (window.electronAPI && window.electronAPI.saveFile) {
+                    // Direkt über Electron speichern
+                    await window.electronAPI.saveFile(Array.from(content), filename);
+                } else {
+                    const link = document.createElement('a');
+                    link.href = URL.createObjectURL(content);
+                    link.download = filename;
+                    link.click();
+                    setTimeout(() => { URL.revokeObjectURL(link.href); }, 1000);
+                }
+
                 updateStatus('ZIP-Download gestartet');
-                
+
             } catch (error) {
                 console.error('Download error:', error);
                 alert('Fehler beim Download: ' + error.message);
@@ -7224,13 +7228,22 @@ function checkFileAccess() {
                 folderCustomizations: folderCustomizations,
                 currentProjectId: currentProject?.id
             };
-            
-            const blob = new Blob([JSON.stringify(backup, null, 2)], { type: 'application/json' });
-            const link = document.createElement('a');
-            link.href = URL.createObjectURL(blob);
-            link.download = `hla_translation_backup_${new Date().toISOString().split('T')[0]}.json`;
-            link.click();
-            
+
+            const json = JSON.stringify(backup, null, 2);
+
+            // In Electron speichern wir die Datei direkt
+            if (window.electronAPI && window.electronAPI.saveFile) {
+                const filename = `hla_translation_backup_${new Date().toISOString().split('T')[0]}.json`;
+                const data = Array.from(new TextEncoder().encode(json));
+                window.electronAPI.saveFile(data, filename);
+            } else {
+                const blob = new Blob([json], { type: 'application/json' });
+                const link = document.createElement('a');
+                link.href = URL.createObjectURL(blob);
+                link.download = `hla_translation_backup_${new Date().toISOString().split('T')[0]}.json`;
+                link.click();
+            }
+
             updateStatus('Backup erstellt');
         }
 


### PR DESCRIPTION
## Zusammenfassung
- IPC-Handler `save-file` implementiert
- Methode `saveFile` in `preload.js` bereitgestellt
- ZIP- und Backup-Erstellung nutzen unter Electron den neuen Handler

## Tests
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848b41220888327ad777235c5d6870b