### PR TITLE
Ordnerliste im Dialog und Version 3.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.20.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.21.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.20.0](#-neue-features-in-3200)
+* [✨ Neue Features in 3.21.0](#-neue-features-in-3210)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [ElevenLabs-Dubbing](#elevenlabs-dubbing)
@@ -27,7 +27,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.20.0
+## ✨ Neue Features in 3.21.0
 
 |  Kategorie                 |  Beschreibung
 | -------------------------- | ------------------------------------------------- |
@@ -41,6 +41,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 | **Stimmenverwaltung**  | Benutzerdefinierte IDs umbenennen, löschen und Name abrufen. |
 | **CSP-Fix**          | API-Tests im Browser funktionieren jetzt dank angepasster Content Security Policy. |
 | **Fehlende Ordner**  | Neues Tool sucht in der Datenbank nach Ordnern ohne Dateien und bietet deren Löschung an. |
+| **Ordnerliste**      | Zweite Liste zeigt alle Ordner mit Pfad aus der Datenbank. |
 ---
 
 ## 🚀 Features (komplett)
@@ -331,7 +332,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.20.0 (aktuell) - Fehlende Ordner
+### 3.21.0 (aktuell) - Fehlende Ordner
 
 **✨ Neue Features:**
 * Benutzerdefinierte Stimmen lassen sich jetzt bearbeiten und löschen.
@@ -339,6 +340,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 * Test-Button für den API-Key mit grüner Erfolgsanzeige.
 * Fehler beim "Neue Stimme"-Knopf behoben; neuer Dialog zum Hinzufügen.
 * Neues Tool listet fehlende Ordner auf und erlaubt deren Löschung.
+* Zusätzlich zeigt eine zweite Liste alle Ordner mit Pfad aus der Datenbank an.
 
 ### 3.15.0 - Überarbeitetes API-Menü
 
@@ -477,7 +479,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.20.0** - Fehlende Ordner und Stimmenverwaltung
+**Version 3.21.0** - Fehlende Ordner, Stimmenverwaltung und Ordnerliste
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -391,6 +391,8 @@
 <button class="dialog-close-btn" onclick="closeMissingFoldersDialog()">×</button>
             <h3>🚫 Fehlende Ordner</h3>
             <div id="missingFoldersList" style="margin-bottom:15px;"></div>
+            <h4>📁 Ordner in der Datenbank</h4>
+            <div id="databaseFoldersList" style="margin-bottom:15px;"></div>
             <div class="dialog-buttons">
                 <button class="btn btn-danger" id="deleteAllMissingBtn">Alle löschen</button>
                 <button class="btn btn-secondary" onclick="closeMissingFoldersDialog()">Schließen</button>
@@ -412,7 +414,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.20.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.21.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -3919,7 +3919,9 @@ function showFolderDebug() {
 function showMissingFoldersDialog() {
     const dialog  = document.getElementById('missingFoldersDialog');
     const listDiv = document.getElementById('missingFoldersList');
+    const dbDiv   = document.getElementById('databaseFoldersList');
     listDiv.innerHTML = '';
+    dbDiv.innerHTML   = '';
 
     const folderMap = {};
     Object.values(filePathDatabase).forEach(paths => {
@@ -3928,6 +3930,10 @@ function showMissingFoldersDialog() {
             folderMap[p.folder].push(p.fullPath);
         });
     });
+
+    // Alle Ordner aus der Datenbank sortiert sammeln
+    const allFolders = Object.entries(folderMap)
+        .sort((a, b) => a[0].localeCompare(b[0]));
 
     const missing = Object.entries(folderMap)
         .filter(([folder, paths]) => !paths.some(full => audioFileCache[full]))
@@ -3963,6 +3969,24 @@ function showMissingFoldersDialog() {
             missing.forEach(folder => deleteFolderFromDatabase(folder));
             showMissingFoldersDialog();
         };
+    }
+
+    // Zweite Liste mit allen Ordnern und erstem Pfad anzeigen
+    if (allFolders.length === 0) {
+        dbDiv.textContent = 'Keine Ordner in der Datenbank.';
+    } else {
+        const dbUl = document.createElement('ul');
+        dbUl.style.listStyle = 'none';
+        dbUl.style.padding = '0';
+
+        allFolders.forEach(([folder, paths]) => {
+            const li = document.createElement('li');
+            li.style.marginBottom = '6px';
+            li.textContent = `${folder} – ${paths[0]}`;
+            dbUl.appendChild(li);
+        });
+
+        dbDiv.appendChild(dbUl);
     }
 
     dialog.style.display = 'flex';
@@ -4974,7 +4998,7 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.20.0',
+                version: '3.21.0',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
@@ -8106,7 +8130,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.20.0 - Fehlende Ordner');
+        console.log('Version 3.21.0 - Fehlende Ordner');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');


### PR DESCRIPTION
## Summary
- erweitere `showMissingFoldersDialog` um Liste aller Ordner aus der DB
- zeige neue Liste im HTML-Dialog an
- dokumentiere die Funktionserweiterung
- Versionsnummer auf **3.21.0** angehoben

## Testing
- `npm test` *(scheitert: jest nicht gefunden)*

------
https://chatgpt.com/codex/tasks/task_e_684adc20d2588327a22b915566a5e851