### PR TITLE
Ordnerlisten-Bugfix und Bereinigung

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.21.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.21.1-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.21.0](#-neue-features-in-3210)
+* [✨ Neue Features in 3.21.1](#-neue-features-in-3211)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [ElevenLabs-Dubbing](#elevenlabs-dubbing)
@@ -27,7 +27,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.21.0
+## ✨ Neue Features in 3.21.1
 
 |  Kategorie                 |  Beschreibung
 | -------------------------- | ------------------------------------------------- |
@@ -42,6 +42,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 | **CSP-Fix**          | API-Tests im Browser funktionieren jetzt dank angepasster Content Security Policy. |
 | **Fehlende Ordner**  | Neues Tool sucht in der Datenbank nach Ordnern ohne Dateien und bietet deren Löschung an. |
 | **Ordnerliste**      | Zweite Liste zeigt alle Ordner mit Pfad aus der Datenbank. |
+| **Bereinigung**      | API-Menü und Ordner-Browser verwenden jetzt dieselbe Liste. |
 ---
 
 ## 🚀 Features (komplett)
@@ -332,7 +333,13 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.21.0 (aktuell) - Fehlende Ordner
+### 3.21.1 (aktuell) - Ordnerlisten bereinigt
+
+**🛠️ Bugfix:**
+* API-Menü zeigt jetzt nur Ordner aus der Datenbank an.
+* Verwaiste Ordner-Anpassungen werden automatisch entfernt.
+
+### 3.21.0 - Fehlende Ordner
 
 **✨ Neue Features:**
 * Benutzerdefinierte Stimmen lassen sich jetzt bearbeiten und löschen.
@@ -479,7 +486,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.21.0** - Fehlende Ordner, Stimmenverwaltung und Ordnerliste
+**Version 3.21.1** - Ordnerlisten bereinigt und alte Einträge entfernt
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -414,7 +414,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.21.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.21.1</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "devDependencies": {
     "jest": "^29.6.1",
     "nock": "^14.0.5"

--- a/src/main.js
+++ b/src/main.js
@@ -146,6 +146,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (savedPathDB) {
         filePathDatabase = JSON.parse(savedPathDB);
     }
+    // Verwaiste Ordner-Anpassungen bereinigen
+    cleanupOrphanCustomizations();
 
     if (!window.electronAPI) {
         // 👉 Zuletzt verwendeten Projektordner laden (Browser-Version)
@@ -3995,6 +3997,26 @@ function showMissingFoldersDialog() {
 function closeMissingFoldersDialog() {
     document.getElementById('missingFoldersDialog').style.display = 'none';
 }
+// =========================== CLEANUPORPHANCUSTOMIZATIONS START =============
+// Entfernt gespeicherte Ordner-Anpassungen, die keinen Datenbankeintrag mehr besitzen
+function cleanupOrphanCustomizations() {
+    const knownFolders = new Set();
+    Object.values(filePathDatabase).forEach(paths => {
+        paths.forEach(p => knownFolders.add(p.folder));
+    });
+    let removed = 0;
+    Object.keys(folderCustomizations).forEach(folder => {
+        if (!knownFolders.has(folder)) {
+            delete folderCustomizations[folder];
+            removed++;
+        }
+    });
+    if (removed > 0) {
+        saveFolderCustomizations();
+        console.log(`[CLEANUP] ${removed} verwaiste Ordner-Anpassungen entfernt`);
+    }
+}
+// =========================== CLEANUPORPHANCUSTOMIZATIONS END ===============
 // =========================== SHOWMISSINGFOLDERSDIALOG END ===================
 
 // =========================== GETBROWSERDEBUGPATHINFO START ===========================
@@ -4998,7 +5020,7 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.21.0',
+                version: '3.21.1',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
@@ -5116,6 +5138,9 @@ function checkFileAccess() {
 
             await validateApiKey();
 
+            // Vor dem Aufbau verwaiste Anpassungen entfernen
+            cleanupOrphanCustomizations();
+
             const list = document.getElementById('voiceIdList');
             list.innerHTML = '';
 
@@ -5124,7 +5149,6 @@ function checkFileAccess() {
             Object.values(filePathDatabase).forEach(paths => {
                 paths.forEach(p => folderSet.add(p.folder));
             });
-            Object.keys(folderCustomizations).forEach(f => folderSet.add(f));
             const folders = Array.from(folderSet).sort();
 
             const groups = { combine: [], vortigaunt: [], citizen: [], other: [] };
@@ -8130,7 +8154,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.21.0 - Fehlende Ordner');
+        console.log('Version 3.21.1 - Ordnerlisten bereinigt');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');


### PR DESCRIPTION
## Summary
- API-Dialog benutzt nur noch Ordner aus der Datenbank
- neue Funktion `cleanupOrphanCustomizations` löscht verwaiste Ordner-Anpassungen
- Versionsnummer auf 3.21.1/1.5.1 angehoben
- Dokumentation aktualisiert

## Testing
- `npm test` *(fehlgeschlagen: jest nicht gefunden)*

------
https://chatgpt.com/codex/tasks/task_e_684adda4cb708327af130497ff3c116a