### PR TITLE
Add applyVolumeMatch button

### DIFF
--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -328,10 +328,10 @@
             <div style="margin-bottom:15px; display:flex; gap:10px;">
                 <label>Start (ms): <input type="number" id="editStart" value="0" step="100"></label>
                 <label>Ende (ms): <input type="number" id="editEnd" value="0" step="100"></label>
-                <label><input type="checkbox" id="volumeMatchToggle" onchange="toggleVolumeMatch()"> Lautstärke angleichen</label>
             </div>
             <div class="dialog-buttons">
                 <button class="btn btn-secondary" onclick="resetDeEdit()">Zurücksetzen</button>
+                <button id="volumeMatchBtn" class="btn btn-secondary" onclick="applyVolumeMatch()">Lautstärke angleichen</button>
                 <button class="btn btn-secondary" onclick="applyDeEdit()">Speichern</button>
                 <button class="btn btn-secondary" onclick="closeDeEdit()">Abbrechen</button>
             </div>


### PR DESCRIPTION
## Summary
- füge neuen Button *Lautstärke angleichen* in der HTML-Dialogansicht ein
- entferne Checkbox und ersetze `toggleVolumeMatch` durch `applyVolumeMatch`
- passe Kommentare und Logik im Editor an

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a0194c4408327a01e5f2c48e5f93e