### PR TITLE
Add test for calculateProjectStats without files

### DIFF
--- a/tests/calculateProjectStats.test.js
+++ b/tests/calculateProjectStats.test.js
@@ -11,6 +11,17 @@ describe('calculateProjectStats', () => {
         });
     });
 
+    // Testfall: Aufruf ohne "files"-Eigenschaft
+    test('project ohne files liefert 0% Statistiken', () => {
+        const result = calculateProjectStats({});
+        expect(result).toEqual({
+            enPercent: 0,
+            dePercent: 0,
+            completedPercent: 0,
+            totalFiles: 0
+        });
+    });
+
     test('single completed file returns 100% in all categories', () => {
         const result = calculateProjectStats({
             files: [{ enText: 'EN', deText: 'DE', completed: true }]


### PR DESCRIPTION
## Summary
- test `calculateProjectStats` with missing `files` property

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848c157bb68832780f9d6e9a09b2bea