### PR TITLE
Edit-Statussymbole neben Bearbeiten-Button

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1550,10 +1550,13 @@ return `
         </td>
         <td><button class="upload-btn" onclick="initiateDeUpload(${file.id})">⬆️</button></td>
         <td>${hasHistory ? `<button class="history-btn" onclick="openHistory(${file.id})">🕒</button>` : ''}</td>
-        <td><button class="edit-audio-btn" onclick="openDeEdit(${file.id})">✂️</button>
-            ${file.trimStartMs !== 0 || file.trimEndMs !== 0 ? '<span class="edit-status-icon">✂️</span>' : ''}
-            ${file.volumeMatched ? '<span class="edit-status-icon">🔊</span>' : ''}
-        </td>
+        <td><div style="display:flex;align-items:flex-start;gap:5px;">
+            <button class="edit-audio-btn" onclick="openDeEdit(${file.id})">✂️</button>
+            <div class="edit-column">
+                ${file.trimStartMs !== 0 || file.trimEndMs !== 0 ? '<span class="edit-status-icon">✂️</span>' : ''}
+                ${file.volumeMatched ? '<span class="edit-status-icon">🔊</span>' : ''}
+            </div>
+        </div></td>
         <td><button class="delete-row-btn" onclick="deleteFile(${file.id})">🗑️</button></td>
     </tr>
 `;

--- a/src/style.css
+++ b/src/style.css
@@ -639,7 +639,7 @@ th:nth-child(6) {
             color: white;
         }
 
-        /* Kleine Statussymbole hinter dem ✂️-Button */
+        /* Kleine Statussymbole rechts neben dem ✂️-Button */
         .edit-status-icon {
             background: #444;
             color: #e0e0e0;
@@ -648,10 +648,16 @@ th:nth-child(6) {
             font-size: 11px;
             min-width: 24px;
             height: 24px;
-            display: inline-flex;
+            display: flex;
             align-items: center;
             justify-content: center;
-            margin-left: 2px;
+        }
+
+        /* Vertikale Anordnung der Bearbeitungs-Symbole */
+        .edit-column {
+            display: flex;
+            flex-direction: column;
+            gap: 3px;
         }
 
         .upload-btn {


### PR DESCRIPTION
## Zusammenfassung
- Symbole fuer Beschnitt und Lautstaerke direkt rechts neben dem Bearbeiten-Button anordnen
- entsprechende Styles anpassen

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a04caa474832789e888d302e56e38