### PR TITLE
Implement level sorting/edit dialog

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1903,7 +1903,23 @@ th:nth-child(6) {
     border-radius: 4px;
     cursor: pointer;
     margin-bottom: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
+.level-edit-btn {
+    background: none;
+    border: none;
+    color: rgba(255,255,255,0.7);
+    cursor: pointer;
+    padding: 2px 5px;
+    opacity: 0;
+    border-radius: 3px;
+    transition: opacity 0.2s;
+    font-size: 12px;
+}
+.level-header:hover .level-edit-btn { opacity: 1; }
+.level-edit-btn:hover { background: rgba(255,255,255,0.2); }
 .level-group.collapsed .level-projects { display: none; }
 /* =========================== LEVEL-GROUP STYLES END ========================= */
 


### PR DESCRIPTION
## Summary
- add global Level-Reihenfolge
- speichere und lade Level-Sortierung
- sortiere Level-Gruppen und Projekte nach Nummern
- erlaube Level-Einstellungen über neuen Dialog
- Style für Level-Edit-Button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a856d65c0832794adec8788d4210f