### PR TITLE
Fix Level-Projekte beim Umbenennen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.8.4-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.8.5-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.8.4](#-neue-features-in-384)
+* [✨ Neue Features in 3.8.5](#-neue-features-in-385)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [🏁 Erste Schritte](#-erste-schritte)
@@ -26,12 +26,13 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.8.4
+## ✨ Neue Features in 3.8.5
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Dialog-Fokus**           | Eingabefelder in Dialogen erhalten nun direkt den Cursor. |
 | **Versionsanzeige**        | Oben links zeigt ein Link die aktuelle Version und öffnet GitHub. |
+| **Automatische Projektumbenennung** | Beim Umbenennen eines Levels werden gleichnamige Projekte aktualisiert. |
 | **Level‑Management**       | Projekte besitzen jetzt **Level‑Namen** + **Teil‑Nummern**.<br>Alle vorhandenen Namen werden beim Anlegen/Umbenennen als Dropdown angeboten.                |
 | **Projekt‑Metaleiste**     | Über der Tabelle erscheint **Projekt • Level • Teil** + Ein‑Klick‑Button ⧉ zum Kopieren des Level‑Namens.                                                   |
 | **Globale Text‑Statistik** | Neue Kachel **EN / DE / BEIDE / ∑** in den globalen Statistiken + Live‑Update beim Tippen.                                                                  |
@@ -323,12 +324,13 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.8.4 (aktuell) - Fehlerkorrekturen
+### 3.8.5 (aktuell) - Fehlerkorrekturen
 
 **✨ Neue Features:**
 * **Dialog-Fokus**: Eingabefelder bekommen automatisch den Cursor (Projekt-, Level-, Ordner- und Import-Dialog).
 * **Versionsanzeige**: Oben links zeigt ein Link die aktuelle Version und öffnet GitHub.
 * **Fix**: Umbenannte Level speichern nun den Namen korrekt und behalten die eingestellte Reihenfolge.
+* **Neu**: Beim Umbenennen eines Levels werden passende Projektnamen automatisch angepasst.
 
 ### 3.7.1 - Level‑Nummern-Fix
 
@@ -429,7 +431,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.8.4** - Fehlerkorrekturen & Versionslink oben
+**Version 3.8.5** - Fehlerkorrekturen & Versionslink oben
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -350,7 +350,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.8.4</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.8.5</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -4763,7 +4763,7 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.8.4',
+                version: '3.8.5',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
@@ -7194,8 +7194,16 @@ function showLevelCustomization(levelName, ev) {
         const newOrder = Math.max(1, parseInt(pop.querySelector('#lvlOrder').value) || oldOrder);
         const newColor = pop.querySelector('#lvlColor').value;
 
+        // Anzeigenamen der Projekte, falls noch identisch mit dem Levelnamen, ebenfalls aktualisieren
+        const oldDisplayName = `${oldOrder}.${levelName}`;
+        const newDisplayName = `${newOrder}.${newName}`;
+
         projects.forEach(p => {
             if (p.levelName === levelName) {
+                // Nur anpassen, wenn der Projektname dem alten Levelnamen entspricht
+                if (p.name === levelName || p.name === oldDisplayName || p.name === `${oldOrder} ${levelName}`) {
+                    p.name = newDisplayName;
+                }
                 p.levelName = newName;
                 p.color = newColor;
             }
@@ -7546,7 +7554,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.8.4 - Fehlerkorrekturen');
+        console.log('Version 3.8.5 - Fehlerkorrekturen');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');

--- a/tests/levelRenameProjectName.test.js
+++ b/tests/levelRenameProjectName.test.js
@@ -1,0 +1,41 @@
+const { expect, test } = require('@jest/globals');
+
+let projects = [
+    { name: '5.Hallo', levelName: 'Hallo', levelPart: 1, color: '#fff' },
+    { name: '5.Hallo', levelName: 'Hallo', levelPart: 2, color: '#fff' },
+    { name: 'Anderes', levelName: 'Anderes', levelPart: 1, color: '#fff' }
+];
+
+let levelOrders = { 'Hallo': 5, 'Anderes': 1 };
+let levelColors = { 'Hallo': '#fff', 'Anderes': '#fff' };
+
+function setLevelOrder(levelName, order) {
+    levelOrders[levelName] = order;
+}
+
+function renameLevel(oldName, newName, newOrder, newColor) {
+    const oldOrder = levelOrders[oldName];
+    const oldDisplayName = `${oldOrder}.${oldName}`;
+    const newDisplayName = `${newOrder}.${newName}`;
+
+    projects.forEach(p => {
+        if (p.levelName === oldName) {
+            if (p.name === oldName || p.name === oldDisplayName || p.name === `${oldOrder} ${oldName}`) {
+                p.name = newDisplayName;
+            }
+            p.levelName = newName;
+            p.color = newColor;
+        }
+    });
+    if (levelColors[oldName] && oldName !== newName) delete levelColors[oldName];
+    if (levelOrders[oldName] && oldName !== newName) delete levelOrders[oldName];
+    levelColors[newName] = newColor;
+    setLevelOrder(newName, newOrder);
+}
+
+test('rename level updates project names', () => {
+    renameLevel('Hallo', 'Hallo2', 6, '#0f0');
+    expect(projects[0].name).toBe('6.Hallo2');
+    expect(projects[1].name).toBe('6.Hallo2');
+    expect(projects[2].name).toBe('Anderes');
+});


### PR DESCRIPTION
## Summary
- passe Projekte beim Umbenennen eines Levels an
- neue Tests zum automatischen Umbenennen der Projekte
- aktualisiere Version auf 3.8.5 und ergänze Dokumentation

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a9fc116fc83278a72055bc10341d4