### PR TITLE
Pfadspalte vereinheitlicht

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -107,8 +107,7 @@
         <th class="sortable">Ordner</th>
         <th>EN Text</th>
         <th>DE Text</th>
-        <th width="200" title="Pfad der EN-Datei">EN-Pfad</th>
-        <th width="200" title="Pfad der DE-Datei">DE Pfad</th>
+        <th width="120" title="Pfad der EN- und DE-Datei">Pfad</th>
         <th width="60">Upload</th>
         <th width="60">Historie</th>
         <th width="60">Bearbeiten</th>

--- a/src/main.js
+++ b/src/main.js
@@ -1540,10 +1540,11 @@ return `
             </div>
         </div></td>
         <td class="path-cell" style="font-size: 11px; color: #666; word-break: break-all;">
-            ${getDebugPathInfo(file)}
-        </td>
-        <td class="path-cell" style="font-size: 11px; color: #666; word-break: break-all;">
-            ${dePath ? `✅<span class="path-detail"> sounds/DE/${dePath}</span>` : '❌'}
+            <div class="btn-column">
+                <span class="path-btn ${audioFileCache[relPath] ? 'exists' : 'missing'}" title="Pfad der EN-Datei">EN</span>
+                <span class="path-btn ${dePath ? 'exists' : 'missing'}" title="Pfad der DE-Datei">DE</span>
+            </div>
+            <span class="path-detail">EN: sounds/EN/${relPath}<br>DE: ${dePath ? `sounds/DE/${dePath}` : 'fehlend'}</span>
         </td>
         <td><button class="upload-btn" onclick="initiateDeUpload(${file.id})">⬆️</button></td>
         <td>${hasHistory ? `<button class="history-btn" onclick="openHistory(${file.id})">🕒</button>` : ''}</td>

--- a/src/style.css
+++ b/src/style.css
@@ -738,11 +738,34 @@ th:nth-child(6) {
         }
 
         /* Vertikale Anordnung von Copy- und Play-Button */
-        .btn-column {
-            display: flex;
-            flex-direction: column;
-            gap: 3px;
-        }
+.btn-column {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+/* Symbole für Pfad-Verfügbarkeit */
+.path-btn {
+    background: #444;
+    border: none;
+    color: #e0e0e0;
+    padding: 4px 6px;
+    border-radius: 3px;
+    font-size: 11px;
+    min-width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.path-btn.exists {
+    background: #2e7d32;
+}
+
+.path-btn.missing {
+    background: #b71c1c;
+}
 
         .completion-checkbox {
             width: 18px;


### PR DESCRIPTION
## Summary
- neue Spalte **Pfad** im HTML‐Header
- Pfadinformationen werden als zwei farbige Icons angezeigt
- CSS um `.path-btn` ergänzt
- Rendering in `renderFileTableWithOrder` angepasst

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a007892c8832790561eccbe310728