### PR TITLE
Fix local storage persistence

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -2,6 +2,14 @@ const { app, BrowserWindow, ipcMain, globalShortcut, dialog } = require('electro
 const path = require('path');
 const fs = require('fs');
 
+// =========================== USER-DATA-PFAD START ===========================
+// Benutzer-Datenordner festlegen, damit lokale Daten auch nach einem Neustart
+// verfügbar bleiben und nicht durch Zugriffsrechte im Standardpfad verloren gehen
+const userDataPath = path.join(app.getPath('home'), '.hla_translation_tool');
+fs.mkdirSync(userDataPath, { recursive: true });
+app.setPath('userData', userDataPath);
+// =========================== USER-DATA-PFAD END =============================
+
 // Flag, ob die DevTools beim Start geöffnet werden sollen
 const isDebug = process.argv.includes('--debug');
 


### PR DESCRIPTION
## Summary
- set the Electron `userData` path to an application-specific folder so project data survives restarts

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848ba0032f483279120d0f4941963ee