### PR TITLE
Add manual voice ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.14.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.15.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.14.0](#-neue-features-in-3140)
+* [✨ Neue Features in 3.15.0](#-neue-features-in-3150)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [ElevenLabs-Dubbing](#elevenlabs-dubbing)
@@ -27,7 +27,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.14.0
+## ✨ Neue Features in 3.15.0
 
 |  Kategorie                 |  Beschreibung
 | -------------------------- | ------------------------------------------------- |
@@ -35,6 +35,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 | **Alle zurücksetzen**   | Ein Klick leert sämtliche Voice-IDs. |
 | **Voice-IDs testen**    | Prüft alle gewählten Stimmen auf Erreichbarkeit. |
 | **Sichtbarer API-Key**  | Augen-Button zeigt/versteckt den eingegebenen Schlüssel. |
+| **Eigene IDs**          | Neue Voice-IDs können manuell hinzugefügt werden. |
 ---
 
 ## 🚀 Features (komplett)
@@ -325,7 +326,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.14.0 (aktuell) - Überarbeitetes API-Menü
+### 3.15.0 (aktuell) - Überarbeitetes API-Menü
 
 **✨ Neue Features:**
 * Gruppierte Voice-IDs, Dropdown-Auswahl und Key-Prüfung.
@@ -462,7 +463,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.14.0** - Überarbeitetes API-Menü
+**Version 3.15.0** - Überarbeitetes API-Menü
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -306,6 +306,7 @@
             <div class="dialog-buttons">
                 <button class="btn" onclick="testVoiceIds()">Voice-IDs testen</button>
                 <button class="btn" onclick="clearAllVoiceIds()">Alle zurücksetzen</button>
+                <button class="btn" onclick="addCustomVoice()">Neue Stimme</button>
                 <button class="btn btn-secondary" onclick="closeApiDialog()">Abbrechen</button>
                 <button class="btn btn-success" onclick="saveApiSettings()">Speichern</button>
             </div>
@@ -372,7 +373,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.14.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.15.0</a>
 
     <script src="src/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- allow adding custom ElevenLabs voices
- store custom voice IDs locally and mix them with fetched voices
- adjust API dialog with a button to add new voices
- bump version to 3.15.0

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684acd871cbc83279f5e8c8babbddd87