### PR TITLE
Update Dubbing error hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.18.7-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.18.8-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,6 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
+* [✨ Neue Features in 1.18.8](#-neue-features-in-1.18.8)
 * [✨ Neue Features in 1.18.7](#-neue-features-in-1.18.7)
 * [🚀 Features (komplett)](#-features-komplett)
 * [🛠️ Installation](#-installation)
@@ -26,6 +27,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * [📝 Changelog](#-changelog)
 
 ---
+
+## ✨ Neue Features in 1.18.8
+
+|  Kategorie                 |  Beschreibung |
+| -------------------------- | ----------------------------------------------- |
+| **Besseres Fehlerlogging** | Hinweis bei `dubbing_not_found` im Download. |
 
 ## ✨ Neue Features in 1.18.7
 
@@ -439,6 +446,10 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 * ▶ **Lösung:** Haupt‑Audio‑Ordner erneut einlesen
 * ▶ **Prüfung:** Debug‑Spalte zeigt Pfad‑Status
 
+**⚠️ dubbing_not_found**
+* ▶ **Ursache:** Die deutsche Spur wurde noch nicht erzeugt.
+* ▶ **Lösung:** Beim Anlegen `target_lang:"de"` setzen und Datei unter `/audio/de` abrufen.
+
 
 **🔄 Duplikate in Datenbank**
 * ▶ **Lösung:** „🧹 Duplikate bereinigen" verwenden
@@ -461,7 +472,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.18.7 (aktuell)
+### 1.18.8 (aktuell)
+
+**✨ Neue Features:**
+* Hinweistext bei `dubbing_not_found` erklärt fehlende Zielsprache.
+
+### 1.18.7
 
 **✨ Neue Features:**
 * Dubbing-Log wird nicht mehr im Browser gespeichert und bei jedem Dub automatisch geleert.

--- a/elevenlabs.js
+++ b/elevenlabs.js
@@ -81,7 +81,12 @@ async function downloadDubbingAudio(apiKey, dubbingId, lang = 'de', targetPath) 
     }
 
     if (!response.ok) {
-        throw new Error('Download fehlgeschlagen: ' + errText);
+        let hinweis = '';
+        // Spezieller Hinweis für 'dubbing_not_found'
+        if (errText.includes('dubbing_not_found')) {
+            hinweis = ' - Zielsprache fehlt oder falscher Download-Pfad';
+        }
+        throw new Error('Download fehlgeschlagen: ' + errText + hinweis);
     }
 
     return await new Promise((resolve, reject) => {

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.18.7</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.18.8</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.18.7",
+  "version": "1.18.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.18.7",
+      "version": "1.18.8",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.18.7",
+  "version": "1.18.8",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.18.7';
+const APP_VERSION = '1.18.8';
 
 // =========================== GLOBAL STATE END ===========================
 

--- a/tests/elevenlabs.test.js
+++ b/tests/elevenlabs.test.js
@@ -49,6 +49,15 @@ describe('ElevenLabs API', () => {
         await expect(downloadDubbingAudio('key', 'abc', 'de', 'out.mp3')).rejects.toThrow('Download fehlgeschlagen');
     });
 
+    test('Hinweis bei dubbing_not_found', async () => {
+        nock(API)
+            .get('/v1/dubbing/hint/audio/de')
+            .times(4)
+            .reply(404, 'dubbing_not_found');
+
+        await expect(downloadDubbingAudio('key', 'hint', 'de', 'out.mp3')).rejects.toThrow('falscher Download-Pfad');
+    });
+
     test('Download erfolgreich', async () => {
         const outPath = path.join(__dirname, 'out.mp3');
         nock(API)


### PR DESCRIPTION
## Summary
- hint for `dubbing_not_found` error in elevenlabs.js
- add test for the new hint
- expand README troubleshooting and changelog
- bump version to 1.18.8

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b4851658c8327af846cf742940053