### PR TITLE
Fix Stop button in audio editor

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -314,7 +314,7 @@
                     <div style="display:flex;align-items:center;gap:10px;">
                         <canvas id="waveOriginal" width="500" height="80" style="width:100%; background:#111;"></canvas>
                         <button id="playOrigPreview" class="de-play-btn" onclick="playOriginalPreview()">▶</button>
-                        <button class="de-play-btn" onclick="stopEditPlayback()">⏹</button>
+                        <button class="de-stop-btn" onclick="stopEditPlayback()">⏹</button>
                     </div>
                 </div>
                 <div style="display:flex;flex-direction:column;gap:5px;margin-top:10px;">
@@ -322,7 +322,7 @@
                     <div style="display:flex;align-items:center;gap:10px;">
                         <canvas id="waveEdited" width="500" height="80" style="width:100%; background:#111;"></canvas>
                         <button id="playDePreview" class="de-play-btn" onclick="playDePreview()">▶</button>
-                        <button class="de-play-btn" onclick="stopEditPlayback()">⏹</button>
+                        <button class="de-stop-btn" onclick="stopEditPlayback()">⏹</button>
                     </div>
                 </div>
             </div>

--- a/src/style.css
+++ b/src/style.css
@@ -611,9 +611,31 @@ th:nth-child(6) {
             justify-content: center;
         }
 
+        /* Stopp-Button im Audio-Editor */
+        .de-stop-btn {
+            background: #444;
+            border: none;
+            color: #e0e0e0;
+            padding: 4px 6px; /* gleiche Größe wie Copy-Button */
+            border-radius: 3px;
+            cursor: pointer;
+            transition: all 0.2s;
+            font-size: 11px;
+            min-width: 24px;
+            height: 24px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
         .de-play-btn.playing,
         .de-play-btn:hover {
             background: #2e7d32;
+            color: white;
+        }
+
+        .de-stop-btn:hover {
+            background: #b71c1c;
             color: white;
         }
 


### PR DESCRIPTION
## Summary
- correct stop button class so stop button doesn't become a play button
- style `.de-stop-btn` and adjust markup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f6fb75e08327813960b6963c5671