### PR TITLE
Fixe DE Audio Cache

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -4925,7 +4925,8 @@ async function playDeAudio(fileId) {
 
     let url = null;
     if (window.electronAPI && typeof deAudioCache[relPath] === 'string') {
-        audio.src = deAudioCache[relPath];
+        // Cache-Buster anhängen, damit nach Bearbeitungen sofort die neue Datei gespielt wird
+        audio.src = `${deAudioCache[relPath]}?v=${Date.now()}`;
     } else {
         url = URL.createObjectURL(deAudioCache[relPath]);
         audio.src = url;


### PR DESCRIPTION
## Notes
- Keine besonderen Hinweise.

## Summary
- verhindere Audio-Caching bei `playDeAudio`
- Tests weiterhin grün

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849b2fa6f808327a92533266ce43648