### PR TITLE
Bugfix: Level-Umbenennung

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.8.3-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.8.4-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.8.3](#-neue-features-in-383)
+* [✨ Neue Features in 3.8.4](#-neue-features-in-384)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [🏁 Erste Schritte](#-erste-schritte)
@@ -26,7 +26,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.8.3
+## ✨ Neue Features in 3.8.4
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -323,12 +323,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.8.3 (aktuell) - Fehlerkorrekturen
+### 3.8.4 (aktuell) - Fehlerkorrekturen
 
 **✨ Neue Features:**
 * **Dialog-Fokus**: Eingabefelder bekommen automatisch den Cursor (Projekt-, Level-, Ordner- und Import-Dialog).
 * **Versionsanzeige**: Oben links zeigt ein Link die aktuelle Version und öffnet GitHub.
-* **Fix**: Umbenannte Level behalten jetzt sicher die eingestellte Reihenfolge.
+* **Fix**: Umbenannte Level speichern nun den Namen korrekt und behalten die eingestellte Reihenfolge.
 
 ### 3.7.1 - Level‑Nummern-Fix
 
@@ -429,7 +429,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.8.3** - Fehlerkorrekturen & Versionslink oben
+**Version 3.8.4** - Fehlerkorrekturen & Versionslink oben
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -350,7 +350,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.8.3</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.8.4</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "devDependencies": {
         "jest": "^29.6.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "devDependencies": {
     "jest": "^29.6.1"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -446,7 +446,7 @@ function renderProjects() {
         header.style.background = getLevelColor(lvl);
         header.innerHTML = `
             <span class="level-title">${order}.${lvl}</span>
-            <button class="level-edit-btn" onclick="showLevelCustomization('${lvl}', event)">⚙️</button>
+            <button class="level-edit-btn" data-level="${lvl}" onclick="showLevelCustomization(this.dataset.level, event)">⚙️</button>
         `;
         header.onclick = (e) => {
             if (e.target.classList.contains('level-edit-btn')) return;
@@ -4763,7 +4763,7 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.8.3',
+                version: '3.8.4',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
@@ -7546,7 +7546,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.8.3 - Fehlerkorrekturen');
+        console.log('Version 3.8.4 - Fehlerkorrekturen');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');


### PR DESCRIPTION
## Summary
- behebe Fehler beim Speichern von Levelnamen
- Versionsnummer auf 3.8.4 bzw. 1.0.5 angehoben
- Versionsanzeige in HTML und Scripts angepasst

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a9cca4bd083279dbb4e6ee0b3936f