### PR TITLE
Add GPU disable flags for electron startup

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -70,6 +70,10 @@ function createWindow() {
   });
 }
 
+// GPU-Beschleunigung ausschalten, um Cache-Probleme zu vermeiden
+app.commandLine.appendSwitch('disable-gpu');
+app.commandLine.appendSwitch('disable-gpu-compositing');
+
 app.whenReady().then(() => {
   // Basis- und Sprachordner relativ zur App bestimmen
   const projectBase = path.join(__dirname, '..', 'sounds');


### PR DESCRIPTION
## Summary
- disable GPU and GPU compositing in `electron/main.js`

## Testing
- `npm test`
- `npm install` and attempted `npx electron . --no-sandbox` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_e_6848c447f94c8327853f2b32d70dad06