### PR TITLE
Allow four digit level numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.7.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.7.1-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.7.0](#-neue-features-in-370)
+* [✨ Neue Features in 3.7.1](#-neue-features-in-371)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [🏁 Erste Schritte](#-erste-schritte)
@@ -26,7 +26,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.7.0
+## ✨ Neue Features in 3.7.1
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -39,6 +39,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 | **Datenbank‑Bereinigung**  | **Ordnernamen bereinigen**: Korrigiert falsche Ordnernamen basierend auf echten Dateipfaden. |
 | **Ordner‑Löschfunktion**   | Komplette Ordner können sicher aus der Datenbank gelöscht werden (mit Schutz vor Datenverlust). |
 | **Level-Reihenfolge sichtbar** | Dropdowns und Level-Kopfzeilen zeigen jetzt die zugehörige Zahl, z.B. `1.Levelname`. |
+| **Level-Nummern bis 9999** | Level-Reihenfolge und Teil-Nummern unterstützen jetzt Werte bis 9999. |
 | **Cleanup‑Routine**        | Fehlende Dateien **ohne** EN & DE werden automatisch aus der DB entfernt. |
 | **Verbesserter UI‑Polish** | • Schließen‑Knopf (×) nun oben rechts 🡆 hover‑animiert.<br>• Fertige Projekte/Ordner erhalten leuchtend grünen Rahmen.<br>• Dark‑Theme‑Kontrast optimiert. |
 | **DE-Audio-Bearbeitung**   | DE-Audiodateien lassen sich direkt kürzen oder verlängern. Vor dem Speichern wird automatisch eine Sicherung im Ordner `DE-Backup` angelegt. |
@@ -317,10 +318,11 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.7.0 (aktuell) - Level‑UI-Verbesserungen
+### 3.7.1 (aktuell) - Level‑Nummern-Fix
 
 **✨ Neue Features:**
 * **Level-Reihenfolge sichtbar**: Dropdowns und Level-Kopfzeilen zeigen jetzt die zugehörige Zahl, z.B. `1.Levelname`.
+* **Level-Nummern bis 9999**: Reihenfolge und Teil-Nummern akzeptieren vierstellige Werte.
 
 ### 3.6.0 - Level‑Management & Datenbank‑Tools
 
@@ -415,7 +417,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.7.0** - Level‑UI-Verbesserungen Edition
+**Version 3.7.1** - Level‑Nummern-Fix
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla-translation-desktop",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "main.js",
   "scripts": {
     "start": "electron ."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "devDependencies": {
     "jest": "^29.6.1"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -206,7 +206,7 @@ function setLevelColor(levelName, color) {
 /* =========================== LEVEL ORDER HELPERS START ======================== */
 function getLevelOrder(levelName) {
     // Standardwert, falls keine Reihenfolge gesetzt ist
-    return levelOrders[levelName] || 999;
+    return levelOrders[levelName] || 9999;
 }
 
 function setLevelOrder(levelName, order) {
@@ -7066,7 +7066,7 @@ function showProjectCustomization(id, ev) {
 
       <div class="customize-field">
         <label>Teil-Nummer:</label>
-        <input type="number" id="cPart" min="1" max="99" value="${prj.levelPart}">
+        <input type="number" id="cPart" min="1" max="9999" value="${prj.levelPart}">
       </div>
 
       <div class="customize-field">
@@ -7131,7 +7131,7 @@ function showLevelCustomization(levelName, ev) {
 
       <div class="customize-field">
         <label>Reihenfolge:</label>
-        <input type="number" id="lvlOrder" min="1" max="99" value="${order}">
+        <input type="number" id="lvlOrder" min="1" max="9999" value="${order}">
       </div>
 
       <div class="customize-field">


### PR DESCRIPTION
## Summary
- allow Teil-Nummer und Level-Reihenfolge bis 9999
- erhöhe Standardwert für Levelreihenfolge
- Dokumentation und Versionsnummern angepasst

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8b7a3b308327a6413701823a8a01