### PR TITLE
Neues API-Menü mit Stimmgruppen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.13.1-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.14.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.13.1](#-neue-features-in-3131)
+* [✨ Neue Features in 3.14.0](#-neue-features-in-3140)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [ElevenLabs-Dubbing](#elevenlabs-dubbing)
@@ -27,7 +27,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.13.1
+## ✨ Neue Features in 3.14.0
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -346,7 +346,14 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.13.1 (aktuell) - Ordnerübergreifende Voice-IDs
+### 3.14.0 (aktuell) - Überarbeitetes API-Menü
+
+**✨ Neue Features:**
+* Gruppierte Stimmenzuordnung mit aufklappbaren Bereichen.
+* Dropdown-Auswahl samt Hörprobe für jede Stimme.
+* Button zum Zurücksetzen aller Zuordnungen und zum Testen des API-Keys.
+
+### 3.13.1 - Ordnerübergreifende Voice-IDs
 
 **✨ Neue Features:**
 * API-Dialog listet jetzt alle Ordner aus der Datenbank.
@@ -468,7 +475,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.13.1** - Ordnerübergreifende Voice-IDs
+**Version 3.14.0** - Überarbeitetes API-Menü
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -298,10 +298,15 @@
             <h3>🔊 ElevenLabs API</h3>
             <div class="customize-field">
                 <label>API-Key:</label>
-                <input type="password" id="apiKeyInput" style="width:80%;">
+                <div style="display:flex; gap:5px; align-items:center;">
+                    <input type="password" id="apiKeyInput" style="flex:1;">
+                    <button class="btn" onclick="toggleApiKeyVisibility()">👁</button>
+                </div>
             </div>
             <div id="voiceIdList" style="margin-top:15px;"></div>
             <div class="dialog-buttons">
+                <button class="btn btn-secondary" onclick="testVoiceIds()">Voice-IDs testen</button>
+                <button class="btn btn-secondary" onclick="resetAllVoiceIds()">Alle zurücksetzen</button>
                 <button class="btn btn-secondary" onclick="closeApiDialog()">Abbrechen</button>
                 <button class="btn btn-success" onclick="saveApiSettings()">Speichern</button>
             </div>
@@ -368,7 +373,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.13.1</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.14.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "devDependencies": {
         "jest": "^29.6.1",
         "nock": "^14.0.5"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "devDependencies": {
     "jest": "^29.6.1",
     "nock": "^14.0.5"

--- a/src/main.js
+++ b/src/main.js
@@ -48,6 +48,8 @@ let autoBackupTimer    = null;
 
 // API-Key für ElevenLabs und hinterlegte Stimmen pro Ordner
 let elevenLabsApiKey   = localStorage.getItem('hla_elevenLabsApiKey') || '';
+// Liste aller verfügbaren Stimmen (wird beim Öffnen des API-Dialogs geladen)
+let availableVoices    = [];
 
 // === Stacks für Undo/Redo ===
 let undoStack          = [];
@@ -4823,7 +4825,7 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.13.1',
+                version: '3.14.0',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
@@ -4928,12 +4930,14 @@ function checkFileAccess() {
         }
 
         // =========================== SHOWAPIDIALOG START ======================
-        function showApiDialog() {
+        async function showApiDialog() {
             document.getElementById('apiDialog').style.display = 'flex';
             document.getElementById('apiKeyInput').value = elevenLabsApiKey;
 
             const list = document.getElementById('voiceIdList');
             list.innerHTML = '';
+
+            await loadVoiceList();
 
             // Alle bekannten Ordner sammeln – projektübergreifend
             const folderSet = new Set();
@@ -4943,14 +4947,73 @@ function checkFileAccess() {
             Object.keys(folderCustomizations).forEach(f => folderSet.add(f));
             const folders = Array.from(folderSet).sort();
 
+            const groups = {
+                combine: { title: 'Combine', items: [] },
+                vortigaunts: { title: 'Vortigaunts', items: [] },
+                zivilisten: { title: 'Zivilisten', items: [] },
+                sonstige: { title: 'Sonstige', items: [] }
+            };
+
             folders.forEach(name => {
-                const cust = folderCustomizations[name] || {};
-                const id = cust.voiceId || '';
-                const row = document.createElement('div');
-                row.className = 'voice-id-item';
-                row.innerHTML = `<label>${escapeHtml(name)}<input data-folder="${escapeHtml(name)}" value="${id}" placeholder="voice_id"></label>`;
-                list.appendChild(row);
+                const lower = name.toLowerCase();
+                let key = 'sonstige';
+                if (lower.includes('combine')) key = 'combine';
+                else if (lower.includes('vort')) key = 'vortigaunts';
+                else if (lower.includes('citizen')) key = 'zivilisten';
+                groups[key].items.push(name);
             });
+
+            Object.values(groups).forEach(group => {
+                if (group.items.length === 0) return;
+                const wrapper = document.createElement('div');
+                wrapper.className = 'voice-group';
+                const header = document.createElement('div');
+                header.className = 'voice-group-header';
+                header.textContent = group.title;
+                wrapper.appendChild(header);
+                const content = document.createElement('div');
+                content.className = 'voice-group-content';
+                const grid = document.createElement('div');
+                grid.className = 'voice-id-grid';
+                group.items.forEach(name => {
+                    const cust = folderCustomizations[name] || {};
+                    const id = cust.voiceId || '';
+                    const item = document.createElement('div');
+                    item.className = 'voice-id-item';
+
+                    const label = document.createElement('label');
+                    label.textContent = name;
+                    label.title = `Diese Stimme wird für ${name} verwendet`;
+
+                    const select = document.createElement('select');
+                    select.dataset.folder = name;
+                    const emptyOpt = document.createElement('option');
+                    emptyOpt.value = '';
+                    emptyOpt.textContent = '--';
+                    select.appendChild(emptyOpt);
+                    availableVoices.forEach(v => {
+                        const opt = document.createElement('option');
+                        opt.value = v.voice_id;
+                        opt.textContent = v.name;
+                        if (v.voice_id === id) opt.selected = true;
+                        select.appendChild(opt);
+                    });
+
+                    const play = document.createElement('button');
+                    play.textContent = '▶';
+                    play.onclick = () => playVoicePreview(select.value);
+
+                    item.appendChild(label);
+                    item.appendChild(select);
+                    item.appendChild(play);
+                    grid.appendChild(item);
+                });
+                content.appendChild(grid);
+                wrapper.appendChild(content);
+                header.onclick = () => wrapper.classList.toggle('open');
+                list.appendChild(wrapper);
+            });
+
             document.getElementById('apiKeyInput').focus();
         }
 
@@ -4958,9 +5021,9 @@ function checkFileAccess() {
             elevenLabsApiKey = document.getElementById('apiKeyInput').value.trim();
             localStorage.setItem('hla_elevenLabsApiKey', elevenLabsApiKey);
 
-            document.querySelectorAll('#voiceIdList input').forEach(inp => {
-                const folder = inp.dataset.folder;
-                const val = inp.value.trim();
+            document.querySelectorAll('#voiceIdList select').forEach(sel => {
+                const folder = sel.dataset.folder;
+                const val = sel.value.trim();
                 if (!folderCustomizations[folder]) folderCustomizations[folder] = {};
                 if (val) {
                     folderCustomizations[folder].voiceId = val;
@@ -4975,6 +5038,51 @@ function checkFileAccess() {
 
         function closeApiDialog() {
             document.getElementById('apiDialog').style.display = 'none';
+        }
+
+        async function loadVoiceList() {
+            if (!elevenLabsApiKey) return;
+            try {
+                const res = await fetch('https://api.elevenlabs.io/v1/voices', {
+                    headers: { 'xi-api-key': elevenLabsApiKey }
+                });
+                if (!res.ok) throw new Error();
+                const data = await res.json();
+                availableVoices = data.voices || [];
+                document.getElementById('apiKeyInput').classList.add('valid');
+                document.getElementById('apiKeyInput').classList.remove('invalid');
+            } catch (e) {
+                availableVoices = [];
+                document.getElementById('apiKeyInput').classList.remove('valid');
+                document.getElementById('apiKeyInput').classList.add('invalid');
+            }
+        }
+
+        function playVoicePreview(id) {
+            const voice = availableVoices.find(v => v.voice_id === id);
+            if (voice && voice.preview_url) {
+                const audio = new Audio(voice.preview_url);
+                audio.play();
+            }
+        }
+
+        function resetAllVoiceIds() {
+            document.querySelectorAll('#voiceIdList select').forEach(sel => sel.value = '');
+            Object.keys(folderCustomizations).forEach(f => {
+                if (folderCustomizations[f]) delete folderCustomizations[f].voiceId;
+            });
+        }
+
+        function toggleApiKeyVisibility() {
+            const inp = document.getElementById('apiKeyInput');
+            inp.type = inp.type === 'password' ? 'text' : 'password';
+        }
+
+        function testVoiceIds() {
+            loadVoiceList().then(() => {
+                if (availableVoices.length > 0) updateStatus('API-Key gültig');
+                else updateStatus('Fehler beim Abrufen der Stimmen');
+            });
         }
         // =========================== SHOWAPIDIALOG END ========================
 
@@ -7710,7 +7818,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.13.1 - Ordnerübergreifende Voice-IDs');
+        console.log('Version 3.14.0 - Überarbeitetes API-Menü');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');

--- a/src/style.css
+++ b/src/style.css
@@ -1953,4 +1953,16 @@ th:nth-child(6) {
 
 #versionLink:hover { color: #ff6b1a; }
 
+/* ===== API-Dialog-Stile ===== */
+.voice-group { margin-bottom: 10px; }
+.voice-group-header { background:#333; padding:5px; cursor:pointer; border-radius:4px; }
+.voice-group-content { display:none; margin-top:5px; }
+.voice-group.open .voice-group-content { display:block; }
+.voice-id-grid { display:grid; grid-template-columns: 1fr 1fr; gap:10px; }
+.voice-id-item { display:flex; flex-direction:column; gap:4px; background:#1a1a1a; padding:5px; border-radius:4px; }
+.voice-id-item label { font-size:12px; color:#ccc; }
+.voice-id-item select { width:100%; }
+.valid { border-color:#4caf50; }
+.invalid { border-color:#f44336; }
+
 		


### PR DESCRIPTION
## Zusammenfassung
- verbessertes API-Menü mit ausklappbaren Kategorien
- Stimmenauswahl nun per Dropdown inkl. Vorschau
- Buttons zum Testen des API-Keys und zum Zurücksetzen aller Zuordnungen
- neue Styles für das Menü
- Versionsnummer auf 3.14.0 / 1.4.0 angehoben

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ac42bb0608327aeb0480d6741227d