### PR TITLE
Fix for new ElevenLabs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.19.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.19.1-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,6 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
+* [✨ Neue Features in 1.19.1](#-neue-features-in-1.19.1)
 * [✨ Neue Features in 1.19.0](#-neue-features-in-1.19.0)
 * [✨ Neue Features in 1.18.8](#-neue-features-in-1.18.8)
 * [✨ Neue Features in 1.18.7](#-neue-features-in-1.18.7)
@@ -28,6 +29,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * [📝 Changelog](#-changelog)
 
 ---
+
+## ✨ Neue Features in 1.19.1
+
+|  Kategorie                 |  Beschreibung |
+| -------------------------- | ----------------------------------------------- |
+| **Fehlerbehebung**        | API-Aufruf übergibt jetzt `segments` und `languages`. |
 
 ## ✨ Neue Features in 1.19.0
 
@@ -481,7 +488,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.19.0 (aktuell)
+### 1.19.1 (aktuell)
+
+**✨ Neue Features:**
+* API-Aufruf übergibt jetzt `segments` und `languages`.
+
+### 1.19.0
 
 **✨ Neue Features:**
 * Studio-Workflow nutzt jetzt `resource/dub` und `resource/render`.

--- a/elevenlabs.js
+++ b/elevenlabs.js
@@ -120,11 +120,26 @@ async function getDefaultVoiceSettings(apiKey) {
 // =========================== GETDEFAULTVOICESETTINGS END ==================
 
 // =========================== DUBSEGMENTS START ============================
-// Startet die Vertonung aller Clips eines Projekts
-async function dubSegments(apiKey, resourceId) {
+// Vertont alle Segmente eines Projekts im Studio-Workflow
+async function dubSegments(apiKey, resourceId, languages = ['de']) {
+    // Zuerst die vorhandenen Segment-IDs abfragen
+    const infoRes = await fetch(`https://api.elevenlabs.io/v1/dubbing/resource/${resourceId}`, {
+        headers: { 'xi-api-key': apiKey }
+    });
+    if (!infoRes.ok) {
+        throw new Error('Segmente konnten nicht geladen werden: ' + await infoRes.text());
+    }
+    const info = await infoRes.json();
+    const segIds = Object.keys(info.speaker_segments || {});
+
+    // Anschließend alle Segmente in den gewählten Sprachen vertonen
     const res = await fetch(`https://api.elevenlabs.io/v1/dubbing/resource/${resourceId}/dub`, {
         method: 'POST',
-        headers: { 'xi-api-key': apiKey }
+        headers: {
+            'xi-api-key': apiKey,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ segments: segIds, languages })
     });
     if (!res.ok) {
         throw new Error('Dub-Auftrag fehlgeschlagen: ' + await res.text());

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.19.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.19.1</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/tests/elevenlabs.test.js
+++ b/tests/elevenlabs.test.js
@@ -131,11 +131,15 @@ describe('ElevenLabs API', () => {
     });
 
     test('dubSegments sendet Request', async () => {
+        const resInfo = nock(API)
+            .get('/v1/dubbing/resource/55')
+            .reply(200, { speaker_segments: { '0': {} } });
         const scope = nock(API)
-            .post('/v1/dubbing/resource/55/dub')
+            .post('/v1/dubbing/resource/55/dub', { segments: ['0'], languages: ['de'] })
             .reply(200, { ok: true });
 
         const res = await dubSegments('key', '55');
+        expect(resInfo.isDone()).toBe(true);
         expect(scope.isDone()).toBe(true);
         expect(res).toEqual({ ok: true });
     });


### PR DESCRIPTION
## Summary
- pass `segments` and `languages` when dubbing a resource
- document the bug fix and bump version to 1.19.1

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b4e9c56448327ad8ba008e2b62e1a