### PR TITLE
Fix persistence of trimmed audio

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -7781,6 +7781,8 @@ async function resetDeEdit() {
         editEndTrim = 0;
         currentEditFile.trimStartMs = 0;
         currentEditFile.trimEndMs = 0;
+        // Projekt als geändert markieren, damit Rücksetzungen gespeichert werden
+        isDirty = true;
         editDurationMs = originalEditBuffer.length / originalEditBuffer.sampleRate * 1000;
         updateDeEditWaveforms();
         updateStatus('DE-Audio zurückgesetzt');
@@ -7856,6 +7858,8 @@ async function applyDeEdit() {
     }
     currentEditFile.trimStartMs = editStartTrim;
     currentEditFile.trimEndMs = editEndTrim;
+    // Änderungen sichern
+    isDirty = true;
     renderFileTable();
     closeDeEdit();
     updateStatus('DE-Audio bearbeitet und gespeichert');


### PR DESCRIPTION
## Summary
- mark projects dirty when trimming audio is saved or reset

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849acf5d2c883278c1b8cd4df8b8b53