### PR TITLE
Fokusfix und Versionslink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.7.3-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.8.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.7.3](#-neue-features-in-373)
+* [✨ Neue Features in 3.8.0](#-neue-features-in-380)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [🏁 Erste Schritte](#-erste-schritte)
@@ -26,10 +26,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.7.3
+## ✨ Neue Features in 3.8.0
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Dialog-Fokus**           | Eingabefelder in Dialogen erhalten nun direkt den Cursor. |
+| **Versionsanzeige**        | Unten rechts zeigt ein Link die aktuelle Version und öffnet GitHub. |
 | **Level‑Management**       | Projekte besitzen jetzt **Level‑Namen** + **Teil‑Nummern**.<br>Alle vorhandenen Namen werden beim Anlegen/Umbenennen als Dropdown angeboten.                |
 | **Projekt‑Metaleiste**     | Über der Tabelle erscheint **Projekt • Level • Teil** + Ein‑Klick‑Button ⧉ zum Kopieren des Level‑Namens.                                                   |
 | **Globale Text‑Statistik** | Neue Kachel **EN / DE / BEIDE / ∑** in den globalen Statistiken + Live‑Update beim Tippen.                                                                  |
@@ -319,10 +321,11 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.7.3 (aktuell) - Level-Nummer beim Anlegen
+### 3.8.0 (aktuell) - Verbesserte Dialoge & Versionslink
 
 **✨ Neue Features:**
-* **Level-Nummer beim Erstellen**: Beim Anlegen eines neuen Levels kann sofort eine Reihenfolge-Zahl vergeben werden.
+* **Dialog-Fokus**: Eingabefelder bekommen automatisch den Cursor (Projekt-, Level-, Ordner- und Import-Dialog).
+* **Versionsanzeige**: Unten rechts zeigt ein Link die aktuelle Version und öffnet GitHub.
 
 ### 3.7.1 - Level‑Nummern-Fix
 
@@ -423,7 +426,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.7.3** - Level-Nummer beim Anlegen
+**Version 3.8.0** - Verbesserte Dialoge & Versionslink
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -349,6 +349,9 @@
     </details>
 
 
+    <!-- Versionsanzeige -->
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.8.0</a>
+
     <script src="src/main.js"></script>
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -4254,6 +4254,9 @@ function addFileFromFolderBrowser(filename, folder, fullPath) {
             
             document.body.appendChild(overlay);
             document.body.appendChild(popup);
+
+            // Fokussiere das Icon-Feld
+            popup.querySelector('#customIcon').focus();
         }
 
         function updateCustomizationPreview() {
@@ -4355,7 +4358,9 @@ function addFileFromFolderBrowser(filename, folder, fullPath) {
             document.getElementById('columnSelection').style.display = 'none';
             document.getElementById('analyzeDataBtn').style.display = 'block';
             document.getElementById('startImportBtn').style.display = 'none';
-            document.getElementById('importData').value = '';
+            const field = document.getElementById('importData');
+            field.value = '';
+            field.focus();
         }
 
         function closeImportDialog() {
@@ -4758,7 +4763,7 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.6.0',
+                version: '3.8.0',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
@@ -4836,6 +4841,7 @@ function checkFileAccess() {
         function showBackupDialog() {
             document.getElementById('backupDialog').style.display = 'flex';
             loadBackupList();
+            document.getElementById('backupInterval').focus();
             document.getElementById('backupInterval').onchange = () => {
                 autoBackupInterval = parseInt(document.getElementById('backupInterval').value) || 1;
                 localStorage.setItem('hla_autoBackupInterval', autoBackupInterval);
@@ -7092,6 +7098,16 @@ function showProjectCustomization(id, ev) {
     ov.appendChild(pop);
     document.body.appendChild(ov);
 
+    // Fokussiere das Namensfeld
+    pop.querySelector('#lvlName').focus();
+
+    // Fokussiere direkt das passende Eingabefeld
+    if (!sel.value) {
+        inp.focus();
+    } else {
+        pop.querySelector('#cName').focus();
+    }
+
     /* Eingabedynamik */
     const sel = pop.querySelector('#cLevel');
     const inp = pop.querySelector('#cLevelNew');
@@ -7100,6 +7116,9 @@ function showProjectCustomization(id, ev) {
         const show = !sel.value;
         inp.style.display = show ? 'block' : 'none';
         ordInp.style.display = show ? 'block' : 'none';
+        if (show) {
+            inp.focus();
+        }
     };
 
     pop.querySelector('#cCancel').onclick = () => document.body.removeChild(ov);
@@ -7524,7 +7543,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.6.0 Level-Management & Datenbank-Tools Edition');
+        console.log('Version 3.8.0 - Verbesserte Dialoge');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');

--- a/src/style.css
+++ b/src/style.css
@@ -1923,4 +1923,16 @@ th:nth-child(6) {
 .level-group.collapsed .level-projects { display: none; }
 /* =========================== LEVEL-GROUP STYLES END ========================= */
 
+/* Versionsnummer unten rechts */
+#versionLink {
+    position: fixed;
+    bottom: 5px;
+    right: 10px;
+    font-size: 12px;
+    color: #888;
+    text-decoration: none;
+}
+
+#versionLink:hover { color: #ff6b1a; }
+
 		


### PR DESCRIPTION
## Summary
- sorge dafür, dass Eingabedialoge sofort den Cursor erhalten
- zeige die aktuelle Version rechts unten mit Link zu GitHub
- aktualisiere Versionsnummer auf **3.8.0** und passe die Doku an

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a90351b7c832783e44901665987eb