### PR TITLE
Add ElevenLabs API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.11.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.12.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.11.0](#-neue-features-in-3110)
+* [✨ Neue Features in 3.12.0](#-neue-features-in-3120)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [🏁 Erste Schritte](#-erste-schritte)
@@ -26,7 +26,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.11.0
+## ✨ Neue Features in 3.12.0
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -52,6 +52,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 | **Level-Haken**            | Level-Reiter zeigen einen grünen Haken, wenn alle Projekte darin 100% abgeschlossen sind. |
 | **Level-Icons**            | Jedes Level besitzt ein eigenes Icon, einstellbar im Level-Dialog. |
 | **Icon-Auswahl**           | Neben freier Eingabe kann man nun aus vordefinierten Icons wählen. |
+| **ElevenLabs-Dubbing**     | Erste Anbindung an die ElevenLabs-API zum automatischen Vertonen. |
 ---
 
 ## 🚀 Features (komplett)
@@ -327,7 +328,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.11.0 (aktuell) - Icon-Auswahl & Haken-Fix
+### 3.12.0 (aktuell) - ElevenLabs-Anbindung
+
+**✨ Neue Features:**
+* **ElevenLabs-Dubbing**: Audiodateien lassen sich jetzt direkt per API vertonen.
+
+### 3.11.0 - Icon-Auswahl & Haken-Fix
 
 **✨ Neue Features:**
 * **Icon-Auswahl**: Im Level-Dialog steht nun eine Liste gängiger Icons zur Verfügung.
@@ -438,7 +444,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.11.0** - Icon-Auswahl & Haken-Fix
+**Version 3.12.0** - ElevenLabs-Anbindung
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/elevenlabs.js
+++ b/elevenlabs.js
@@ -1,0 +1,80 @@
+const fs = require('fs');
+
+// =========================== CREATEDUBBING START ===========================
+/**
+ * Startet einen Dubbing-Auftrag bei ElevenLabs und gibt die Antwort zurueck.
+ * @param {string} apiKey - Eigener API-Schluessel.
+ * @param {string} audioPath - Pfad zur englischen Audiodatei.
+ * @param {string} [targetLang='de'] - Ziel-Sprache fuer das Dubbing.
+ * @returns {Promise<object>} Antwort der API als Objekt.
+ */
+async function createDubbing(apiKey, audioPath, targetLang = 'de') {
+    if (!fs.existsSync(audioPath)) {
+        throw new Error('Audio-Datei nicht gefunden: ' + audioPath);
+    }
+
+    const form = new FormData();
+    form.append('file', fs.createReadStream(audioPath));
+    form.append('target_lang', targetLang);
+
+    const response = await fetch('https://api.elevenlabs.io/v1/dubbing', {
+        method: 'POST',
+        headers: { 'xi-api-key': apiKey },
+        body: form
+    });
+
+    if (!response.ok) {
+        throw new Error('Fehler beim Dubbing: ' + await response.text());
+    }
+    return await response.json();
+}
+// =========================== CREATEDUBBING END =============================
+
+// =========================== GETDUBBINGSTATUS START =======================
+/**
+ * Fragt den aktuellen Status eines Dubbings ab.
+ * @param {string} apiKey - Eigener API-Schluessel.
+ * @param {string} dubbingId - Die von createDubbing erhaltene ID.
+ * @returns {Promise<object>} Status-Objekt der API.
+ */
+async function getDubbingStatus(apiKey, dubbingId) {
+    const response = await fetch(`https://api.elevenlabs.io/v1/dubbing/${dubbingId}`, {
+        headers: { 'xi-api-key': apiKey }
+    });
+
+    if (!response.ok) {
+        throw new Error('Status-Abfrage fehlgeschlagen: ' + await response.text());
+    }
+    return await response.json();
+}
+// =========================== GETDUBBINGSTATUS END =========================
+
+// =========================== DOWNLOADDUBBING START ========================
+/**
+ * Laedt die fertige Dub-Datei herunter und speichert sie lokal.
+ * @param {string} apiKey - Eigener API-Schluessel.
+ * @param {string} dubbingId - ID des Dubbings.
+ * @param {string} [lang='de'] - Sprache der gewuenschten Datei.
+ * @param {string} targetPath - Dateipfad fuer die gespeicherte Ausgabe.
+ * @returns {Promise<string>} Pfad zur gespeicherten Datei.
+ */
+async function downloadDubbingAudio(apiKey, dubbingId, lang = 'de', targetPath) {
+    const response = await fetch(`https://api.elevenlabs.io/v1/dubbing/${dubbingId}/audio/${lang}`, {
+        headers: { 'xi-api-key': apiKey }
+    });
+
+    if (!response.ok) {
+        throw new Error('Download fehlgeschlagen: ' + await response.text());
+    }
+
+    const buffer = await response.arrayBuffer();
+    fs.writeFileSync(targetPath, Buffer.from(buffer));
+    return targetPath;
+}
+// =========================== DOWNLOADDUBBING END ==========================
+
+module.exports = {
+    createDubbing,
+    getDubbingStatus,
+    downloadDubbingAudio
+};

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -350,7 +350,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.11.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.12.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "devDependencies": {
         "jest": "^29.6.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "devDependencies": {
     "jest": "^29.6.1"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -4810,7 +4810,7 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.11.0',
+                version: '3.12.0',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
@@ -7646,7 +7646,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.11.0 - Icon-Auswahl & Haken-Fix');
+        console.log('Version 3.12.0 - ElevenLabs-Anbindung');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');


### PR DESCRIPTION
## Summary
- add Node helper to access ElevenLabs Dubbing API
- bump version to 3.12.0 / 1.2.0
- document ElevenLabs feature in README
- update displayed version in app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab77926048327b3f622af2a950ba2