### PR TITLE
feat: gemeinsame waitForDubbing Funktion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.19.4-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.20.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -11,7 +11,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ---
 
 ## 📋 Inhaltsverzeichnis
-
+* [✨ Neue Features in 1.20.0](#-neue-features-in-1.20.0)
 * [✨ Neue Features in 1.19.4](#-neue-features-in-1.19.4)
 * [✨ Neue Features in 1.19.2](#-neue-features-in-1.19.2)
 * [✨ Neue Features in 1.19.1](#-neue-features-in-1.19.1)
@@ -31,6 +31,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * [📝 Changelog](#-changelog)
 
 ---
+## ✨ Neue Features in 1.20.0
+
+|  Kategorie                 |  Beschreibung |
+| -------------------------- | ----------------------------------------------- |
+| **Gemeinsame Funktion**    | `waitForDubbing()` überwacht den Dub-Status und wird nun überall genutzt. |
+
 
 ## ✨ Neue Features in 1.19.4
 
@@ -502,10 +508,15 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.19.4 (aktuell)
+### 1.20.0 (aktuell)
+
+**✨ Neue Features:**
+* Gemeinsame Funktion `waitForDubbing()` ersetzt doppelte Polling-Schleifen.
+### 1.19.4
 
 **✨ Neue Features:**
 * Dubbing-Sprache über Parameter frei wählbar.
+
 
 ### 1.19.2
 
@@ -795,7 +806,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 1.19.4** - Sprache für Dubbing wählbar
+**Version 1.20.0 - Gemeinsame waitForDubbing-Funktion
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.19.4</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.20.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.19.4",
+  "version": "1.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.19.4",
+      "version": "1.20.0",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.19.4",
+  "version": "1.20.0",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",


### PR DESCRIPTION
## Summary
- Auslagerung der Polling-Schleife in `waitForDubbing`
- Nutzung der neuen Funktion in `startDubbing`
- Export und Tests für `waitForDubbing`
- Dokumentation im README ergänzt
- Version auf **1.20.0** angehoben

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b5f8f9de4832787f747b8735bc833