### PR TITLE
DE-Audio-Prozent richtig berechnen

### DIFF
--- a/calculateProjectStats.js
+++ b/calculateProjectStats.js
@@ -1,3 +1,4 @@
+// Ermittelt Statistiken fuer ein Projekt
 function calculateProjectStats(project) {
     const files = project.files || [];
     const totalFiles = files.length;
@@ -15,7 +16,7 @@ function calculateProjectStats(project) {
     const filesWithEN = files.filter(f => f.enText && f.enText.trim().length > 0).length;
     const filesWithDE = files.filter(f => f.deText && f.deText.trim().length > 0).length;
     const filesCompleted = files.filter(f => f.completed).length;
-    const filesWithDeAudio = files.filter(f => f.hasDeAudio || f.deAudioPath || f.deAudio).length;
+    const filesWithDeAudio = files.filter(f => getDeFilePath(f)).length;
 
     return {
         enPercent: Math.round((filesWithEN / totalFiles) * 100),
@@ -24,6 +25,17 @@ function calculateProjectStats(project) {
         completedPercent: Math.round((filesCompleted / totalFiles) * 100),
         totalFiles: totalFiles
     };
+}
+
+// Liefert den Pfad einer vorhandenen DE-Audiodatei oder null
+function getDeFilePath(file) {
+    if (file.deAudioPath) return file.deAudioPath;
+    if (file.deAudio) return file.deAudio;
+    if (file.hasDeAudio) return true;
+    if (global.deAudioCache && file.fullPath && global.deAudioCache[file.fullPath]) {
+        return file.fullPath;
+    }
+    return null;
 }
 
 module.exports = calculateProjectStats;

--- a/tests/calculateProjectStats.test.js
+++ b/tests/calculateProjectStats.test.js
@@ -1,6 +1,9 @@
 const calculateProjectStats = require('../calculateProjectStats');
 
 describe('calculateProjectStats', () => {
+    afterEach(() => {
+        delete global.deAudioCache;
+    });
     test('empty file list returns 0% stats', () => {
         const result = calculateProjectStats({ files: [] });
         expect(result).toEqual({
@@ -90,10 +93,11 @@ describe('calculateProjectStats', () => {
     });
 
     test('de audio percentage calculated correctly', () => {
+        global.deAudioCache = { '/game/file1.wav': true };
         const result = calculateProjectStats({
             files: [
-                { enText: 'EN', deText: 'DE', hasDeAudio: true, completed: true },
-                { enText: 'EN2', deText: 'DE2', hasDeAudio: false, completed: false }
+                { enText: 'EN', deText: 'DE', fullPath: '/game/file1.wav', completed: true },
+                { enText: 'EN2', deText: 'DE2', fullPath: '/game/file2.wav', completed: false }
             ]
         });
         expect(result).toEqual({


### PR DESCRIPTION
## Summary
- nutze `getDeFilePath` in `calculateProjectStats.js`
- implementiere `getDeFilePath` für Node-Umgebung
- passe Test an und verwende `deAudioCache`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849362822a88327a19a1f7e88cf0dcc