### PR TITLE
Pfad-Ansicht per Rechtsklick und Lautstärke-Speichern

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1555,6 +1555,7 @@ return `
     tbody.innerHTML = rows.join('');
     
     addDragAndDropHandlers();
+    addPathCellContextMenus();
     updateCounts();
     
     // Auto-resize all text inputs after rendering
@@ -2459,6 +2460,21 @@ function addDragAndDropHandlers() {
             cell.addEventListener('dragover', handleRowDragOver);
             cell.addEventListener('drop', handleRowDrop);
         });
+    });
+}
+
+// Registriert Rechtsklick-Handler für Pfad-Zellen, um Details anzuzeigen
+function addPathCellContextMenus() {
+    document.querySelectorAll('.path-cell').forEach(cell => {
+        cell.addEventListener('contextmenu', e => {
+            e.preventDefault();
+            cell.classList.toggle('show-path');
+        });
+    });
+    document.addEventListener('click', e => {
+        if (!e.target.closest('.path-cell')) {
+            document.querySelectorAll('.path-cell.show-path').forEach(c => c.classList.remove('show-path'));
+        }
     });
 }
 
@@ -5996,6 +6012,8 @@ async function resetDeEdit() {
 // Speichert die bearbeitete DE-Datei und legt ein Backup an
 async function applyDeEdit() {
     if (!currentEditFile || !originalEditBuffer) return;
+    // Sicherstellen, dass der aktuelle Zustand des Toggles berücksichtigt wird
+    isVolumeMatched = document.getElementById('volumeMatchToggle').checked;
     const relPath = getFullPath(currentEditFile);
     if (window.electronAPI && window.electronAPI.backupDeFile) {
         // Sicherstellen, dass ein Backup existiert

--- a/src/style.css
+++ b/src/style.css
@@ -1829,12 +1829,12 @@ th:nth-child(6) {
     filter: brightness(1.2);
 }
 
-/* Details für Pfadangaben erst beim Hover anzeigen */
+/* Details für Pfadangaben über Rechtsklick anzeigen */
 .path-cell .path-detail {
     display: none;
 }
 
-.path-cell:hover .path-detail {
+.path-cell.show-path .path-detail {
     display: inline;
 }
 


### PR DESCRIPTION
## Summary
- zeigen der Pfaddetails nur noch nach Rechtsklick
- Kontextmenü-Handler für Pfadzellen ergänzt
- Zustand des Lautstärkeangleich-Toggles beim Speichern berücksichtigen

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849fb606e508327885d5e09e9b29063