### PR TITLE
Icon-Handling vereinheitlicht

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.9.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.10.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.9.0](#-neue-features-in-390)
+* [✨ Neue Features in 3.10.0](#-neue-features-in-3100)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [🏁 Erste Schritte](#-erste-schritte)
@@ -26,7 +26,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.9.0
+## ✨ Neue Features in 3.10.0
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -326,17 +326,11 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.9.0 (aktuell) - Level-Icons
+### 3.10.0 (aktuell) - Gemeinsame Projekt-Icons
 
 **✨ Neue Features:**
-* **Dialog-Fokus**: Eingabefelder bekommen automatisch den Cursor (Projekt-, Level-, Ordner- und Import-Dialog).
-* **Versionsanzeige**: Oben links zeigt ein Link die aktuelle Version und öffnet GitHub.
-* **Fix**: Umbenannte Level speichern nun den Namen korrekt und behalten die eingestellte Reihenfolge.
-* **Neu**: Beim Umbenennen eines Levels werden passende Projektnamen automatisch angepasst.
-* **Level-Haken**: Level-Reiter erhalten einen grünen Haken, wenn alle Projekte abgeschlossen sind.
-* **Level-Icons**: Icons je Level können jetzt angepasst werden.
-* **Fix**: Abgebrochene Projekte werden nicht mehr angelegt und fehlende Levelangaben melden einen Fehler.
-* **Projektverschiebung**: Beim Wechsel in einen anderen Level übernimmt das Projekt automatisch dessen Farbe.
+* **Gemeinsame Icons**: Projekte eines Levels verwenden automatisch das Icon des Levels.
+* **Haken-Layout**: Der grüne Fertig-Haken verdeckt das Icon nicht mehr.
 
 ### 3.7.1 - Level‑Nummern-Fix
 
@@ -437,7 +431,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.9.0** - Level-Icons & Versionslink oben
+**Version 3.10.0** - Gemeinsame Projekt-Icons
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -350,7 +350,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.9.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.10.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -355,7 +355,8 @@ function loadProjects() {
 
         let migrated = false;
         projects.forEach(p => {
-            if (!p.hasOwnProperty('icon'))  { p.icon  = '🗂️'; migrated = true; }
+            // Alte Icon-Felder entfernen, Projekte erben nun das Level-Icon
+            if (p.hasOwnProperty('icon')) { delete p.icon; migrated = true; }
             if (!p.hasOwnProperty('color')) { p.color = '#333333'; migrated = true; }
             if (!p.hasOwnProperty('levelName')) { p.levelName = ''; migrated = true; }
             if (!p.hasOwnProperty('levelPart')) { p.levelPart = 1;  migrated = true; }
@@ -377,7 +378,6 @@ function loadProjects() {
             levelName: '',
             levelPart: 1,
             files: [],
-            icon: '🎮',
             color: '#ff6b1a'
         }];
         saveProjects();
@@ -522,7 +522,7 @@ function renderProjects() {
                 ${badge}
                 ${doneMark}
                 <div style="display:flex;gap:8px;align-items:flex-start;">
-                    <span style="font-size:16px;">${p.icon || '🗂️'}</span>
+                    <span style="font-size:16px;">${getLevelIcon(p.levelName)}</span>
                     <div style="flex:1;min-width:0;">
                         <div style="font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
                             ${p.name}
@@ -4807,7 +4807,7 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.9.0',
+                version: '3.10.0',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
@@ -5040,8 +5040,9 @@ function checkFileAccess() {
 
             let migrationNeeded = false;
             projects.forEach(project => {
-                if (!project.hasOwnProperty('icon')) {
-                    project.icon = '🗂️';
+                // Icon-Felder aus alten Backups entfernen
+                if (project.hasOwnProperty('icon')) {
+                    delete project.icon;
                     migrationNeeded = true;
                 }
                 if (!project.hasOwnProperty('color')) {
@@ -7315,15 +7316,9 @@ function showLevelCustomization(levelName, ev) {
 
 
         function updateProjectCustomizationPreview() {
-            const iconInput = document.getElementById('customProjectIcon');
             const colorInput = document.getElementById('customProjectColor');
-            const iconPreview = document.getElementById('projectIconPreview');
             const colorPreview = document.getElementById('projectColorPreview');
-            
-            if (iconInput && iconPreview) {
-                iconPreview.textContent = iconInput.value || '🗂️';
-            }
-            
+
             if (colorInput && colorPreview) {
                 colorPreview.style.background = colorInput.value;
             }
@@ -7333,7 +7328,6 @@ function showLevelCustomization(levelName, ev) {
 
         function applyProjectPreset(projectId) {
             const presetSelect = document.getElementById('projectPresetSelect');
-            const iconInput = document.getElementById('customProjectIcon');
             const colorInput = document.getElementById('customProjectColor');
             
             const presets = {
@@ -7350,19 +7344,16 @@ function showLevelCustomization(levelName, ev) {
             
             const preset = presets[presetSelect.value];
             if (preset) {
-                iconInput.value = preset.icon;
                 colorInput.value = preset.color;
                 updateProjectCustomizationPreview();
             }
         }
 
         function saveProjectCustomization(projectId) {
-            const iconInput = document.getElementById('customProjectIcon');
             const colorInput = document.getElementById('customProjectColor');
-            
+
             const project = projects.find(p => p.id === projectId);
             if (project) {
-                project.icon = iconInput.value || '🗂️';
                 project.color = colorInput.value || '#333333';
                 
                 saveProjects();
@@ -7382,7 +7373,6 @@ function showLevelCustomization(levelName, ev) {
             if (confirm('Möchten Sie die Anpassungen für dieses Projekt wirklich zurücksetzen?')) {
                 const project = projects.find(p => p.id === projectId);
                 if (project) {
-                    project.icon = '🗂️';
                     project.color = '#333333';
                     
                     saveProjects();
@@ -7637,7 +7627,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.9.0 - Level-Icons');
+        console.log('Version 3.10.0 - Gemeinsame Projekt-Icons');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');

--- a/src/style.css
+++ b/src/style.css
@@ -1690,7 +1690,7 @@ th:nth-child(6) {
 .project-done-marker{
     position:absolute;
     top:6px;
-    left:10px;
+    left:36px; /* nicht mehr über dem Icon */
     font-size:18px;
     color:#4caf50;
     pointer-events:none;


### PR DESCRIPTION
## Zusammenfassung
- Projekte erben nun das Level-Icon
- Position des Fertig-Hakens angepasst, damit das Icon sichtbar bleibt
- Versionsnummer auf 3.10.0 erhöht und Dokumentation aktualisiert

## Testing
- `npm test` *(schlug fehl: jest nicht gefunden)*

------
https://chatgpt.com/codex/tasks/task_e_684aa97a85dc8327ad2c89535465e95a