### PR TITLE
Add play button column layout

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1524,15 +1524,19 @@ return `
             <textarea class="text-input"
                  onchange="updateText(${file.id}, 'en', this.value)"
                  oninput="autoResizeInput(this)">${escapeHtml(file.enText)}</textarea>
-            <button class="copy-btn" onclick="copyTextToClipboard(${file.id}, 'en')" title="EN Text kopieren">📋</button>
-            <button class="play-btn" onclick="playAudio(${file.id})">▶</button>
+            <div class="btn-column">
+                <button class="copy-btn" onclick="copyTextToClipboard(${file.id}, 'en')" title="EN Text kopieren">📋</button>
+                <button class="play-btn" onclick="playAudio(${file.id})">▶</button>
+            </div>
         </div></td>
         <td><div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
             <textarea class="text-input"
                  onchange="updateText(${file.id}, 'de', this.value)"
                  oninput="autoResizeInput(this)">${escapeHtml(file.deText)}</textarea>
-            <button class="copy-btn" onclick="copyTextToClipboard(${file.id}, 'de')" title="DE Text kopieren">📋</button>
-            ${hasDeAudio ? `<button class="de-play-btn" onclick="playDeAudio(${file.id})">▶</button>` : ''}
+            <div class="btn-column">
+                <button class="copy-btn" onclick="copyTextToClipboard(${file.id}, 'de')" title="DE Text kopieren">📋</button>
+                ${hasDeAudio ? `<button class="de-play-btn" onclick="playDeAudio(${file.id})">▶</button>` : ''}
+            </div>
         </div></td>
         <td style="font-size: 11px; color: #666; word-break: break-all;">
             ${getDebugPathInfo(file)}

--- a/src/style.css
+++ b/src/style.css
@@ -541,15 +541,21 @@ th:nth-child(6) {
     }
 }
 
+        /* Play-Buttons neben den Textfeldern */
         .play-btn {
             background: #444;
             border: none;
             color: #e0e0e0;
-            padding: 6px 12px;
-            border-radius: 4px;
+            padding: 4px 6px; /* gleiche Größe wie Copy-Button */
+            border-radius: 3px;
             cursor: pointer;
             transition: all 0.2s;
-            font-size: 16px;
+            font-size: 11px;
+            min-width: 24px;
+            height: 24px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
         }
 
         .play-btn:hover {
@@ -567,11 +573,16 @@ th:nth-child(6) {
             background: #444;
             border: none;
             color: #e0e0e0;
-            padding: 6px 12px;
-            border-radius: 4px;
+            padding: 4px 6px; /* gleiche Größe wie Copy-Button */
+            border-radius: 3px;
             cursor: pointer;
             transition: all 0.2s;
-            font-size: 16px;
+            font-size: 11px;
+            min-width: 24px;
+            height: 24px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
         }
 
         .de-play-btn.playing,
@@ -676,6 +687,13 @@ th:nth-child(6) {
 
         .copy-btn:active {
             transform: scale(0.95);
+        }
+
+        /* Vertikale Anordnung von Copy- und Play-Button */
+        .btn-column {
+            display: flex;
+            flex-direction: column;
+            gap: 3px;
         }
 
         .completion-checkbox {


### PR DESCRIPTION
## Summary
- resize play buttons to match copy button
- stack copy/play buttons vertically next to text fields
- show German play button in same column when audio available

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ec2d890483279eeed71f1503a4f2