### PR TITLE
Behebe Level-Reihenfolge Bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.7.1-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.7.2-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.7.1](#-neue-features-in-371)
+* [✨ Neue Features in 3.7.2](#-neue-features-in-372)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [🏁 Erste Schritte](#-erste-schritte)
@@ -26,7 +26,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.7.1
+## ✨ Neue Features in 3.7.2
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -318,7 +318,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.7.1 (aktuell) - Level‑Nummern-Fix
+### 3.7.2 (aktuell) - Initialisierungsfehler behoben
+
+**🐞 Bugfixes:**
+* Korrigiert die Anzeige der Level-Reihenfolge beim Start des Tools.
+
+### 3.7.1 - Level‑Nummern-Fix
 
 **✨ Neue Features:**
 * **Level-Reihenfolge sichtbar**: Dropdowns und Level-Kopfzeilen zeigen jetzt die zugehörige Zahl, z.B. `1.Levelname`.
@@ -417,7 +422,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.7.1** - Level‑Nummern-Fix
+**Version 3.7.2** - Initialisierungsfehler behoben
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "devDependencies": {
         "jest": "^29.6.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "devDependencies": {
     "jest": "^29.6.1"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -308,6 +308,12 @@ function loadProjects() {
         levelColors = JSON.parse(savedLevelColors);
     }
 
+    // 🟢 Ebenfalls Reihenfolge der Level laden
+    const savedLevelOrders = localStorage.getItem('hla_levelOrders');
+    if (savedLevelOrders) {
+        levelOrders = JSON.parse(savedLevelOrders);
+    }
+
     // DANN: Projekte laden
     const savedProjects = localStorage.getItem('hla_projects');
     if (savedProjects) {


### PR DESCRIPTION
## Summary
- lade gespeicherte Level-Reihenfolge bereits in `loadProjects`
- Versionsnummer auf 1.0.2/3.7.2 angehoben
- Dokumentation und Changelog auf den aktuellen Stand gebracht

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a8d39b39c8327ad0122a0912b48d7