### PR TITLE
Add Level order input on project creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.7.2-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.7.3-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.7.2](#-neue-features-in-372)
+* [✨ Neue Features in 3.7.3](#-neue-features-in-373)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [🏁 Erste Schritte](#-erste-schritte)
@@ -26,7 +26,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.7.2
+## ✨ Neue Features in 3.7.3
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -40,6 +40,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 | **Ordner‑Löschfunktion**   | Komplette Ordner können sicher aus der Datenbank gelöscht werden (mit Schutz vor Datenverlust). |
 | **Level-Reihenfolge sichtbar** | Dropdowns und Level-Kopfzeilen zeigen jetzt die zugehörige Zahl, z.B. `1.Levelname`. |
 | **Level-Nummern bis 9999** | Level-Reihenfolge und Teil-Nummern unterstützen jetzt Werte bis 9999. |
+| **Level-Nummer beim Erstellen** | Beim Anlegen eines neuen Levels kann sofort eine Reihenfolge-Zahl vergeben werden. |
 | **Cleanup‑Routine**        | Fehlende Dateien **ohne** EN & DE werden automatisch aus der DB entfernt. |
 | **Verbesserter UI‑Polish** | • Schließen‑Knopf (×) nun oben rechts 🡆 hover‑animiert.<br>• Fertige Projekte/Ordner erhalten leuchtend grünen Rahmen.<br>• Dark‑Theme‑Kontrast optimiert. |
 | **DE-Audio-Bearbeitung**   | DE-Audiodateien lassen sich direkt kürzen oder verlängern. Vor dem Speichern wird automatisch eine Sicherung im Ordner `DE-Backup` angelegt. |
@@ -318,10 +319,10 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.7.2 (aktuell) - Initialisierungsfehler behoben
+### 3.7.3 (aktuell) - Level-Nummer beim Anlegen
 
-**🐞 Bugfixes:**
-* Korrigiert die Anzeige der Level-Reihenfolge beim Start des Tools.
+**✨ Neue Features:**
+* **Level-Nummer beim Erstellen**: Beim Anlegen eines neuen Levels kann sofort eine Reihenfolge-Zahl vergeben werden.
 
 ### 3.7.1 - Level‑Nummern-Fix
 
@@ -422,7 +423,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.7.2** - Initialisierungsfehler behoben
+**Version 3.7.3** - Level-Nummer beim Anlegen
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla-translation-desktop",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "main.js",
   "scripts": {
     "start": "electron ."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "devDependencies": {
     "jest": "^29.6.1"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -7068,6 +7068,9 @@ function showProjectCustomization(id, ev) {
         <input id="cLevelNew"
                placeholder="Neuen Level-Namen"
                style="margin-top:8px;display:${prj.levelName?'none':'block'};">
+        <input type="number" id="cLevelOrder" min="1" max="9999"
+               placeholder="Level-Nummer"
+               style="margin-top:8px;display:${prj.levelName?'none':'block'};">
       </div>
 
       <div class="customize-field">
@@ -7092,8 +7095,11 @@ function showProjectCustomization(id, ev) {
     /* Eingabedynamik */
     const sel = pop.querySelector('#cLevel');
     const inp = pop.querySelector('#cLevelNew');
+    const ordInp = pop.querySelector('#cLevelOrder');
     sel.onchange = () => {
-        inp.style.display = sel.value ? 'none' : 'block';
+        const show = !sel.value;
+        inp.style.display = show ? 'block' : 'none';
+        ordInp.style.display = show ? 'block' : 'none';
     };
 
     pop.querySelector('#cCancel').onclick = () => document.body.removeChild(ov);
@@ -7106,6 +7112,12 @@ function showProjectCustomization(id, ev) {
         /* Level-Farbe global anwenden */
         const newColor = pop.querySelector('#cColor').value;
         setLevelColor(prj.levelName, newColor);
+
+        // Level-Reihenfolge setzen, falls neuer Level angelegt wird
+        if (!sel.value) {
+            const order = Math.max(1, parseInt(ordInp.value) || 1);
+            setLevelOrder(prj.levelName, order);
+        }
 
         saveProjects();
         updateProjectMetaBar();


### PR DESCRIPTION
## Summary
- beim Projekt-Dialog kann man nun beim Anlegen eines neuen Levels auch gleich die Level-Nummer (Reihenfolge) vergeben
- Versionsnummern aktualisiert
- Dokumentation zu neuem Feature ergänzt

## Testing
- `npm test` *(fail: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8e75e89483279fe65d45bfbd1c12