### PR TITLE
Fix: warte auf Sprache fertig

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.19.2-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.19.3-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -12,6 +12,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ## 📋 Inhaltsverzeichnis
 
+* [✨ Neue Features in 1.19.3](#-neue-features-in-1.19.3)
 * [✨ Neue Features in 1.19.2](#-neue-features-in-1.19.2)
 * [✨ Neue Features in 1.19.1](#-neue-features-in-1.19.1)
 * [✨ Neue Features in 1.19.0](#-neue-features-in-1.19.0)
@@ -30,6 +31,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * [📝 Changelog](#-changelog)
 
 ---
+
+## ✨ Neue Features in 1.19.3
+
+|  Kategorie                 |  Beschreibung |
+| -------------------------- | ----------------------------------------------- |
+| **Fehlerbehebung**        | Prüft `progress.langs.de` und wartet auf `finished`. |
 
 ## ✨ Neue Features in 1.19.2
 
@@ -495,7 +502,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.19.2 (aktuell)
+### 1.19.3 (aktuell)
+
+**✨ Neue Features:**
+* Prüft `progress.langs.de` und wartet auf `finished`.
+
+### 1.19.2
 
 **✨ Neue Features:**
 * Nur noch Basis-Endpunkte `/v1/dubbing` – Fehler `no_dubbing_api_access` behoben.
@@ -783,7 +795,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 1.18.6** - Sekundenformat im CSV
+**Version 1.19.3** - Prüft Fortschritt beim Dubbing
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.19.2</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.19.3</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.19.2",
+      "version": "1.19.3",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/tests/elevenlabs.test.js
+++ b/tests/elevenlabs.test.js
@@ -42,6 +42,9 @@ describe('ElevenLabs API', () => {
 
     test('Download-Fehler', async () => {
         nock(API)
+            .get('/v1/dubbing/abc')
+            .reply(200, { status: 'dubbed', progress: { langs: { de: { state: 'finished' } } } });
+        nock(API)
             .get('/v1/dubbing/abc/audio/de')
             .times(4)
             .reply(404, 'not found');
@@ -52,6 +55,9 @@ describe('ElevenLabs API', () => {
 
     test('Download erfolgreich', async () => {
         const outPath = path.join(__dirname, 'out.mp3');
+        nock(API)
+            .get('/v1/dubbing/xyz')
+            .reply(200, { status: 'dubbed', progress: { langs: { de: { state: 'finished' } } } });
         nock(API)
             .get('/v1/dubbing/xyz/audio/de')
             .reply(200, 'sound');
@@ -65,6 +71,9 @@ describe('ElevenLabs API', () => {
 
     test('Download klappt nach zweitem Versuch', async () => {
         const outPath = path.join(__dirname, 'retry.mp3');
+        nock(API)
+            .get('/v1/dubbing/retry')
+            .reply(200, { status: 'dubbed', progress: { langs: { de: { state: 'finished' } } } });
         nock(API)
             .get('/v1/dubbing/retry/audio/de')
             .reply(500, 'dubbing_not_found')


### PR DESCRIPTION
## Summary
- warte beim Dubbing auf `progress.langs.de`
- exportiere `waitForDubbing` und nutze es beim Download
- README und Version auf **1.19.3** aktualisiert
- Tests an neues Verhalten angepasst

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b56d822148327a23606fecbf0287a