### PR TITLE
Backup-Ordner öffnbar

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, globalShortcut, dialog } = require('electron');
+const { app, BrowserWindow, ipcMain, globalShortcut, dialog, shell } = require('electron');
 const path = require('path');
 const fs = require('fs');
 
@@ -9,7 +9,8 @@ const userDataPath = path.join(app.getPath('home'), '.hla_translation_tool');
 fs.mkdirSync(userDataPath, { recursive: true });
 app.setPath('userData', userDataPath);
 // Ordner für automatische Backups im Benutzerverzeichnis anlegen
-const backupPath = path.join(userDataPath, 'backups');
+// Neuer Pfad 'Backups' laut Benutzerwunsch
+const backupPath = path.join(userDataPath, 'Backups');
 fs.mkdirSync(backupPath, { recursive: true });
 // =========================== USER-DATA-PFAD END =============================
 
@@ -127,6 +128,12 @@ app.whenReady().then(() => {
   // Backup löschen
   ipcMain.handle('delete-backup', async (event, name) => {
     fs.unlinkSync(path.join(backupPath, name));
+    return true;
+  });
+
+  // Backup-Ordner im Dateimanager öffnen
+  ipcMain.handle('open-backup-folder', async () => {
+    shell.openPath(backupPath);
     return true;
   });
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -12,4 +12,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   saveBackup: (data) => ipcRenderer.invoke('save-backup', data),
   readBackup: (name) => ipcRenderer.invoke('read-backup', name),
   deleteBackup: (name) => ipcRenderer.invoke('delete-backup', name),
+  openBackupFolder: () => ipcRenderer.invoke('open-backup-folder'),
 });

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -1961,6 +1961,7 @@ th:nth-child(9) {
             </div>
             <div class="dialog-buttons">
                 <button class="btn btn-secondary" onclick="createBackup(true)">Backup erstellen</button>
+                <button class="btn btn-secondary" onclick="openBackupFolder()">Ordner öffnen</button>
                 <button class="btn btn-secondary" onclick="closeBackupDialog()">Schließen</button>
             </div>
         </div>
@@ -6613,6 +6614,14 @@ function checkFileAccess() {
 
         function closeBackupDialog() {
             document.getElementById('backupDialog').style.display = 'none';
+        }
+
+        function openBackupFolder() {
+            if (window.electronAPI && window.electronAPI.openBackupFolder) {
+                window.electronAPI.openBackupFolder();
+            } else {
+                alert('Nur in der Desktop-Version verfügbar');
+            }
         }
 // =========================== SHOWBACKUPDIALOG END ========================
 


### PR DESCRIPTION
## Zusammenfassung
- passe den Backup-Pfad an den neuen `Backups`-Ordner an
- ermögliche das Öffnen des Backup-Ordners über neuen IPC-Handler
- erweitere preload um `openBackupFolder`
- füge im Backup-Dialog einen Button zum Öffnen des Ordners hinzu

## Testanweisungen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68493cac09e88327a24ab248443815e9