### PR TITLE
Fix DE uploads in Electron

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -99,6 +99,16 @@ app.whenReady().then(() => {
     return filePath;
   });
 
+  // =========================== SAVE-DE-FILE START ===========================
+  // Speichert eine hochgeladene DE-Datei im richtigen Unterordner
+  ipcMain.handle('save-de-file', async (event, { relPath, data }) => {
+    const target = path.join(dePath, relPath);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, Buffer.from(data));
+    return target;
+  });
+  // =========================== SAVE-DE-FILE END =============================
+
   // DevTools per IPC ein-/ausblenden
   ipcMain.on('toggle-devtools', (event) => {
     const win = BrowserWindow.fromWebContents(event.sender);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -5,4 +5,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   toggleDevTools: () => ipcRenderer.send('toggle-devtools'),
   // Datei speichern (z.B. ZIP oder Backup)
   saveFile: (data, defaultPath) => ipcRenderer.invoke('save-file', { data, defaultPath }),
+  // DE-Datei im Projektordner speichern
+  saveDeFile: (relPath, data) => ipcRenderer.invoke('save-de-file', { relPath, data }),
 });

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -7675,7 +7675,13 @@ async function handleDeUpload(input) {
     if (!datei || !aktuellerUploadPfad) {
         return;
     }
-    await speichereUebersetzungsDatei(datei, aktuellerUploadPfad);
+    if (window.electronAPI && window.electronAPI.saveDeFile) {
+        const buffer = await datei.arrayBuffer();
+        await window.electronAPI.saveDeFile(aktuellerUploadPfad, new Uint8Array(buffer));
+        deAudioCache[aktuellerUploadPfad] = `sounds/DE/${aktuellerUploadPfad}`;
+    } else {
+        await speichereUebersetzungsDatei(datei, aktuellerUploadPfad);
+    }
 
     // Zugehörige Datei als fertig markieren
     const file = files.find(f => getFullPath(f) === aktuellerUploadPfad);


### PR DESCRIPTION
## Summary
- add IPC handler to save DE audio files in Electron
- expose `saveDeFile` via preload
- use new API in HTML upload handler

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848c9a8b2ec8327aa02aec7bd21c518