### PR TITLE
Improve path display

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1539,11 +1539,11 @@ return `
                 ${hasDeAudio ? `<button class="de-play-btn" onclick="playDeAudio(${file.id})">▶</button>` : ''}
             </div>
         </div></td>
-        <td style="font-size: 11px; color: #666; word-break: break-all;">
+        <td class="path-cell" style="font-size: 11px; color: #666; word-break: break-all;">
             ${getDebugPathInfo(file)}
         </td>
-        <td style="font-size: 11px; color: #666; word-break: break-all;">
-            ${dePath ? `✅ sounds/DE/${dePath}` : '❌'}
+        <td class="path-cell" style="font-size: 11px; color: #666; word-break: break-all;">
+            ${dePath ? `✅<span class="path-detail"> sounds/DE/${dePath}</span>` : '❌'}
         </td>
         <td><button class="upload-btn" onclick="initiateDeUpload(${file.id})">⬆️</button></td>
         <td>${hasHistory ? `<button class="history-btn" onclick="openHistory(${file.id})">🕒</button>` : ''}</td>
@@ -1976,19 +1976,19 @@ function getDebugPathInfo(file) {
         const bestPath = exactMatches[0];
         const isAudioAvailable = !!audioFileCache[bestPath.fullPath];
         const status = isAudioAvailable ? '✅' : '❌';
-        return `${status} EXAKT<br><small>${bestPath.fullPath}</small>`;
+        return `${status} EXAKT<span class="path-detail"><br><small>${bestPath.fullPath}</small></span>`;
     }
     
     if (normalizedMatches.length > 0) {
         const bestPath = normalizedMatches[0];
         const isAudioAvailable = !!audioFileCache[bestPath.fullPath];
         const status = isAudioAvailable ? '✅' : '⚠️';
-        return `${status} NORMALISIERT<br><small>Projekt: ${file.folder}<br>DB: ${bestPath.folder}</small>`;
+        return `${status} NORMALISIERT<span class="path-detail"><br><small>Projekt: ${file.folder}<br>DB: ${bestPath.folder}</small></span>`;
     }
     
     // Keine Matches - zeige was verfügbar ist
     const availableFolders = dbPaths.map(p => p.folder).join('<br>');
-    return `❌ KEINE MATCHES<br><small>Projekt: ${file.folder}<br>DB hat:<br>${availableFolders}</small>`;
+    return `❌ KEINE MATCHES<span class="path-detail"><br><small>Projekt: ${file.folder}<br>DB hat:<br>${availableFolders}</small></span>`;
 }
 
 // Repariere Ordnernamen in allen Projekten basierend auf Database

--- a/src/style.css
+++ b/src/style.css
@@ -1807,4 +1807,13 @@ th:nth-child(6) {
     filter: brightness(1.2);
 }
 
+/* Details für Pfadangaben erst beim Hover anzeigen */
+.path-cell .path-detail {
+    display: none;
+}
+
+.path-cell:hover .path-detail {
+    display: inline;
+}
+
 		


### PR DESCRIPTION
## Summary
- add hover-only path display for EN and DE path columns
- update `getDebugPathInfo` to hide path details until hover
- introduce CSS rules for `.path-cell` and `.path-detail`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f45cae74832785f158f77e01fec2