### PR TITLE
Fix Levelfarbe beim Projektwechsel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.8.6-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.8.7-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.8.6](#-neue-features-in-386)
+* [✨ Neue Features in 3.8.7](#-neue-features-in-387)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [🏁 Erste Schritte](#-erste-schritte)
@@ -26,7 +26,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.8.6
+## ✨ Neue Features in 3.8.7
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -324,7 +324,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.8.6 (aktuell) - Fehlerkorrekturen
+### 3.8.7 (aktuell) - Fehlerkorrekturen
 
 **✨ Neue Features:**
 * **Dialog-Fokus**: Eingabefelder bekommen automatisch den Cursor (Projekt-, Level-, Ordner- und Import-Dialog).
@@ -332,6 +332,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 * **Fix**: Umbenannte Level speichern nun den Namen korrekt und behalten die eingestellte Reihenfolge.
 * **Neu**: Beim Umbenennen eines Levels werden passende Projektnamen automatisch angepasst.
 * **Fix**: Abgebrochene Projekte werden nicht mehr angelegt und fehlende Levelangaben melden einen Fehler.
+* **Projektverschiebung**: Beim Wechsel in einen anderen Level übernimmt das Projekt automatisch dessen Farbe.
 
 ### 3.7.1 - Level‑Nummern-Fix
 
@@ -432,7 +433,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.8.6** - Fehlerkorrekturen & Versionslink oben
+**Version 3.8.7** - Fehlerkorrekturen & Versionslink oben
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -350,7 +350,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.8.6</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.8.7</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -4756,7 +4756,7 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.8.6',
+                version: '3.8.7',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
@@ -7113,6 +7113,9 @@ function showProjectCustomization(id, ev, tempProject) {
         ordInp.style.display = show ? 'block' : 'none';
         if (show) {
             inp.focus();
+        } else {
+            // Beim Wechsel auf einen bestehenden Level dessen Farbe übernehmen
+            pop.querySelector('#cColor').value = getLevelColor(sel.value);
         }
     };
 
@@ -7573,7 +7576,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.8.6 - Fehlerkorrekturen');
+        console.log('Version 3.8.7 - Fehlerkorrekturen');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');


### PR DESCRIPTION
## Zusammenfassung
- Levelfarbe des Ziel-Levels wird beim Projektverschieben übernommen
- Versionsnummer auf 3.8.7 angehoben
- README mit neuem Feature und Version angepasst

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa40428a8832792225204d1b5c0b3