### PR TITLE
Add missing folder cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.19.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.20.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.19.0](#-neue-features-in-3190)
+* [✨ Neue Features in 3.20.0](#-neue-features-in-3200)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [ElevenLabs-Dubbing](#elevenlabs-dubbing)
@@ -27,7 +27,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.19.0
+## ✨ Neue Features in 3.20.0
 
 |  Kategorie                 |  Beschreibung
 | -------------------------- | ------------------------------------------------- |
@@ -41,6 +41,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 | **Stimmenverwaltung**  | Benutzerdefinierte IDs umbenennen, löschen und Name abrufen. |
 | **CSP-Fix**          | API-Tests im Browser funktionieren jetzt dank angepasster Content Security Policy. |
 | **Ordner-Debug**     | Zeigt alle Ordner aus der Datenbank und löscht nicht mehr existente Einträge. |
+| **Verwaiste Ordner** | Sucht nach fehlenden Ordnern und bietet Löschoptionen. |
 ---
 
 ## 🚀 Features (komplett)
@@ -331,7 +332,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.19.0 (aktuell) - Ordner-Debug
+### 3.20.0 (aktuell) - Verwaiste Ordner
+
+**✨ Neue Features:**
+* Neuer Button sucht fehlende Ordner im Ordner-Browser und bietet Löschoptionen.
+
+### 3.19.0 - Ordner-Debug
 
 **✨ Neue Features:**
 * Benutzerdefinierte Stimmen lassen sich jetzt bearbeiten und löschen.
@@ -477,7 +483,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.19.0** - Ordner-Debug und Stimmenverwaltung
+**Version 3.20.0** - Verwaiste Ordner und Stimmenverwaltung
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -289,6 +289,19 @@
                 <button class="btn btn-secondary" onclick="openBackupFolder()">Ordner öffnen</button>
                 <button class="btn btn-secondary" onclick="closeBackupDialog()">Schließen</button>
             </div>
+    </div>
+    </div>
+
+    <!-- Missing Folders Dialog -->
+    <div class="dialog-overlay" id="missingFoldersDialog" style="display:none">
+        <div class="dialog">
+<button class="dialog-close-btn" onclick="closeMissingFoldersDialog()">×</button>
+            <h3>🚮 Fehlende Ordner</h3>
+            <div id="missingFoldersList" style="margin:15px 0; max-height:300px; overflow:auto;"></div>
+            <div class="dialog-buttons">
+                <button class="btn btn-secondary" onclick="closeMissingFoldersDialog()">Abbrechen</button>
+                <button class="btn btn-success" onclick="deleteSelectedMissingFolders()">Ausgewählte löschen</button>
+            </div>
         </div>
     </div>
 
@@ -399,7 +412,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.19.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.20.0</a>
 
     <script src="src/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add 'Fehlende Ordner suchen' option in folder browser
- implement missing folder dialog with delete option
- update deleteFolderFromDatabase to allow skipping confirmations
- bump version to 3.20.0 and document changes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad842ea308327912e1291c5878fca