### PR TITLE
Add completion marker on project tiles

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -409,8 +409,10 @@ function renderProjects() {
         const badge = `<span class="level-part-badge">${p.levelPart}</span>`;
 
         /* ► HTML-Inhalt */
+        const doneMark = done ? `<span class="project-done-marker">✅</span>` : '';
         card.innerHTML = `
             ${badge}
+            ${doneMark}
             <div style="display:flex;gap:8px;align-items:flex-start;">
                 <span style="font-size:16px;">${p.icon || '🗂️'}</span>
                 <div style="flex:1;min-width:0;">
@@ -442,7 +444,7 @@ function renderProjects() {
             (p.levelName ? `Level: ${p.levelName}\n` : '') +
             `Teil:  ${p.levelPart}\n\n` +
             `• EN: ${stats.enPercent}%  • DE: ${stats.dePercent}%\n` +
-            `• DE-Audio: ${stats.deAudioPercent}%  • Fertig: ${stats.completedPercent}%\n` +
+            `• DE-Audio: ${stats.deAudioPercent}%  • Fertig: ${stats.completedPercent}%${done ? ' ✅' : ''}\n` +
             `• Dateien: ${stats.totalFiles}`;
 
         /* ► Klick / Drag */

--- a/src/style.css
+++ b/src/style.css
@@ -1686,6 +1686,17 @@ th:nth-child(6) {
     pointer-events:none;
     text-shadow:0 0 4px rgba(0,0,0,0.6);
 }
+/* =========================== PROJECT DONE MARKER STYLE START ================ */
+.project-done-marker{
+    position:absolute;
+    top:6px;
+    left:10px;
+    font-size:18px;
+    color:#4caf50;
+    pointer-events:none;
+    text-shadow:0 0 4px rgba(0,0,0,0.6);
+}
+/* =========================== PROJECT DONE MARKER STYLE END ================== */
 /* =========================== PROJECT LEVEL BADGE STYLE END =========================== */
 
 /* =========================== PROJECT PERCENT STYLE START =========================== */


### PR DESCRIPTION
## Summary
- mark fertige Projekte in `renderProjects()` sichtbar
- neuen CSS-Stil `.project-done-marker` definieren
- Tooltip um Häkchen ergänzen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a0b909f888327bd0732cefb69039f