### PR TITLE
Ordner sounds bei Git-Reset ausnehmen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 electron/node_modules/
+sounds/

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 4. Beim Start werden die Ordner `sounds/EN` und `sounds/DE` automatisch erstellt und eingelesen
 5. Kopieren Sie Ihre Originaldateien in `sounds/EN` und legen Sie Übersetzungen in `sounds/DE` ab
 6. Während des Setups erzeugen beide Skripte (`start_tool.bat` bzw. `start_tool.js`) die Logdatei `setup.log`, in der alle Schritte gespeichert werden
+7. Die Skripte verwerfen lokale Änderungen, **ohne** den Ordner `sounds` anzutasten – Projektdaten bleiben somit erhalten
 
 ---
 

--- a/start_tool.bat
+++ b/start_tool.bat
@@ -73,7 +73,8 @@ cd hla_translation_tool
 
 REM ----------------------- Lokale Änderungen verwerfen --------------------
 call :log "Verwerfe lokale Änderungen"
-git reset --hard
+REM Sounds-Ordner nicht überschreiben
+git reset --hard HEAD -- ":!sounds"
 IF ERRORLEVEL 1 (
     call :log "git reset fehlgeschlagen"
 ) ELSE (

--- a/start_tool.js
+++ b/start_tool.js
@@ -75,7 +75,8 @@ process.chdir(repoPath);
 // ----------------------- Lokale Änderungen verwerfen --------------------
 log('Verwerfe lokale Änderungen');
 try {
-    run('git reset --hard');
+    // Sounds-Ordner nicht überschreiben
+    run('git reset --hard HEAD -- :!sounds');
     log('Lokale Änderungen verworfen');
 } catch (err) {
     log('git reset fehlgeschlagen');

--- a/start_tool.py
+++ b/start_tool.py
@@ -78,7 +78,8 @@ else:
 # ----------------------- Lokale Änderungen verwerfen --------------------
 log("Verwerfe lokale Änderungen")
 try:
-    run("git reset --hard")
+    # Sounds-Ordner nicht überschreiben
+    run("git reset --hard HEAD -- :!sounds")
     log("Lokale Änderungen verworfen")
 except subprocess.CalledProcessError:
     log("git reset fehlgeschlagen")


### PR DESCRIPTION
## Summary
- `git reset --hard` so anpassen, dass `sounds` unangetastet bleibt
- `sounds/` ins `.gitignore` aufnehmen
- README mit Hinweis ergänzen, dass Projektdaten erhalten bleiben

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848c39e39248327a6f445c766bb13dc