### PR TITLE
Verbesserter Reset beim DE-Audio-Editor

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -7784,6 +7784,10 @@ async function resetDeEdit() {
         editDurationMs = originalEditBuffer.length / originalEditBuffer.sampleRate * 1000;
         updateDeEditWaveforms();
         updateStatus('DE-Audio zurückgesetzt');
+        // Tabelle neu zeichnen, damit der Play-Button die aktuelle Datei nutzt
+        renderFileTable();
+        // Bearbeitungsfenster schließen
+        closeDeEdit();
     } catch (err) {
         console.error('Fehler beim Zurücksetzen', err);
         updateStatus('Fehler beim Zurücksetzen');


### PR DESCRIPTION
## Zusammenfassung
- Schließe den Bearbeitungsdialog direkt nach dem Zurücksetzen
- Aktualisiere die Dateitabelle damit der Play‑Button die aktuelle Datei nutzt

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849a95386d48327bd09ddd324bb0a1c