### PR TITLE
Add content security policy

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Half-Life: Alyx Translation Tool</title>
+    <!-- Sicherheitsrichtlinie für Electron: verhindert Warnhinweise -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline';">
     <style>
         * {
             margin: 0;


### PR DESCRIPTION
## Summary
- set Content-Security-Policy in HTML head to remove Electron warning

## Testing
- `npm test`
- `npm start -- --no-sandbox` *(fails: Missing X11 DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_6848c099c25883279eb86a658a4dc084