### PR TITLE
Audio-Wave proportional anzeigen

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -310,7 +310,7 @@
             <h3>✂️ DE-Audio bearbeiten</h3>
             <div style="margin-bottom:15px;">
                 <div style="display:flex;flex-direction:column;gap:5px;">
-                    <span class="wave-label">EN (Original)</span>
+                    <span class="wave-label" id="waveLabelOriginal">EN (Original)</span>
                     <div style="display:flex;align-items:center;gap:10px;">
                         <canvas id="waveOriginal" width="500" height="80" style="width:100%; background:#111;"></canvas>
                         <button id="playOrigPreview" class="de-play-btn" onclick="playOriginalPreview()">▶</button>
@@ -318,7 +318,7 @@
                     </div>
                 </div>
                 <div style="display:flex;flex-direction:column;gap:5px;margin-top:10px;">
-                    <span class="wave-label">DE (bearbeiten)</span>
+                    <span class="wave-label" id="waveLabelEdited">DE (bearbeiten)</span>
                     <div style="display:flex;align-items:center;gap:10px;">
                         <canvas id="waveEdited" width="500" height="80" style="width:100%; background:#111;"></canvas>
                         <button id="playDePreview" class="de-play-btn" onclick="playDePreview()">▶</button>

--- a/src/main.js
+++ b/src/main.js
@@ -5633,6 +5633,10 @@ async function openDeEdit(fileId) {
     }
     const enBuffer = await loadAudioBuffer(enSrc);
     editEnBuffer = enBuffer;
+    // Länge der beiden Dateien in Sekunden bestimmen
+    const enSeconds = enBuffer.length / enBuffer.sampleRate;
+    const deSeconds = originalEditBuffer.length / originalEditBuffer.sampleRate;
+    const maxSeconds = Math.max(enSeconds, deSeconds);
     editDurationMs = originalEditBuffer.length / originalEditBuffer.sampleRate * 1000;
     // Beide Cursor zurücksetzen
     editOrigCursor = 0;
@@ -5646,11 +5650,25 @@ async function openDeEdit(fileId) {
     document.getElementById('editEnd').value = editEndTrim;
     document.getElementById('editStart').oninput = e => { editStartTrim = parseInt(e.target.value) || 0; updateDeEditWaveforms(); };
     document.getElementById('editEnd').oninput = e => { editEndTrim = parseInt(e.target.value) || 0; updateDeEditWaveforms(); };
-    updateDeEditWaveforms();
-    document.getElementById('deEditDialog').style.display = 'flex';
 
     const deCanvas = document.getElementById('waveEdited');
     const origCanvas = document.getElementById('waveOriginal');
+
+    // Wellenbreite passend zur Länge setzen
+    const enRatio = enSeconds / maxSeconds;
+    const deRatio = deSeconds / maxSeconds;
+    const baseWidth = 500;
+    origCanvas.width = Math.round(baseWidth * enRatio);
+    deCanvas.width  = Math.round(baseWidth * deRatio);
+    origCanvas.style.width = `${enRatio * 100}%`;
+    deCanvas.style.width  = `${deRatio * 100}%`;
+
+    // Längen in Sekunden anzeigen
+    document.getElementById('waveLabelOriginal').textContent = `EN (Original) - ${enSeconds.toFixed(2)}s`;
+    document.getElementById('waveLabelEdited').textContent = `DE (bearbeiten) - ${deSeconds.toFixed(2)}s`;
+
+    updateDeEditWaveforms();
+    document.getElementById('deEditDialog').style.display = 'flex';
 
     // Klick auf das Original-Wellenbild setzt den EN-Cursor
     origCanvas.onmousedown = e => {


### PR DESCRIPTION
## Summary
- zeige bei den Wave-Labels die jeweilige Länge an
- passe die Canvas-Breite der Waves an die tatsächliche Spieldauer an

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849f7f0d43c8327b1506cb91119d6ee