### PR TITLE
Add DE history feature

### DIFF
--- a/electron/preload.js
+++ b/electron/preload.js
@@ -10,6 +10,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   backupDeFile: (relPath) => ipcRenderer.invoke('backup-de-file', relPath),
   restoreDeFile: (relPath) => ipcRenderer.invoke('restore-de-file', relPath),
   deleteDeBackupFile: (relPath) => ipcRenderer.invoke('delete-de-backup-file', relPath),
+  listDeHistory: (relPath) => ipcRenderer.invoke('list-de-history', relPath),
+  restoreDeHistory: (relPath, name) => ipcRenderer.invoke('restore-de-history', { relPath, name }),
   // Backup-Funktionen
   listBackups: () => ipcRenderer.invoke('list-backups'),
   saveBackup: (data) => ipcRenderer.invoke('save-backup', data),

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -163,6 +163,9 @@
         <div class="context-menu-item" onclick="contextMenuAction('uploadDE')">
             <span>⬆️</span> DE-Datei hochladen
         </div>
+        <div class="context-menu-item" onclick="contextMenuAction('history')">
+            <span>🕒</span> Historie
+        </div>
         <div class="context-menu-divider"></div>
         <div class="context-menu-item" onclick="contextMenuAction('openFolder')">
             <span>📁</span> In Ordner-Browser öffnen
@@ -290,6 +293,18 @@
                 <button class="btn btn-secondary" onclick="createBackup(true)">Backup erstellen</button>
                 <button class="btn btn-secondary" onclick="openBackupFolder()">Ordner öffnen</button>
                 <button class="btn btn-secondary" onclick="closeBackupDialog()">Schließen</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- History Dialog -->
+    <div class="dialog-overlay" id="historyDialog">
+        <div class="dialog">
+<button class="dialog-close-btn" onclick="closeHistoryDialog()">×</button>
+            <h3>🕒 Historie</h3>
+            <div id="historyList" style="margin-bottom:15px;"></div>
+            <div class="dialog-buttons">
+                <button class="btn btn-secondary" onclick="closeHistoryDialog()">Schließen</button>
             </div>
         </div>
     </div>

--- a/src/style.css
+++ b/src/style.css
@@ -1240,6 +1240,21 @@ th:nth-child(9) {
             margin-left: 10px;
         }
 
+        .history-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            background: #1a1a1a;
+            border: 1px solid #444;
+            padding: 8px 12px;
+            border-radius: 4px;
+            margin-bottom: 8px;
+        }
+
+        .history-item button {
+            margin-left: 10px;
+        }
+
         /* Folder customization */
         .folder-header {
             display: flex;

--- a/tests/historyFunctions.test.js
+++ b/tests/historyFunctions.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { saveVersion, listVersions, restoreVersion } = require('../historyUtils');
+
+describe('history utils', () => {
+    test('keeps maximal zehn Versionen', () => {
+        const historyRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-'));
+        const source = path.join(historyRoot, 'src.wav');
+        fs.writeFileSync(source, 'data');
+        const relPath = 'test/file.wav';
+        for (let i = 0; i < 12; i++) {
+            fs.writeFileSync(source, `d${i}`);
+            saveVersion(historyRoot, relPath, source, 10);
+        }
+        const list = listVersions(historyRoot, relPath);
+        expect(list.length).toBe(10);
+    });
+
+    test('restores a version correctly', () => {
+        const historyRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-'));
+        const targetRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'de-'));
+        const source = path.join(historyRoot, 'src.wav');
+        fs.writeFileSync(source, 'abc');
+        const relPath = 'a/b.wav';
+        saveVersion(historyRoot, relPath, source, 10);
+        const name = listVersions(historyRoot, relPath)[0];
+        restoreVersion(historyRoot, relPath, name, targetRoot);
+        const restored = fs.readFileSync(path.join(targetRoot, relPath), 'utf8');
+        expect(restored).toBe('abc');
+    });
+});


### PR DESCRIPTION
## Summary
- keep old DE files in new `DE-History` folder
- allow listing and restoring history via IPC
- expose history API in preload
- add UI elements to view and restore file history
- provide helper functions with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e624b56c832796c55fd4630053a2