### PR TITLE
fix: remove enterprise dubbing routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.19.1-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.19.2-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,6 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
+* [✨ Neue Features in 1.19.2](#-neue-features-in-1.19.2)
 * [✨ Neue Features in 1.19.1](#-neue-features-in-1.19.1)
 * [✨ Neue Features in 1.19.0](#-neue-features-in-1.19.0)
 * [✨ Neue Features in 1.18.8](#-neue-features-in-1.18.8)
@@ -30,6 +31,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ---
 
+## ✨ Neue Features in 1.19.2
+
+|  Kategorie                 |  Beschreibung |
+| -------------------------- | ----------------------------------------------- |
+| **Bugfix**                | Verwendet nur noch `/v1/dubbing`-Endpunkte und behebt `no_dubbing_api_access`. |
+
 ## ✨ Neue Features in 1.19.1
 
 |  Kategorie                 |  Beschreibung |
@@ -40,7 +47,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 |  Kategorie                 |  Beschreibung |
 | -------------------------- | ----------------------------------------------- |
-| **Studio-Workflow**        | Clips werden jetzt über `resource/dub` vertont und anschließend gerendert. |
+| **Studio-Workflow**        | Entfernt: Ab 1.19.2 genügt `POST/GET /v1/dubbing` zum Dubben. |
 
 ## ✨ Neue Features in 1.18.8
 
@@ -267,7 +274,7 @@ Intern nutzt es `downloadDubbingAudio()` aus `elevenlabs.js`.
 
 Ab Version 1.10.3 wird beim Dubbing der selbst eingetragene deutsche Text genutzt. Das Tool erzeugt dazu eine CSV-Datei mit dem Format `speaker,start_time,end_time,transcription,translation`. Die Felder `start_time` und `end_time` enthalten seit Version 1.18.6 Sekundenwerte mit drei Nachkommastellen und leiten sich aus `trimStartMs` bzw. `trimEndMs` ab. Diese CSV wird zusammen mit `mode=manual` und `dubbing_studio=true` an die API übermittelt.
 
-Seit Version 1.19.0 wird der Studio-Workflow vollständig unterstützt. Nach dem Upload startet das Tool automatisch `POST /v1/dubbing/resource/<ID>/dub` und wartet, bis alle Segmente `dubbed` sind. Anschließend erfolgt ein `POST /v1/dubbing/resource/<ID>/render/de` und das Herunterladen der Datei über die in `render_url.de` bereitgestellte Adresse.
+Bis Version 1.19.1 nutzte das Tool den Studio-Workflow über `resource/dub` und `resource/render`. Ab Version 1.19.2 erfolgt das Dubbing ausschließlich über die Standard-Endpunkte: Nach `POST /v1/dubbing` wird regelmäßig `GET /v1/dubbing/<ID>` aufgerufen und das Ergebnis anschließend via `GET /v1/dubbing/<ID>/audio/de` heruntergeladen.
 
 Beispiel einer gültigen CSV:
 
@@ -488,7 +495,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.19.1 (aktuell)
+### 1.19.2 (aktuell)
+
+**✨ Neue Features:**
+* Nur noch Basis-Endpunkte `/v1/dubbing` – Fehler `no_dubbing_api_access` behoben.
+
+### 1.19.1
 
 **✨ Neue Features:**
 * API-Aufruf übergibt jetzt `segments` und `languages`.
@@ -496,7 +508,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 ### 1.19.0
 
 **✨ Neue Features:**
-* Studio-Workflow nutzt jetzt `resource/dub` und `resource/render`.
+* Studio-Workflow über `resource/dub` und `resource/render` (entfernt ab 1.19.2).
 
 ### 1.18.8
 

--- a/elevenlabs.js
+++ b/elevenlabs.js
@@ -77,16 +77,6 @@ async function downloadDubbingAudio(apiKey, dubbingId, lang = 'de', targetPath) 
         if (response.ok) break;
         errText = await response.text();
 
-        // Studio/Manual-Dub nutzt einen anderen Endpunkt
-        if (response.status === 404 && errText.includes('dubbing_not_found')) {
-            const info = await getDubbingResource(apiKey, dubbingId).catch(() => null);
-            const url = info && info.render_url && info.render_url[lang];
-            if (url) {
-                return await downloadFromUrl(url, targetPath);
-            }
-            throw new Error('Download fehlgeschlagen: ' + errText + ' - Zielsprache fehlt oder falscher Download-Pfad');
-        }
-
         if (attempt < 3) {
             await new Promise(r => setTimeout(r, 1000));
         }
@@ -198,8 +188,5 @@ module.exports = {
     createDubbing,
     getDubbingStatus,
     downloadDubbingAudio,
-    getDefaultVoiceSettings,
-    dubSegments,
-    renderDubbingResource,
-    getDubbingResource
+    getDefaultVoiceSettings
 };

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.19.1</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.19.2</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.19.1",
+      "version": "1.19.2",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",


### PR DESCRIPTION
## Summary
- use Standard-API-Routen fuer Dubbing
- entferne Enterprise-spezifische Funktionen
- passe Tests an und aktualisiere Dokumentation
- erhoehe Version auf 1.19.2

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b538797288327ac9600156ceaa994