### PR TITLE
Verbesserte Voice-ID Zuordnung

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.12.3-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.13.1-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.12.3](#-neue-features-in-3123)
+* [✨ Neue Features in 3.13.1](#-neue-features-in-3131)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [ElevenLabs-Dubbing](#elevenlabs-dubbing)
@@ -27,7 +27,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.12.3
+## ✨ Neue Features in 3.13.1
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -54,6 +54,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 | **Level-Icons**            | Jedes Level besitzt ein eigenes Icon, einstellbar im Level-Dialog. |
 | **Icon-Auswahl**           | Neben freier Eingabe kann man nun aus vordefinierten Icons wählen. |
 | **ElevenLabs-Dubbing**     | Erste Anbindung an die ElevenLabs-API zum automatischen Vertonen. |
+| **API-Menü**               | Neues Menü zur Eingabe des API-Keys und Zuweisung von Voice-IDs je Ordner. Voice-IDs gelten projektübergreifend. |
 ---
 
 ## 🚀 Features (komplett)
@@ -344,10 +345,11 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.12.3 (aktuell) - ElevenLabs-Anbindung
+### 3.13.1 (aktuell) - API-Menü erweitert
 
 **✨ Neue Features:**
 * **ElevenLabs-Dubbing**: Audiodateien lassen sich jetzt direkt per API vertonen.
+* **API-Menü**: API-Key eingeben und Stimmen projektübergreifend hinterlegen.
 
 ### 3.11.0 - Icon-Auswahl & Haken-Fix
 
@@ -460,7 +462,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.12.3** - ElevenLabs-Anbindung
+**Version 3.13.1** - API-Menü erweitert
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -41,6 +41,7 @@
                     <div class="settings-menu" id="settingsMenu">
                         <div class="settings-item" onclick="cleanupDuplicates()">🧹 Duplikate bereinigen</div>
                         <div class="settings-item" onclick="showBackupDialog()">💾 Backup</div>
+                        <div class="settings-item" onclick="showApiDialog()">🔊 ElevenLabs API</div>
                         <div class="settings-item" onclick="resetFileDatabase()">🔄 Reset DB</div>
                         <div class="settings-item" onclick="updateAllFilePaths()">🔄 Projekte bereinigen</div>
                         <div class="settings-item" onclick="repairProjectFolders()">🔧 Ordner reparieren</div>
@@ -290,6 +291,23 @@
         </div>
     </div>
 
+    <!-- ElevenLabs API Dialog -->
+    <div class="dialog-overlay" id="apiDialog">
+        <div class="dialog">
+<button class="dialog-close-btn" onclick="closeApiDialog()">×</button>
+            <h3>🔊 ElevenLabs API</h3>
+            <div class="customize-field">
+                <label>API-Key:</label>
+                <input type="password" id="apiKeyInput" style="width:80%;">
+            </div>
+            <div id="voiceIdList" style="margin-top:15px;"></div>
+            <div class="dialog-buttons">
+                <button class="btn btn-secondary" onclick="closeApiDialog()">Abbrechen</button>
+                <button class="btn btn-success" onclick="saveApiSettings()">Speichern</button>
+            </div>
+        </div>
+    </div>
+
     <!-- History Dialog -->
     <div class="dialog-overlay" id="historyDialog">
         <div class="dialog">
@@ -350,7 +368,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.12.3</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.13.1</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.2.3",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.2.3",
+    "version": "1.3.1",
       "devDependencies": {
         "jest": "^29.6.1",
         "nock": "^14.0.5"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.2.3",
+  "version": "1.3.1",
   "devDependencies": {
     "jest": "^29.6.1",
     "nock": "^14.0.5"


### PR DESCRIPTION
## Summary
- erweitere API-Menü um alle bekannten Ordner aus der Pfaddatenbank
- Voice-IDs gelten nun projektübergreifend
- Versionsnummer auf 3.13.1 angehoben

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab8e49fdc8327892e26a06735d7df