### PR TITLE
Entferne Abschnitt Code-Ausgabe Regeln

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Beitragstipps
+
+Die folgenden Regeln helfen dabei, Code-Änderungen übersichtlich und sicher zu gestalten:
+
+1. **Vollständige Funktionen** – immer den ganzen Funktionsblock angeben.
+2. **Start-/End-Kommentare** – Funktionen klar abgrenzen.
+3. **Schrittweise vorgehen** – eine Funktion nach der anderen ändern und testen.
+4. **Kleine Schritte** – möglichst wenig ändern, bei Fehlern zur letzten Version zurück.
+5. **Präzise Angaben** – angeben, welche Funktion ersetzt werden soll.
+

--- a/README.md
+++ b/README.md
@@ -528,36 +528,3 @@ ElevenLabs‑Anbindung (z. B. `getDubbingStatus`), die die API‑Aufrufe mit *
 * **`delete-de-backup-file(relPath)`** – löscht eine Sicherung aus `DE-Backup` und entfernt leere Unterordner.
 * **`restore-de-file(relPath)`** – stellt eine deutsche Audiodatei aus dem Backup wieder her.
 * **`calculateProjectStats(project)`** – ermittelt pro Projekt den Übersetzungs‑ und Audio‑Fortschritt. Diese Funktion wird auch in den Tests ausführlich geprüft.
-
-> Die im Abschnitt **Code-Ausgabe Regeln** gezeigte `meineFunktion` ist lediglich ein Beispiel aus der Anleitung.
-
-
-## Code-Ausgabe Regeln
-
-**1. Vollständige Funktionen:**
-- Immer die **komplette** Funktion ausgeben, damit sie einfach ersetzt werden kann
-- Nie nur Teile oder Snippets
-
-**2. Klare Markierungen:**
-- Jede Funktion mit Start- und End-Kommentaren umrahmen:
-```javascript
-// =========================== FUNKTIONSNAME START ===========================
-function meineFunktion() {
-    // code hier
-}
-// =========================== FUNKTIONSNAME END ===========================
-```
-
-**3. Schritt für Schritt:**
-- **Nur eine Funktion pro Antwort**
-- Nach jeder Änderung testen lassen
-- Erst wenn eine Funktion funktioniert, zur nächsten
-
-**4. Sichere Änderungen:**
-- Minimale Änderungen bevorzugen
-- Bei Fehlern sofort zur ursprünglichen Version zurück
-
-**5. Klare Anweisungen:**
-- Sagen welche Funktion gesucht und ersetzt werden soll
-- Eindeutige Such-Strings angeben
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "devDependencies": {
         "jest": "^29.6.1",
         "nock": "^14.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "devDependencies": {
     "jest": "^29.6.1",
     "nock": "^14.0.5"


### PR DESCRIPTION
## Summary
- entferne die Anleitung **Code-Ausgabe Regeln** aus der README
- lagere die Regeln gekürzt in eine neue `CONTRIBUTING.md` aus
- erhöhe Patch-Version auf **1.7.1**

## Testing
- `npm test` *(fail: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af0f893ac8327893e88fcf807e5d8