### PR TITLE
History-Funktion verbessert

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -201,9 +201,9 @@ app.whenReady().then(() => {
     return historyUtils.listVersions(deHistoryPath, relPath);
   });
 
-  // Stellt eine gewählte History-Version wieder her
+  // Stellt eine gewählte History-Version wieder her und tauscht sie mit der aktuellen
   ipcMain.handle('restore-de-history', async (event, { relPath, name }) => {
-    return historyUtils.restoreVersion(deHistoryPath, relPath, name, dePath);
+    return historyUtils.switchVersion(deHistoryPath, relPath, name, dePath);
   });
   // =========================== SAVE-DE-FILE END =============================
 

--- a/historyUtils.js
+++ b/historyUtils.js
@@ -39,4 +39,19 @@ function restoreVersion(historyRoot, relPath, name, targetRoot) {
     return target;
 }
 
-module.exports = { saveVersion, listVersions, restoreVersion };
+// Tauscht die aktuelle Datei mit einer History-Version aus und aktualisiert die Historie
+function switchVersion(historyRoot, relPath, name, targetRoot, limit = 10) {
+    const source = path.join(historyRoot, relPath, name);
+    const target = path.join(targetRoot, relPath);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    if (fs.existsSync(target)) {
+        // Aktuelle Datei vorher in die Historie verschieben
+        saveVersion(historyRoot, relPath, target, limit);
+    }
+    fs.copyFileSync(source, target);
+    // Wiederhergestellte Version aus der Historie entfernen
+    fs.unlinkSync(source);
+    return target;
+}
+
+module.exports = { saveVersion, listVersions, restoreVersion, switchVersion };

--- a/src/main.js
+++ b/src/main.js
@@ -4786,6 +4786,18 @@ function checkFileAccess() {
                 listDiv.textContent = 'Nur in der Desktop-Version verfügbar';
                 return;
             }
+            // Aktuelle Datei anzeigen
+            const currentItem = document.createElement('div');
+            currentItem.className = 'history-item';
+            const curLabel = document.createElement('span');
+            curLabel.textContent = 'Aktuelle Datei';
+            const curPlay = document.createElement('button');
+            curPlay.textContent = '▶';
+            curPlay.onclick = () => playCurrentSample(relPath);
+            currentItem.appendChild(curLabel);
+            currentItem.appendChild(curPlay);
+            listDiv.appendChild(currentItem);
+
             const files = await window.electronAPI.listDeHistory(relPath);
             files.forEach(name => {
                 const item = document.createElement('div');
@@ -4808,6 +4820,12 @@ function checkFileAccess() {
         function playHistorySample(relPath, name) {
             const audio = document.getElementById('audioPlayer');
             audio.src = `sounds/DE-History/${relPath}/${name}`;
+            audio.play();
+        }
+
+        function playCurrentSample(relPath) {
+            const audio = document.getElementById('audioPlayer');
+            audio.src = `sounds/DE/${relPath}`;
             audio.play();
         }
 

--- a/tests/historyFunctions.test.js
+++ b/tests/historyFunctions.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { saveVersion, listVersions, restoreVersion } = require('../historyUtils');
+const { saveVersion, listVersions, restoreVersion, switchVersion } = require('../historyUtils');
 
 describe('history utils', () => {
     test('keeps maximal zehn Versionen', () => {
@@ -28,5 +28,28 @@ describe('history utils', () => {
         restoreVersion(historyRoot, relPath, name, targetRoot);
         const restored = fs.readFileSync(path.join(targetRoot, relPath), 'utf8');
         expect(restored).toBe('abc');
+    });
+
+    test('switchVersion tauscht Dateien und aktualisiert die Historie', () => {
+        const historyRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-'));
+        const targetRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'de-'));
+        const relPath = 'c/d.wav';
+        const currentFile = path.join(targetRoot, relPath);
+        fs.mkdirSync(path.dirname(currentFile), { recursive: true });
+        // aktuelle Datei erstellen
+        fs.writeFileSync(currentFile, 'alt');
+        // Version in Historie speichern
+        saveVersion(historyRoot, relPath, currentFile, 10);
+        const histName = listVersions(historyRoot, relPath)[0];
+        // Datei ändern
+        fs.writeFileSync(currentFile, 'neu');
+        // Version wiederherstellen und tauschen
+        switchVersion(historyRoot, relPath, histName, targetRoot);
+        const inhalt = fs.readFileSync(currentFile, 'utf8');
+        expect(inhalt).toBe('alt');
+        const histFiles = listVersions(historyRoot, relPath);
+        expect(histFiles.length).toBe(1);
+        const histInhalt = fs.readFileSync(path.join(historyRoot, relPath, histFiles[0]), 'utf8');
+        expect(histInhalt).toBe('neu');
     });
 });


### PR DESCRIPTION
## Zusammenfassung
- aktuelle Datei in der History-Liste anzeigen
- beim Wiederherstellen landet die bisherige Datei in der Historie
- neue Utility-Funktion `switchVersion`
- Tests für `switchVersion`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849f2961d2083279fb20ce4d6d6cb51