### PR TITLE
Add cliRedownload tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 | -------------------------- | ----------------------------------------------- |
 | **Versionsplatzhalter** | HTML und JavaScript nutzen nun `__VERSION__` statt fester Zahlen. |
 | **Update-Skript** | `npm run update-version` ersetzt alle Platzhalter automatisch. |
+| **cliRedownload.js** | Neues Node-Skript lädt eine vorhandene Dub-Datei erneut herunter. |
 
 ## ✨ Neue Features in 1.16.0
 
@@ -220,6 +221,15 @@ Beim Öffnen des Dubbing-Dialogs werden gespeicherte Werte automatisch geladen.
 
 Nach erfolgreichem Download merkt sich das Projekt die zugehörige **Dubbing-ID** in der jeweiligen Datei (`dubbingId`).
 So können Sie das Ergebnis später erneut herunterladen oder neu generieren.
+
+Für diesen Zweck gibt es das Node-Skript `cliRedownload.js`.
+Es wird so aufgerufen:
+
+```bash
+node cliRedownload.js <API-Key> <Dubbing-ID> <Ausgabedatei>
+```
+
+Intern nutzt es `downloadDubbingAudio()` aus `elevenlabs.js`.
 
 Über das **API-Menü** lässt sich zudem pro Ordner eine feste ElevenLabs-Stimme wählen. Ist eine Voice-ID hinterlegt, wird sie beim Dubbing automatisch genutzt und Voice Cloning abgeschaltet. Ohne Voice-ID bleibt Voice Cloning aktiv.
 
@@ -445,6 +455,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 **✨ Neue Features:**
 * Alle festen Versionsnummern wurden durch den Platzhalter `__VERSION__` ersetzt.
 * Das Skript `npm run update-version` trägt die aktuelle Version automatisch ein.
+* Neues CLI-Skript `cliRedownload.js` lädt Dub-Dateien erneut herunter.
 
 ### 1.16.3 - CSV-Validierung
 

--- a/cliRedownload.js
+++ b/cliRedownload.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// cliRedownload.js
+// Einfache Kommandozeilenhilfe zum erneuten Herunterladen eines Dubbings
+
+const { downloadDubbingAudio } = require('./elevenlabs');
+
+// Parameter auslesen: node cliRedownload.js API-KEY DUBBING-ID AUSGABEDATEI
+const [,, apiKey, dubbingId, outFile] = process.argv;
+
+if (!apiKey || !dubbingId || !outFile) {
+    console.log('Aufruf: node cliRedownload.js <API-Key> <Dubbing-ID> <Ausgabedatei>');
+    process.exit(1);
+}
+
+(async () => {
+    try {
+        await downloadDubbingAudio(apiKey, dubbingId, 'de', outFile);
+        console.log('Download abgeschlossen:', outFile);
+    } catch (err) {
+        console.error('Fehler:', err.message);
+        process.exit(1);
+    }
+})();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.16.4",
+  "version": "1.17.0",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",


### PR DESCRIPTION
## Summary
- add `cliRedownload.js` for audio re-downloads
- document the new script in README
- bump version to 1.17.0

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2b8e02648327b6168dfac713cbf1