### PR TITLE
Entferne persistentes Dubbing-Log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.18.6-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.18.7-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,7 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
-* [✨ Neue Features in 1.18.6](#-neue-features-in-1.18.6)
+* [✨ Neue Features in 1.18.7](#-neue-features-in-1.18.7)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
 * [ElevenLabs-Dubbing](#elevenlabs-dubbing)
@@ -26,6 +26,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * [📝 Changelog](#-changelog)
 
 ---
+
+## ✨ Neue Features in 1.18.7
+
+|  Kategorie                 |  Beschreibung |
+| -------------------------- | ----------------------------------------------- |
+| **Frisches Dubbing-Log** | Log wird bei jedem Start automatisch geleert. |
 
 ## ✨ Neue Features in 1.18.6
 
@@ -455,7 +461,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.18.6 (aktuell) - Sekundenformat
+### 1.18.7 (aktuell)
+
+**✨ Neue Features:**
+* Dubbing-Log wird nicht mehr im Browser gespeichert und bei jedem Dub automatisch geleert.
+
+### 1.18.6 - Sekundenformat
 
 **✨ Neue Features:**
 * `createDubbingCSV()` erzeugt Sekundenwerte in den Feldern `start_time` und `end_time`.

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.18.6</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.18.7</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.18.6';
+const APP_VERSION = '1.18.7';
 
 // =========================== GLOBAL STATE END ===========================
 
@@ -81,12 +81,12 @@ function debugLog(...args) {
 }
 
 // =========================== DUBBING-LOG START ===========================
+// Aktuelles Dubbing-Protokoll (wird nicht mehr gespeichert)
 let dubbingLogMessages = [];
 
 function addDubbingLog(msg) {
-    // Neue Meldung ans Ende hängen und dauerhaft speichern
+    // Neue Meldung anhängen, aber nur im Arbeitsspeicher behalten
     dubbingLogMessages.push(msg);
-    localStorage.setItem('hla_dubbingLog', JSON.stringify(dubbingLogMessages));
     const logPre = document.getElementById('dubbingLog');
     if (logPre) {
         logPre.textContent = dubbingLogMessages.join('\n');
@@ -95,9 +95,7 @@ function addDubbingLog(msg) {
 }
 
 function openDubbingLog() {
-    // Beim Öffnen gespeicherte Einträge laden
-    const stored = localStorage.getItem('hla_dubbingLog');
-    dubbingLogMessages = stored ? JSON.parse(stored) : [];
+    // Einfachen Log anzeigen (ohne Laden aus dem Speicher)
     const logPre = document.getElementById('dubbingLog');
     if (logPre) logPre.textContent = dubbingLogMessages.join('\n');
     document.getElementById('dubbingLogDialog').style.display = 'flex';
@@ -113,9 +111,8 @@ function copyDubbingLog() {
 }
 
 function clearDubbingLog() {
-    // Log-Einträge entfernen und Speicher leeren
+    // Log-Einträge entfernen (keine Speicherung mehr)
     dubbingLogMessages = [];
-    localStorage.removeItem('hla_dubbingLog');
     const logPre = document.getElementById('dubbingLog');
     if (logPre) logPre.textContent = '';
     updateStatus('Dubbing-Log gelöscht');
@@ -6371,6 +6368,10 @@ async function startDubbing(fileId, settings = {}) {
     if (!file) return;
     // Ordnerspezifische Voice-ID ermitteln
     const folderVoiceId = folderCustomizations[file.folder]?.voiceId;
+    // Log zu Beginn leeren
+    dubbingLogMessages = [];
+    const logPre = document.getElementById('dubbingLog');
+    if (logPre) logPre.textContent = '';
     openDubbingLog();
     addDubbingLog(`Starte Dubbing für ${file.filename}`);
     if (!elevenLabsApiKey) {
@@ -6572,6 +6573,10 @@ async function startDubbing(fileId, settings = {}) {
 async function redownloadDubbing(fileId) {
     const file = files.find(f => f.id === fileId);
     if (!file || !file.dubbingId) return;
+    // Log zu Beginn leeren
+    dubbingLogMessages = [];
+    const logPre = document.getElementById('dubbingLog');
+    if (logPre) logPre.textContent = '';
     openDubbingLog();
     addDubbingLog(`Lade Dubbing ${file.dubbingId} erneut`);
     if (!elevenLabsApiKey) {


### PR DESCRIPTION
## Summary
- entferne dauerhafte Speicherung des Dubbing-Logs
- Log wird beim Start eines Dub immer geleert
- Versionsnummer auf 1.18.7 erhöht
- README und HTML entsprechend angepasst

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b4590d29483278bda9b8a3bf386c1