### PR TITLE
Add Ordner-Debug Funktion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.18.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.19.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.18.0](#-neue-features-in-3180)
+* [✨ Neue Features in 3.19.0](#-neue-features-in-3190)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [ElevenLabs-Dubbing](#elevenlabs-dubbing)
@@ -27,7 +27,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.18.0
+## ✨ Neue Features in 3.19.0
 
 |  Kategorie                 |  Beschreibung
 | -------------------------- | ------------------------------------------------- |
@@ -40,6 +40,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 | **Fortschrittsanzeige** | Projektübergreifender Fortschritt mit Farbkennzeichnung im Dashboard. |
 | **Stimmenverwaltung**  | Benutzerdefinierte IDs umbenennen, löschen und Name abrufen. |
 | **CSP-Fix**          | API-Tests im Browser funktionieren jetzt dank angepasster Content Security Policy. |
+| **Ordner-Debug**     | Zeigt alle Ordner aus der Datenbank und löscht nicht mehr existente Einträge. |
 ---
 
 ## 🚀 Features (komplett)
@@ -330,13 +331,14 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.18.0 (aktuell) - Stimmenverwaltung
+### 3.19.0 (aktuell) - Ordner-Debug
 
 **✨ Neue Features:**
 * Benutzerdefinierte Stimmen lassen sich jetzt bearbeiten und löschen.
 * Voice-Namen können per API abgerufen werden.
 * Test-Button für den API-Key mit grüner Erfolgsanzeige.
 * Fehler beim "Neue Stimme"-Knopf behoben; neuer Dialog zum Hinzufügen.
+* Neues Ordner-Debug-Tool zeigt alle Ordnernamen an und löscht veraltete Einträge.
 
 ### 3.15.0 - Überarbeitetes API-Menü
 
@@ -475,7 +477,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.18.0** - Stimmenverwaltung und Name-Abruf
+**Version 3.19.0** - Ordner-Debug und Stimmenverwaltung
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -392,12 +392,14 @@
     <!-- Umschaltbare Debug-Konsole -->
     <details id="debugConsoleWrapper" style="margin:10px 0;">
         <summary>🛠️ Debug-Konsole</summary>
+        <button class="btn btn-secondary" onclick="showFolderDebug()">🐞 Ordner prüfen</button>
+        <div id="folderDebug" style="margin:10px 0;"></div>
         <pre id="debugConsole" style="max-height:200px; overflow:auto; background:#000; color:#0f0; padding:5px;"></pre>
     </details>
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.18.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.19.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "devDependencies": {
         "jest": "^29.6.1",
         "nock": "^14.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "devDependencies": {
     "jest": "^29.6.1",
     "nock": "^14.0.5"

--- a/src/main.js
+++ b/src/main.js
@@ -3859,6 +3859,58 @@ function cleanupIncorrectFolderNames() {
 }
 // =========================== CLEANUPINCORRECTFOLDERNAMES END ===========================
 
+// =========================== SHOWFOLDERDEBUG START ===========================
+// Zeigt alle bekannten Ordner aus der Datenbank an und markiert nicht gefundene
+// Ordner. Fehlende Ordner lassen sich direkt löschen.
+function showFolderDebug() {
+    const wrapper = document.getElementById('debugConsoleWrapper');
+    wrapper.open = true;
+
+    const listDiv = document.getElementById('folderDebug');
+    if (!listDiv) return;
+    listDiv.innerHTML = '';
+
+    // Sammle eindeutige Ordnernamen aus der Datenbank
+    const folders = new Set();
+    Object.values(filePathDatabase).forEach(paths => {
+        paths.forEach(p => folders.add(p.folder));
+    });
+
+    if (folders.size === 0) {
+        listDiv.textContent = 'Keine Ordner in der Datenbank.';
+        return;
+    }
+
+    const ul = document.createElement('ul');
+    ul.style.listStyle = 'none';
+    ul.style.padding = '0';
+
+    folders.forEach(folder => {
+        const li = document.createElement('li');
+        li.style.marginBottom = '4px';
+
+        const exists = Object.keys(audioFileCache).some(p => p.startsWith(folder + '/'));
+        const status = document.createElement('span');
+        status.textContent = exists ? '✅' : '❌';
+        li.appendChild(status);
+        li.append(' ' + folder);
+
+        if (!exists) {
+            const btn = document.createElement('button');
+            btn.textContent = 'Löschen';
+            btn.className = 'btn btn-danger';
+            btn.style.marginLeft = '10px';
+            btn.onclick = () => deleteFolderFromDatabase(folder);
+            li.appendChild(btn);
+        }
+
+        ul.appendChild(li);
+    });
+
+    listDiv.appendChild(ul);
+}
+// =========================== SHOWFOLDERDEBUG END =============================
+
 // =========================== GETBROWSERDEBUGPATHINFO START ===========================
 // Debug-Pfad-Information für Ordner-Browser
 function getBrowserDebugPathInfo(file) {
@@ -4860,7 +4912,7 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.17.1',
+                version: '3.19.0',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
@@ -7992,7 +8044,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.17.1 - Globale Fortschrittsanzeige');
+        console.log('Version 3.19.0 - Ordner-Debug');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');


### PR DESCRIPTION
## Summary
- erweitere Debug-Konsole um Button "Ordner prüfen" und Ausgabe
- implementiere `showFolderDebug` zum Auflisten und Löschen verwaister Ordner
- Versionsnummer auf 3.19.0 / 1.4.0 angehoben
- README aktualisiert mit neuer Funktion

## Testing
- `npm test` *(fail: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad6262ddc8327b57a5c6bc16f79fc