### PR TITLE
Ordnerspezifische ElevenLabs-Stimmen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.11.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.12.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 1.11.0](#-neue-features-in-1.11.0)
+* [✨ Neue Features in 1.12.0](#-neue-features-in-1.12.0)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [ElevenLabs-Dubbing](#elevenlabs-dubbing)
@@ -27,13 +27,18 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
+## ✨ Neue Features in 1.12.0
+
+|  Kategorie                 |  Beschreibung |
+| -------------------------- | ----------------------------------------------- |
+| **Ordnerstimmen**         | Jeder Ordner kann eine feste ElevenLabs-Stimme erhalten. |
+
 ## ✨ Neue Features in 1.11.0
 
 |  Kategorie                 |  Beschreibung |
 | -------------------------- | ----------------------------------------------- |
 | **Schneller Dialog**      | Dubbing-Einstellungsfenster öffnet sich nun sofort. |
 | **Manual Dub**            | Eigener DE-Text wird zusammen mit Start- und Endzeiten \*als CSV\* an die API geschickt. |
-
 ## ✨ Neue Features in 1.10.3
 
 |  Kategorie                 |  Beschreibung |
@@ -167,6 +172,8 @@ Die Standardwerte werden über `getDefaultVoiceSettings` geladen und nach dem Sp
 
 Beim Öffnen des Dubbing-Dialogs werden gespeicherte Werte automatisch geladen.
 Über den Button **Reset** lassen sich diese wieder auf die API-Defaults zurücksetzen.
+
+Über das **API-Menü** lässt sich zudem pro Ordner eine feste ElevenLabs-Stimme wählen. Beim Dubbing wird diese Voice-ID automatisch verwendet und Voice Cloning deaktiviert.
 
 Ab Version 1.10.3 wird beim Dubbing der selbst eingetragene deutsche Text genutzt. Das Tool erzeugt dazu eine CSV-Datei mit dem Format `speaker,start_time,end_time,transcription,translation`. Start- und Endzeit leiten sich aus den Feldern `trimStartMs` und `trimEndMs` ab und werden zusammen mit `mode=manual` und `dubbing_studio=true` an die API übermittelt.
 
@@ -372,7 +379,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.11.0 (aktuell) - Manual Dub per CSV
+### 1.12.0 (aktuell) - Feste Ordnerstimmen
+
+**✨ Neue Features:**
+* Ordner können feste ElevenLabs-Stimmen erhalten. Die API erhält diese Voice-ID automatisch, Voice Cloning wird deaktiviert.
+
+### 1.11.0 - Manual Dub per CSV
 
 **✨ Neue Features:**
 * Eigener deutscher Text wird als CSV übermittelt; Start- und Endzeit nutzen `trimStartMs` und `trimEndMs`.
@@ -544,7 +556,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 1.11.0** - Manual Dub per CSV
+**Version 1.12.0** - Feste Ordnerstimmen
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -428,7 +428,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.11.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.12.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -62,7 +62,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.11.0';
+const APP_VERSION = '1.12.0';
 
 // =========================== GLOBAL STATE END ===========================
 
@@ -6276,6 +6276,8 @@ function createDubbingCSV(file, durationMs) {
 async function startDubbing(fileId, settings = {}) {
     const file = files.find(f => f.id === fileId);
     if (!file) return;
+    // Ordnerspezifische Voice-ID ermitteln
+    const folderVoiceId = folderCustomizations[file.folder]?.voiceId;
     openDubbingLog();
     addDubbingLog(`Starte Dubbing für ${file.filename}`);
     if (!elevenLabsApiKey) {
@@ -6322,6 +6324,11 @@ async function startDubbing(fileId, settings = {}) {
     if (settings && Object.keys(settings).length > 0) {
         form.append('voice_settings', JSON.stringify(settings));
     }
+    // Bei vorhandener Ordner-Stimme diese übergeben und Voice Cloning deaktivieren
+    if (folderVoiceId) {
+        form.append('voice_id', folderVoiceId);
+    }
+    form.append('disable_voice_cloning', 'true');
 
     const res = await fetch('https://api.elevenlabs.io/v1/dubbing', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- VoiceID aus Ordner-Einstellungen lesen
- Parameter `voice_id` und `disable_voice_cloning` mitsenden
- Dokumentation zu festen Ordnerstimmen ergänzen
- Versionsnummer auf 1.12.0 anheben

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b0377136c8327bc232b2cf9266c11