### PR TITLE
Implementiere DE-Audio-Bearbeitung

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 | **Ordner‑Löschfunktion**   | Komplette Ordner können sicher aus der Datenbank gelöscht werden (mit Schutz vor Datenverlust).                                                             |
 | **Cleanup‑Routine**        | Fehlende Dateien **ohne** EN & DE werden automatisch aus der DB entfernt.                                                                                   |
 | **Verbesserter UI‑Polish** | • Schließen‑Knopf (×) nun oben rechts 🡆 hover‑animiert.<br>• Fertige Projekte/Ordner erhalten leuchtend grünen Rahmen.<br>• Dark‑Theme‑Kontrast optimiert. |
+| **DE-Audio-Bearbeitung**   | DE-Audiodateien lassen sich direkt kürzen oder verlängern. Vor dem Speichern wird automatisch eine Sicherung im Ordner `DE-Backup` angelegt. |
 
 ---
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -83,8 +83,10 @@ app.whenReady().then(() => {
   const projectBase = path.join(__dirname, '..', 'sounds');
   const enPath = path.join(projectBase, 'EN');
   const dePath = path.join(projectBase, 'DE');
+  const deBackupPath = path.join(projectBase, 'DE-Backup');
   fs.mkdirSync(enPath, { recursive: true }); // EN-Ordner anlegen
   fs.mkdirSync(dePath, { recursive: true }); // DE-Ordner anlegen
+  fs.mkdirSync(deBackupPath, { recursive: true }); // DE-Backup-Ordner anlegen
 
   ipcMain.handle('scan-folders', () => {
     return {
@@ -136,6 +138,19 @@ app.whenReady().then(() => {
     shell.openPath(backupPath);
     return true;
   });
+
+  // =========================== BACKUP-DE-FILE START ===========================
+  // Kopiert eine vorhandene DE-Datei in den Backup-Ordner
+  ipcMain.handle('backup-de-file', async (event, relPath) => {
+    const source = path.join(dePath, relPath);
+    const target = path.join(deBackupPath, relPath);
+    if (fs.existsSync(source)) {
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.copyFileSync(source, target);
+    }
+    return target;
+  });
+  // =========================== BACKUP-DE-FILE END =============================
 
   // =========================== SAVE-DE-FILE START ===========================
   // Speichert eine hochgeladene DE-Datei im richtigen Unterordner

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   saveFile: (data, defaultPath) => ipcRenderer.invoke('save-file', { data, defaultPath }),
   // DE-Datei im Projektordner speichern
   saveDeFile: (relPath, data) => ipcRenderer.invoke('save-de-file', { relPath, data }),
+  backupDeFile: (relPath) => ipcRenderer.invoke('backup-de-file', relPath),
   // Backup-Funktionen
   listBackups: () => ipcRenderer.invoke('list-backups'),
   saveBackup: (data) => ipcRenderer.invoke('save-backup', data),

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -606,6 +606,22 @@ th:nth-child(9) {
             color: white;
         }
 
+        .edit-audio-btn {
+            background: #444;
+            border: none;
+            color: #e0e0e0;
+            padding: 6px 12px;
+            border-radius: 4px;
+            cursor: pointer;
+            transition: all 0.2s;
+            font-size: 16px;
+        }
+
+        .edit-audio-btn:hover {
+            background: #ff6b1a;
+            color: white;
+        }
+
         .delete-row-btn {
             background: none;
             border: none;
@@ -1827,6 +1843,7 @@ th:nth-child(9) {
         <th width="60">Audio</th>
         <th width="60">DE Audio</th>
         <th width="60">Upload</th>
+        <th width="60">Bearbeiten</th>
         <th width="50"></th>
     </tr>
 </thead>
@@ -1999,6 +2016,26 @@ th:nth-child(9) {
                 <button class="btn btn-secondary" onclick="createBackup(true)">Backup erstellen</button>
                 <button class="btn btn-secondary" onclick="openBackupFolder()">Ordner öffnen</button>
                 <button class="btn btn-secondary" onclick="closeBackupDialog()">Schließen</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- DE Edit Dialog -->
+    <div class="dialog-overlay" id="deEditDialog">
+        <div class="dialog">
+<button class="dialog-close-btn" onclick="closeDeEdit()">×</button>
+            <h3>✂️ DE-Audio bearbeiten</h3>
+            <div style="margin-bottom:15px;">
+                <canvas id="waveOriginal" width="500" height="80" style="width:100%; background:#111;"></canvas>
+                <canvas id="waveEdited" width="500" height="80" style="width:100%; background:#111; margin-top:10px;"></canvas>
+            </div>
+            <div style="margin-bottom:15px; display:flex; gap:10px;">
+                <label>Start (ms): <input type="number" id="editStart" value="0" step="100"></label>
+                <label>Ende (ms): <input type="number" id="editEnd" value="0" step="100"></label>
+            </div>
+            <div class="dialog-buttons">
+                <button class="btn btn-secondary" onclick="applyDeEdit()">Speichern</button>
+                <button class="btn btn-secondary" onclick="closeDeEdit()">Abbrechen</button>
             </div>
         </div>
     </div>
@@ -3522,6 +3559,7 @@ return `
             ${hasDeAudio ? `<button class="de-play-btn" onclick="playDeAudio(${file.id})">▶</button>` : ''}
         </td>
         <td><button class="upload-btn" onclick="initiateDeUpload(${file.id})">⬆️</button></td>
+        <td><button class="edit-audio-btn" onclick="openDeEdit(${file.id})">✂️</button></td>
         <td><button class="delete-row-btn" onclick="deleteFile(${file.id})">×</button></td>
     </tr>
 `;
@@ -7287,6 +7325,185 @@ async function handleDeUpload(input) {
     updateStatus('DE-Datei gespeichert');
 }
 // =========================== HANDLEDEUPLOAD END ==============================
+
+// =========================== LOADAUDIOBUFFER START ===========================
+// Lädt eine Audiodatei (String-URL oder File) und liefert ein AudioBuffer
+async function loadAudioBuffer(source) {
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    let arrayBuffer;
+    if (typeof source === 'string') {
+        const resp = await fetch(source);
+        arrayBuffer = await resp.arrayBuffer();
+    } else {
+        arrayBuffer = await source.arrayBuffer();
+    }
+    return await ctx.decodeAudioData(arrayBuffer);
+}
+// =========================== LOADAUDIOBUFFER END =============================
+
+// =========================== DRAWWAVEFORM START =============================
+// Zeichnet ein einfaches Wellenbild in ein Canvas
+function drawWaveform(canvas, buffer) {
+    const ctx = canvas.getContext('2d');
+    const width = canvas.width;
+    const height = canvas.height;
+    ctx.clearRect(0, 0, width, height);
+    ctx.strokeStyle = '#ff6b1a';
+    ctx.beginPath();
+    const data = buffer.getChannelData(0);
+    const step = Math.ceil(data.length / width);
+    for (let i = 0; i < width; i++) {
+        const start = i * step;
+        let min = 1.0;
+        let max = -1.0;
+        for (let j = 0; j < step; j++) {
+            const sample = data[start + j] || 0;
+            if (sample < min) min = sample;
+            if (sample > max) max = sample;
+        }
+        ctx.moveTo(i, (1 + min) * height / 2);
+        ctx.lineTo(i, (1 + max) * height / 2);
+    }
+    ctx.stroke();
+}
+// =========================== DRAWWAVEFORM END ===============================
+
+// =========================== TRIMANDBUFFER START ============================
+// Kürzt oder verlängert ein AudioBuffer um die angegebenen Millisekunden
+function trimAndPadBuffer(buffer, startMs, endMs) {
+    const sr = buffer.sampleRate;
+    const startSamples = Math.max(0, Math.floor(startMs > 0 ? startMs * sr / 1000 : 0));
+    const endSamples = Math.max(0, Math.floor(endMs > 0 ? endMs * sr / 1000 : 0));
+    const padStart = Math.max(0, Math.floor(startMs < 0 ? -startMs * sr / 1000 : 0));
+    const padEnd = Math.max(0, Math.floor(endMs < 0 ? -endMs * sr / 1000 : 0));
+    const newLength = padStart + buffer.length - startSamples - endSamples + padEnd;
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const newBuffer = ctx.createBuffer(buffer.numberOfChannels, newLength, sr);
+    for (let ch = 0; ch < buffer.numberOfChannels; ch++) {
+        const oldData = buffer.getChannelData(ch);
+        const newData = newBuffer.getChannelData(ch);
+        newData.set(oldData.subarray(startSamples, buffer.length - endSamples), padStart);
+    }
+    return newBuffer;
+}
+// =========================== TRIMANDBUFFER END ==============================
+
+// =========================== BUFFERTOWAV START ==============================
+// Wandelt einen AudioBuffer in einen WAV-Blob um
+function bufferToWav(buffer) {
+    const numOfChan = buffer.numberOfChannels;
+    const length = buffer.length * numOfChan * 2 + 44;
+    const arrBuffer = new ArrayBuffer(length);
+    const view = new DataView(arrBuffer);
+    const writeString = (o, s) => { for (let i = 0; i < s.length; i++) view.setUint8(o + i, s.charCodeAt(i)); };
+    writeString(0, 'RIFF');
+    view.setUint32(4, 36 + buffer.length * numOfChan * 2, true);
+    writeString(8, 'WAVE');
+    writeString(12, 'fmt ');
+    view.setUint32(16, 16, true);
+    view.setUint16(20, 1, true);
+    view.setUint16(22, numOfChan, true);
+    view.setUint32(24, buffer.sampleRate, true);
+    view.setUint32(28, buffer.sampleRate * numOfChan * 2, true);
+    view.setUint16(32, numOfChan * 2, true);
+    view.setUint16(34, 16, true);
+    writeString(36, 'data');
+    view.setUint32(40, buffer.length * numOfChan * 2, true);
+    let offset = 44;
+    for (let i = 0; i < buffer.length; i++) {
+        for (let ch = 0; ch < numOfChan; ch++) {
+            let sample = buffer.getChannelData(ch)[i];
+            sample = Math.max(-1, Math.min(1, sample));
+            view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7FFF, true);
+            offset += 2;
+        }
+    }
+    return new Blob([view], { type: 'audio/wav' });
+}
+// =========================== BUFFERTOWAV END ================================
+
+let currentEditFile = null;
+let originalEditBuffer = null;
+
+// =========================== OPENDEEDIT START ===============================
+// Öffnet den Bearbeitungsdialog für eine DE-Datei
+async function openDeEdit(fileId) {
+    const file = files.find(f => f.id === fileId);
+    if (!file) return;
+    currentEditFile = file;
+    const enSrc = `sounds/EN/${getFullPath(file)}`;
+    const rel = getDeFilePath(file) || getFullPath(file);
+    let deSrc = deAudioCache[rel];
+    if (!deSrc) return;
+    if (typeof deSrc !== 'string') {
+        originalEditBuffer = await loadAudioBuffer(deSrc);
+    } else {
+        originalEditBuffer = await loadAudioBuffer(deSrc);
+    }
+    const enBuffer = await loadAudioBuffer(enSrc);
+    drawWaveform(document.getElementById('waveOriginal'), enBuffer);
+    drawWaveform(document.getElementById('waveEdited'), originalEditBuffer);
+    document.getElementById('editStart').value = 0;
+    document.getElementById('editEnd').value = 0;
+    document.getElementById('deEditDialog').style.display = 'flex';
+}
+// =========================== OPENDEEDIT END ================================
+
+// =========================== CLOSEDEEDIT START =============================
+function closeDeEdit() {
+    document.getElementById('deEditDialog').style.display = 'none';
+    currentEditFile = null;
+    originalEditBuffer = null;
+}
+// =========================== CLOSEDEEDIT END ===============================
+
+// =========================== APPLYDEEDIT START =============================
+// Speichert die bearbeitete DE-Datei und legt ein Backup an
+async function applyDeEdit() {
+    if (!currentEditFile || !originalEditBuffer) return;
+    const startMs = parseInt(document.getElementById('editStart').value) || 0;
+    const endMs = parseInt(document.getElementById('editEnd').value) || 0;
+    const newBuffer = trimAndPadBuffer(originalEditBuffer, startMs, endMs);
+    drawWaveform(document.getElementById('waveEdited'), newBuffer);
+    const blob = bufferToWav(newBuffer);
+    const relPath = getFullPath(currentEditFile);
+    if (window.electronAPI && window.electronAPI.backupDeFile) {
+        await window.electronAPI.backupDeFile(relPath);
+        const buf = await blob.arrayBuffer();
+        await window.electronAPI.saveDeFile(relPath, new Uint8Array(buf));
+        deAudioCache[relPath] = `sounds/DE/${relPath}`;
+    } else {
+        // Backup in Browser-Version
+        if (deOrdnerHandle) {
+            try {
+                const teile = relPath.split('/');
+                const name = teile.pop();
+                let ordner = deOrdnerHandle;
+                for (const t of teile) {
+                    ordner = await ordner.getDirectoryHandle(t, { create: true });
+                }
+                const backupRoot = await deOrdnerHandle.getDirectoryHandle('..', {});
+                const backupDir = await backupRoot.getDirectoryHandle('DE-Backup', { create: true });
+                let ziel = backupDir;
+                for (const t of teile) {
+                    ziel = await ziel.getDirectoryHandle(t, { create: true });
+                }
+                const orgFile = await ordner.getFileHandle(name);
+                const backupFile = await ziel.getFileHandle(name, { create: true });
+                const orgData = await orgFile.getFile();
+                const w = await backupFile.createWritable();
+                await w.write(orgData);
+                await w.close();
+            } catch {}
+        }
+        await speichereUebersetzungsDatei(blob, relPath);
+        deAudioCache[relPath] = blob;
+    }
+    renderFileTable();
+    closeDeEdit();
+    updateStatus('DE-Audio bearbeitet und gespeichert');
+}
+// =========================== APPLYDEEDIT END ===============================
 
 
 // =========================== RENAMEFOLDER START ==============================


### PR DESCRIPTION
## Zusammenfassung
- Backup-Ordner `DE-Backup` anlegen und per IPC nutzbar machen
- neue API `backupDeFile` in preload.js
- Bearbeitungsdialog inklusive Wellenanzeige und Trim-Funktion
- Button zum Öffnen des Dialogs in der Dateitabelle
- Dokumentation der neuen Funktion im README

## Testing
- `npm test` *(scheitert: jest nicht gefunden)*

------
https://chatgpt.com/codex/tasks/task_e_68494204491883278de2c1767f74a8f5