### PR TITLE
Backup speichert neue Einstellungen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.13.1-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.13.2-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.13.1](#-neue-features-in-3131)
+* [✨ Neue Features in 3.13.2](#-neue-features-in-3132)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [ElevenLabs-Dubbing](#elevenlabs-dubbing)
@@ -27,7 +27,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.13.1
+## ✨ Neue Features in 3.13.2
 
 |  Kategorie                 |  Beschreibung                                                                                                                                               |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -56,6 +56,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 | **ElevenLabs-Dubbing**     | Erste Anbindung an die ElevenLabs-API zum automatischen Vertonen. |
 | **API-Menü**               | Neues Menü zur Eingabe des API-Keys und Zuweisung von Voice-IDs je Ordner. |
 | **Ordnerübergreifende Voice-IDs** | Voice-IDs gelten jetzt in allen Projekten und werden im API-Dialog für alle Ordner angezeigt. |
+| **Backup-Verbesserung** | Alle Einstellungen wie Level-Farben und Auto-Backup werden nun mitgesichert. |
 ---
 
 ## 🚀 Features (komplett)
@@ -346,7 +347,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.13.1 (aktuell) - Ordnerübergreifende Voice-IDs
+### 3.13.2 (aktuell) - Verbesserte Backup-Funktion
+
+**✨ Neue Features:**
+* Backups enthalten nun Level-Farben, Reihenfolgen, Icons, ignorierte Dateien, Auto-Backup-Einstellungen und den API-Key.
+
+### 3.13.1 - Ordnerübergreifende Voice-IDs
 
 **✨ Neue Features:**
 * API-Dialog listet jetzt alle Ordner aus der Datenbank.
@@ -468,7 +474,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.13.1** - Ordnerübergreifende Voice-IDs
+**Version 3.13.2** - Verbesserte Backup-Funktion
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -368,7 +368,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.13.1</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.13.2</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -4823,12 +4823,19 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.13.1',
+                version: '3.13.2',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
                 filePathDatabase: filePathDatabase,
                 folderCustomizations: folderCustomizations,
+                levelColors: levelColors,
+                levelOrders: levelOrders,
+                levelIcons: levelIcons,
+                autoBackupInterval: autoBackupInterval,
+                autoBackupLimit: autoBackupLimit,
+                ignoredFiles: ignoredFiles,
+                elevenLabsApiKey: elevenLabsApiKey,
                 currentProjectId: currentProject?.id
             };
 
@@ -5104,6 +5111,13 @@ function checkFileAccess() {
             textDatabase = backup.textDatabase || {};
             filePathDatabase = backup.filePathDatabase || {};
             folderCustomizations = backup.folderCustomizations || {};
+            levelColors = backup.levelColors || {};
+            levelOrders = backup.levelOrders || {};
+            levelIcons = backup.levelIcons || {};
+            autoBackupInterval = backup.autoBackupInterval || autoBackupInterval;
+            autoBackupLimit = backup.autoBackupLimit || autoBackupLimit;
+            ignoredFiles = backup.ignoredFiles || {};
+            elevenLabsApiKey = backup.elevenLabsApiKey || elevenLabsApiKey;
 
             let migrationNeeded = false;
             projects.forEach(project => {
@@ -5125,6 +5139,14 @@ function checkFileAccess() {
             saveTextDatabase();
             saveFilePathDatabase();
             saveFolderCustomizations();
+            saveLevelColors();
+            saveLevelOrders();
+            saveLevelIcons();
+            saveIgnoredFiles();
+            localStorage.setItem('hla_elevenLabsApiKey', elevenLabsApiKey);
+            localStorage.setItem('hla_autoBackupInterval', autoBackupInterval);
+            localStorage.setItem('hla_autoBackupLimit', autoBackupLimit);
+            startAutoBackup();
 
             renderProjects();
 
@@ -7710,7 +7732,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.13.1 - Ordnerübergreifende Voice-IDs');
+        console.log('Version 3.13.2 - Verbesserte Backup-Funktion');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');


### PR DESCRIPTION
## Zusammenfassung
- Sicherung erweitert um Level-Farben, Reihenfolge, Icons, ignorierte Dateien, Auto-Backup-Werte und API-Key
- Wiederherstellung übernimmt diese Werte und startet Auto-Backup neu
- Versionsnummer auf 3.13.2 angehoben
- README und HTML mit neuer Version und Feature-Hinweis

## Testanweisungen
- `npm test` ausführen (Jest fehlt derzeit)


------
https://chatgpt.com/codex/tasks/task_e_684ac5f927a483278f7500b0fffd7197