### PR TITLE
Update ElevenLabs usage info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.12.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.12.1-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,9 +12,10 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.12.0](#-neue-features-in-3120)
+* [✨ Neue Features in 3.12.1](#-neue-features-in-3121)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
+* [ElevenLabs-Dubbing](#elevenlabs-dubbing)
 * [🏁 Erste Schritte](#-erste-schritte)
 * [🎮 Bedienung](#-bedienung)
 * [⌨️ Keyboard Shortcuts](#-keyboard-shortcuts)
@@ -26,7 +27,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.12.0
+## ✨ Neue Features in 3.12.1
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -118,8 +119,9 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 * **Moderner Browser:** Chrome, Firefox, Edge, Safari
 * **JavaScript aktiviert**
-* **Lokaler Dateizugriff** für Audio‑Wiedergabe 
+* **Lokaler Dateizugriff** für Audio‑Wiedergabe
 * **Empfohlener Speicher:** 2+ GB freier RAM für große Projekte
+* **Node.js ≥18** für ElevenLabs-Dubbing (benötigt `fetch` und `FormData`)
 
 ### Desktop-Version (Electron)
 1. In das Verzeichnis `electron/` wechseln und `npm install` ausführen. Fehlt npm (z.B. bei Node 22), `npm install -g npm` oder `corepack enable` nutzen
@@ -130,6 +132,20 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 5. Kopieren Sie Ihre Originaldateien in `sounds/EN` und legen Sie Übersetzungen in `sounds/DE` ab
 6. Während des Setups erzeugen alle Skripte (`start_tool.bat`, `start_tool.js` und `start_tool.py`) die Logdatei `setup.log`, in der alle Schritte gespeichert werden
 7. Die Skripte verwerfen lokale Änderungen, **ohne** den Ordner `sounds` anzutasten – Projektdaten bleiben somit erhalten
+
+### ElevenLabs-Dubbing
+
+1. API-Schlüssel bei [ElevenLabs](https://elevenlabs.io) erstellen.
+2. Den Schlüssel als Umgebungsvariable `ELEVEN_API_KEY` setzen oder beim Aufruf der Funktionen eingeben.
+3. Beispielhafte Nutzung:
+
+```javascript
+const { createDubbing, getDubbingStatus, downloadDubbingAudio } = require('./elevenlabs.js');
+const apiKey = process.env.ELEVEN_API_KEY;
+const job = await createDubbing(apiKey, 'sounds/EN/beispiel.wav');
+const status = await getDubbingStatus(apiKey, job.dubbing_id);
+await downloadDubbingAudio(apiKey, job.dubbing_id, 'de', 'sounds/DE/beispiel_de.mp3');
+```
 
 ---
 
@@ -328,7 +344,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.12.0 (aktuell) - ElevenLabs-Anbindung
+### 3.12.1 (aktuell) - ElevenLabs-Anbindung
 
 **✨ Neue Features:**
 * **ElevenLabs-Dubbing**: Audiodateien lassen sich jetzt direkt per API vertonen.
@@ -444,7 +460,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.12.0** - ElevenLabs-Anbindung
+**Version 3.12.1** - ElevenLabs-Anbindung
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -350,7 +350,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.12.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.12.1</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "devDependencies": {
         "jest": "^29.6.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "devDependencies": {
     "jest": "^29.6.1"
   },

--- a/src/main.js
+++ b/src/main.js
@@ -4810,7 +4810,7 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.12.0',
+                version: '3.12.1',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
@@ -7646,7 +7646,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.12.0 - ElevenLabs-Anbindung');
+        console.log('Version 3.12.1 - ElevenLabs-Anbindung');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');


### PR DESCRIPTION
## Summary
- describe how to set up and use the ElevenLabs API
- require Node 18 for fetch and FormData
- bump version to 3.12.1

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab9d724148327a30a689b018bdfdd