### PR TITLE
Add tests for getDubbingStatus and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.23.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-3.23.1-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 3.23.0](#-neue-features-in-3230)
+* [✨ Neue Features in 3.23.1](#-neue-features-in-3231)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [ElevenLabs-Dubbing](#elevenlabs-dubbing)
@@ -27,7 +27,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
-## ✨ Neue Features in 3.23.0
+## ✨ Neue Features in 3.23.1
 
 |  Kategorie                 |  Beschreibung
 | -------------------------- | ------------------------------------------------- |
@@ -335,7 +335,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 3.23.0 (aktuell) - Dubbing-Protokoll
+### 3.23.1 (aktuell) - Dubbing-Protokoll
 
 **✨ Neue Features:**
 * Pro Datei kann per Klick ein automatisches Dubbing via ElevenLabs gestartet werden.
@@ -494,7 +494,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 3.23.0** - Dubbing-Protokoll hinzugefügt
+**Version 3.23.1** - Dubbing-Protokoll hinzugefügt
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests
@@ -512,8 +512,8 @@ Diese Repository nutzt **Jest** als Test Runner. Um die Tests auszuführen:
    ```
 
 Die wichtigsten Tests befinden sich im Ordner `tests/` und prüfen unter
-anderem die Funktion `calculateProjectStats`. Neu ist ein Test für die
-ElevenLabs‑Anbindung, der die API‑Aufrufe mit **nock** simuliert.
+anderem die Funktion `calculateProjectStats`. Neu sind Tests für die
+ElevenLabs‑Anbindung (z. B. `getDubbingStatus`), die die API‑Aufrufe mit **nock** simulieren.
 
 ## 🧩 Wichtige Funktionen
 

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -428,7 +428,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.23.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v3.23.1</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "devDependencies": {
         "jest": "^29.6.1",
         "nock": "^14.0.5"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "devDependencies": {
     "jest": "^29.6.1",
     "nock": "^14.0.5"

--- a/src/main.js
+++ b/src/main.js
@@ -5050,7 +5050,7 @@ function checkFileAccess() {
 // =========================== CREATEBACKUP START ===========================
         function createBackup(showMsg = false) {
             const backup = {
-                version: '3.23.0',
+                version: '3.23.1',
                 date: new Date().toISOString(),
                 projects: projects,
                 textDatabase: textDatabase,
@@ -8291,7 +8291,7 @@ function showLevelCustomization(levelName, ev) {
 
         // Initialize app
         console.log('%c🎮 Half-Life: Alyx Translation Tool geladen!', 'color: #ff6b1a; font-size: 16px; font-weight: bold;');
-        console.log('Version 3.23.0 - Dubbing-Protokoll');
+        console.log('Version 3.23.1 - Dubbing-Protokoll');
         console.log('✨ NEUE FEATURES:');
         console.log('• 📊 Globale Übersetzungsstatistiken: Projekt-übergreifendes Completion-Tracking');
         console.log('• 🟢 Ordner-Completion-Status: Grüne Rahmen für vollständig übersetzte Ordner');

--- a/tests/elevenlabs.test.js
+++ b/tests/elevenlabs.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const nock = require('nock');
 const path = require('path');
 
-const { createDubbing, downloadDubbingAudio } = require('../elevenlabs');
+const { createDubbing, getDubbingStatus, downloadDubbingAudio } = require('../elevenlabs');
 
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io';
@@ -46,5 +46,22 @@ describe('ElevenLabs API', () => {
             .reply(404, 'not found');
 
         await expect(downloadDubbingAudio('key', 'abc', 'de', 'out.mp3')).rejects.toThrow('Download fehlgeschlagen');
+    });
+
+    test('Status erfolgreich abgefragt', async () => {
+        nock(API)
+            .get('/v1/dubbing/123')
+            .reply(200, { status: 'dubbed' });
+
+        const result = await getDubbingStatus('key', '123');
+        expect(result).toEqual({ status: 'dubbed' });
+    });
+
+    test('Fehler bei getDubbingStatus', async () => {
+        nock(API)
+            .get('/v1/dubbing/123')
+            .reply(500, 'kaputt');
+
+        await expect(getDubbingStatus('key', '123')).rejects.toThrow('Status-Abfrage fehlgeschlagen');
     });
 });


### PR DESCRIPTION
## Summary
- test `getDubbingStatus` with nock
- update README with new version and test info
- bump app version to 3.23.1 and package version to 1.6.1

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aece02a488327a7e609f1638d0860