### PR TITLE
Implement Drag-and-Drop Upload

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -101,6 +101,7 @@
                 <table id="fileTable" style="display: none;">
 <thead>
     <tr>
+        <th width="30">↕</th>
         <th width="50" title="Doppelklick auf Nummer um Position zu ändern">#</th>
         <th class="sortable">Dateiname</th>
         <th class="sortable">Ordner</th>
@@ -111,6 +112,7 @@
         <th width="60">Upload</th>
         <th width="60">Historie</th>
         <th width="60">Bearbeiten</th>
+        <th width="60">Löschen</th>
     </tr>
 </thead>
                     <tbody id="fileTableBody"></tbody>

--- a/src/style.css
+++ b/src/style.css
@@ -477,6 +477,26 @@ th:nth-child(6) {
             background: #333 !important;
         }
 
+        /* Hervorhebung beim Datei-Upload per Drag & Drop */
+        .upload-drop-target {
+            position: relative;
+            outline: 2px dashed #1976d2;
+        }
+
+        .upload-overlay {
+            position: absolute;
+            inset: 0;
+            background: rgba(25, 118, 210, 0.8);
+            color: #fff;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 24px;
+            font-weight: bold;
+            pointer-events: none;
+            z-index: 5;
+        }
+
         .text-input {
             width: 100%;
             padding: 8px 10px;


### PR DESCRIPTION
## Summary
- add Spalte für Drag-Handle und Löschbutton zur Dateitabelle
- implementiere Upload per Drag & Drop direkt auf die Zeile
- markiere Zielzeile während des Uploads
- style Anpassungen für neuen Upload-Overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849ef1c6fd88327a87b5a6c63677fba