### PR TITLE
Fix Level-Umbenennung

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.8.2-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.8.3-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.8.2](#-neue-features-in-382)
+* [✨ Neue Features in 3.8.3](#-neue-features-in-383)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [🏁 Erste Schritte](#-erste-schritte)
@@ -26,7 +26,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.8.2
+## ✨ Neue Features in 3.8.3
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -323,12 +323,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.8.2 (aktuell) - Fehlerkorrekturen
+### 3.8.3 (aktuell) - Fehlerkorrekturen
 
 **✨ Neue Features:**
 * **Dialog-Fokus**: Eingabefelder bekommen automatisch den Cursor (Projekt-, Level-, Ordner- und Import-Dialog).
 * **Versionsanzeige**: Oben links zeigt ein Link die aktuelle Version und öffnet GitHub.
-* **Fix**: Umbenannte Level behalten nun die eingestellte Reihenfolge.
+* **Fix**: Umbenannte Level behalten jetzt sicher die eingestellte Reihenfolge.
 
 ### 3.7.1 - Level‑Nummern-Fix
 
@@ -429,7 +429,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.8.2** - Fehlerkorrekturen & Versionslink oben
+**Version 3.8.3** - Fehlerkorrekturen & Versionslink oben
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -350,7 +350,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.8.2</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.8.3</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -4763,7 +4763,7 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.8.2',
+                version: '3.8.3',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
@@ -7189,8 +7189,9 @@ function showLevelCustomization(levelName, ev) {
     pop.querySelector('#lvlCancel').onclick = () => document.body.removeChild(ov);
 
     pop.querySelector('#lvlSave').onclick = () => {
+        const oldOrder = getLevelOrder(levelName);
         const newName  = pop.querySelector('#lvlName').value.trim() || levelName;
-        const newOrder = Math.max(1, parseInt(pop.querySelector('#lvlOrder').value) || 1);
+        const newOrder = Math.max(1, parseInt(pop.querySelector('#lvlOrder').value) || oldOrder);
         const newColor = pop.querySelector('#lvlColor').value;
 
         projects.forEach(p => {
@@ -7204,8 +7205,7 @@ function showLevelCustomization(levelName, ev) {
         if (levelOrders[levelName] && levelName !== newName) delete levelOrders[levelName];
 
         levelColors[newName] = newColor;
-        levelOrders[newName] = newOrder;
-        // Reihenfolge direkt sichern, falls sie neu vergeben wurde
+        // Reihenfolge immer speichern
         setLevelOrder(newName, newOrder);
 
         if (expandedLevel === levelName) expandedLevel = newName;
@@ -7546,7 +7546,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.8.2 - Fehlerkorrekturen');
+        console.log('Version 3.8.3 - Fehlerkorrekturen');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');


### PR DESCRIPTION
## Summary
- Stelle beim Speichern eines Levels sicher, dass die Reihenfolge immer gesetzt wird
- Version auf 3.8.3 angehoben

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a9a2ed904832799adf04891480aa0