### PR TITLE
Fix DE audio playback and label

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -6,7 +6,7 @@
     <title>Half-Life: Alyx Translation Tool</title>
     <!-- Sicherheitsrichtlinie für Electron: verhindert Warnhinweise -->
     <!-- CSP angepasst: erlaubt nun Inline-Skripte -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline'; media-src 'self' blob:;">
     <style>
         * {
             margin: 0;
@@ -2035,7 +2035,7 @@ th:nth-child(9) {
             <h3>✂️ DE-Audio bearbeiten</h3>
             <div style="margin-bottom:15px;">
                 <div style="display:flex;flex-direction:column;gap:5px;">
-                    <span class="wave-label">NE (Original)</span>
+                    <span class="wave-label">EN (Original)</span>
                     <div style="display:flex;align-items:center;gap:10px;">
                         <canvas id="waveOriginal" width="500" height="80" style="width:100%; background:#111;"></canvas>
                         <button id="playOrigPreview" class="de-play-btn" onclick="playOriginalPreview()">▶</button>


### PR DESCRIPTION
## Summary
- erlaub `blob:`-URLs in der CSP, damit Audio per Blob abgespielt werden kann
- Label im DE-Edit-Dialog von `NE (Original)` auf `EN (Original)` korrigiert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68498eb3a3e88327a89c0f3771d44dcb