### PR TITLE
feat: zentrale API Konstante

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.20.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.20.1-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -11,7 +11,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ---
 
 ## 📋 Inhaltsverzeichnis
-* [✨ Neue Features in 1.20.0](#-neue-features-in-1.20.0)
+* [✨ Neue Features in 1.20.1](#-neue-features-in-1.20.1)
 * [✨ Neue Features in 1.19.4](#-neue-features-in-1.19.4)
 * [✨ Neue Features in 1.19.2](#-neue-features-in-1.19.2)
 * [✨ Neue Features in 1.19.1](#-neue-features-in-1.19.1)
@@ -31,11 +31,11 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * [📝 Changelog](#-changelog)
 
 ---
-## ✨ Neue Features in 1.20.0
+## ✨ Neue Features in 1.20.1
 
 |  Kategorie                 |  Beschreibung |
 | -------------------------- | ----------------------------------------------- |
-| **Gemeinsame Funktion**    | `waitForDubbing()` überwacht den Dub-Status und wird nun überall genutzt. |
+| **Konstante API**          | Alle API-Aufrufe nutzen nun die zentrale Variable `API`. |
 
 
 ## ✨ Neue Features in 1.19.4
@@ -508,10 +508,10 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.20.0 (aktuell)
+### 1.20.1 (aktuell)
 
 **✨ Neue Features:**
-* Gemeinsame Funktion `waitForDubbing()` ersetzt doppelte Polling-Schleifen.
+* Alle API-Aufrufe nutzen nun die Variable `API`.
 ### 1.19.4
 
 **✨ Neue Features:**
@@ -806,7 +806,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 1.20.0 - Gemeinsame waitForDubbing-Funktion
+**Version 1.20.1 - Zentrale API-Konstante
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/elevenlabs.js
+++ b/elevenlabs.js
@@ -1,5 +1,8 @@
 const fs = require('fs');
 
+// Basis-URL der API
+const API = 'https://api.elevenlabs.io/v1';
+
 // =========================== CREATEDUBBING START ===========================
 /**
  * Startet einen Dubbing-Auftrag bei ElevenLabs und gibt die Antwort zurueck.
@@ -24,7 +27,7 @@ async function createDubbing(apiKey, audioPath, targetLang = 'de', voiceSettings
         form.append('voice_settings', JSON.stringify(voiceSettings));
     }
 
-    const response = await fetch('https://api.elevenlabs.io/v1/dubbing', {
+    const response = await fetch(`${API}/dubbing`, {
         method: 'POST',
         headers: { 'xi-api-key': apiKey },
         body: form
@@ -45,7 +48,7 @@ async function createDubbing(apiKey, audioPath, targetLang = 'de', voiceSettings
  * @returns {Promise<object>} Status-Objekt der API.
  */
 async function getDubbingStatus(apiKey, dubbingId) {
-    const response = await fetch(`https://api.elevenlabs.io/v1/dubbing/${dubbingId}`, {
+    const response = await fetch(`${API}/dubbing/${dubbingId}`, {
         headers: { 'xi-api-key': apiKey }
     });
 
@@ -98,7 +101,7 @@ async function downloadDubbingAudio(apiKey, dubbingId, lang = 'de', targetPath) 
     let errText = '';
 
     for (let attempt = 0; attempt < 4; attempt++) {
-        response = await fetch(`https://api.elevenlabs.io/v1/dubbing/${dubbingId}/audio/${lang}`, {
+        response = await fetch(`${API}/dubbing/${dubbingId}/audio/${lang}`, {
             headers: { 'xi-api-key': apiKey }
         });
 
@@ -125,7 +128,7 @@ async function downloadDubbingAudio(apiKey, dubbingId, lang = 'de', targetPath) 
  * @returns {Promise<object>} Einstellungen der API als Objekt.
  */
 async function getDefaultVoiceSettings(apiKey) {
-    const response = await fetch('https://api.elevenlabs.io/v1/voices/settings/default', {
+    const response = await fetch(`${API}/voices/settings/default`, {
         headers: { 'xi-api-key': apiKey }
     });
 
@@ -141,7 +144,7 @@ async function getDefaultVoiceSettings(apiKey) {
 // Vertont alle Segmente eines Projekts im Studio-Workflow
 async function dubSegments(apiKey, resourceId, languages = ['de']) {
     // Zuerst die vorhandenen Segment-IDs abfragen
-    const infoRes = await fetch(`https://api.elevenlabs.io/v1/dubbing/resource/${resourceId}`, {
+    const infoRes = await fetch(`${API}/dubbing/resource/${resourceId}`, {
         headers: { 'xi-api-key': apiKey }
     });
     if (!infoRes.ok) {
@@ -151,7 +154,7 @@ async function dubSegments(apiKey, resourceId, languages = ['de']) {
     const segIds = Object.keys(info.speaker_segments || {});
 
     // Anschließend alle Segmente in den gewählten Sprachen vertonen
-    const res = await fetch(`https://api.elevenlabs.io/v1/dubbing/resource/${resourceId}/dub`, {
+    const res = await fetch(`${API}/dubbing/resource/${resourceId}/dub`, {
         method: 'POST',
         headers: {
             'xi-api-key': apiKey,
@@ -169,7 +172,7 @@ async function dubSegments(apiKey, resourceId, languages = ['de']) {
 // =========================== RENDERRESOURCE START ========================
 // Rendert die komplette Audiodatei fuer eine Sprache
 async function renderDubbingResource(apiKey, resourceId, lang = 'de', type = 'mp3') {
-    const res = await fetch(`https://api.elevenlabs.io/v1/dubbing/resource/${resourceId}/render/${lang}`, {
+    const res = await fetch(`${API}/dubbing/resource/${resourceId}/render/${lang}`, {
         method: 'POST',
         headers: { 'xi-api-key': apiKey, 'Content-Type': 'application/json' },
         body: JSON.stringify({ render_type: type })
@@ -184,7 +187,7 @@ async function renderDubbingResource(apiKey, resourceId, lang = 'de', type = 'mp
 // =========================== GETRESOURCE START ===========================
 // Liefert den aktuellen Status eines Dubbing-Resources
 async function getDubbingResource(apiKey, resourceId) {
-    const res = await fetch(`https://api.elevenlabs.io/v1/dubbing/resource/${resourceId}`, {
+    const res = await fetch(`${API}/dubbing/resource/${resourceId}`, {
         headers: { 'xi-api-key': apiKey }
     });
     if (!res.ok) {

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.20.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.20.1</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.20.0",
+      "version": "1.20.1",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",
@@ -3228,7 +3228,7 @@
         "jest-pnp-resolver": "^1.2.2",
         "jest-util": "^29.7.0",
         "jest-validate": "^29.7.0",
-        "resolve": "^1.20.0",
+        "resolve": "^1.20.1",
         "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,9 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.20.0';
+const APP_VERSION = '1.20.1';
+// Basis-URL der API
+const API = 'https://api.elevenlabs.io/v1';
 
 // =========================== GLOBAL STATE END ===========================
 
@@ -5333,7 +5335,7 @@ function checkFileAccess() {
             const status = document.getElementById('apiKeyStatus');
             status.textContent = '⏳';
             try {
-                const res = await fetch('https://api.elevenlabs.io/v1/voices', {
+                const res = await fetch(`${API}/voices`, {
                     headers: { 'xi-api-key': document.getElementById('apiKeyInput').value.trim() }
                 });
                 if (!res.ok) throw new Error('Fehler');
@@ -5384,7 +5386,7 @@ function checkFileAccess() {
                 const id = sel.value.trim();
                 if (!id) continue;
                 try {
-                    const res = await fetch(`https://api.elevenlabs.io/v1/voices/${id}`, {
+                    const res = await fetch(`${API}/voices/${id}`, {
                         headers: { 'xi-api-key': elevenLabsApiKey }
                     });
                     if (!res.ok) throw new Error('Fehler');
@@ -5412,7 +5414,7 @@ function checkFileAccess() {
             const id = document.getElementById('newVoiceId').value.trim();
             if (!id || !elevenLabsApiKey) return;
             try {
-                const res = await fetch(`https://api.elevenlabs.io/v1/voices/${id}`, {
+                const res = await fetch(`${API}/voices/${id}`, {
                     headers: { 'xi-api-key': elevenLabsApiKey }
                 });
                 if (res.ok) {
@@ -5428,7 +5430,7 @@ function checkFileAccess() {
             const nameInput = item.querySelector('.custom-voice-name');
             if (!id || !elevenLabsApiKey) return;
             try {
-                const res = await fetch(`https://api.elevenlabs.io/v1/voices/${id}`, {
+                const res = await fetch(`${API}/voices/${id}`, {
                     headers: { 'xi-api-key': elevenLabsApiKey }
                 });
                 if (res.ok) {
@@ -5444,7 +5446,7 @@ function checkFileAccess() {
             if (!id) return;
             if (!name && elevenLabsApiKey) {
                 try {
-                    const res = await fetch(`https://api.elevenlabs.io/v1/voices/${id}`, {
+                    const res = await fetch(`${API}/voices/${id}`, {
                         headers: { 'xi-api-key': elevenLabsApiKey }
                     });
                     if (res.ok) {
@@ -6218,7 +6220,7 @@ function proceedNewDubbing(fileId) {
 
 // =========================== SHOWDUBBINGSETTINGS START ======================
 async function getDefaultVoiceSettings(apiKey) {
-    const res = await fetch('https://api.elevenlabs.io/v1/voices/settings/default', {
+    const res = await fetch(`${API}/voices/settings/default`, {
         headers: { 'xi-api-key': apiKey }
     });
     if (!res.ok) throw new Error('Fehler beim Abrufen der Default-Settings');
@@ -6372,7 +6374,7 @@ async function waitForDubbing(apiKey, dubbingId, lang = 'de', timeout = 180) {
     for (let i = 0; i < maxLoops; i++) {
         await new Promise(r => setTimeout(r, 3000));
         try {
-            const st = await fetch(`https://api.elevenlabs.io/v1/dubbing/${dubbingId}`, {
+            const st = await fetch(`${API}/dubbing/${dubbingId}`, {
                 headers: { 'xi-api-key': apiKey }
             });
             if (st.ok) {
@@ -6483,7 +6485,7 @@ async function startDubbing(fileId, settings = {}, targetLang = 'de') {
 
     let res;
     try {
-        res = await fetch('https://api.elevenlabs.io/v1/dubbing', {
+        res = await fetch(`${API}/dubbing`, {
             method: 'POST',
             headers: { 'xi-api-key': elevenLabsApiKey },
             body: form
@@ -6540,7 +6542,7 @@ async function startDubbing(fileId, settings = {}, targetLang = 'de') {
     let errText = '';
     for (let attempt = 0; attempt < 4; attempt++) {
         try {
-            audioRes = await fetch(`https://api.elevenlabs.io/v1/dubbing/${id}/audio/${targetLang}`, {
+            audioRes = await fetch(`${API}/dubbing/${id}/audio/${targetLang}`, {
                 headers: { 'xi-api-key': elevenLabsApiKey }
             });
             if (audioRes.ok) break;
@@ -6602,7 +6604,7 @@ async function redownloadDubbing(fileId) {
     let errText = '';
     for (let attempt = 0; attempt < 4; attempt++) {
         try {
-            audioRes = await fetch(`https://api.elevenlabs.io/v1/dubbing/${file.dubbingId}/audio/de`, {
+            audioRes = await fetch(`${API}/dubbing/${file.dubbingId}/audio/de`, {
                 headers: { 'xi-api-key': elevenLabsApiKey }
             });
             if (audioRes.ok) break;

--- a/tests/manualDub.test.js
+++ b/tests/manualDub.test.js
@@ -1,7 +1,7 @@
 const nock = require('nock');
 
 // Basis-URL der API
-const API = 'https://api.elevenlabs.io';
+const API = 'https://api.elevenlabs.io/v1';
 
 afterEach(() => {
     nock.cleanAll();
@@ -42,7 +42,7 @@ beforeEach(() => {
 describe('Manual Dub', () => {
     test('csv_file und voice_id werden übermittelt', async () => {
         const scope = nock(API)
-            .post('/v1/dubbing', body => {
+            .post('/dubbing', body => {
                 const str = body.toString();
                 return str.includes('name="csv_file"') &&
                        str.includes('name="mode"') &&
@@ -61,14 +61,14 @@ describe('Manual Dub', () => {
         form.append('csv_file', new File(['speaker,start,end,text,text'], 'input.csv'));
         form.append('voice_id', 'abc123');
 
-        await fetch(`${API}/v1/dubbing`, { method: 'POST', body: form });
+        await fetch(`${API}/dubbing`, { method: 'POST', body: form });
 
         expect(scope.isDone()).toBe(true);
     });
 
     test('voice_id ist optional', async () => {
         const scope = nock(API)
-            .post('/v1/dubbing', body => {
+            .post('/dubbing', body => {
                 const str = body.toString();
                 return str.includes('name="csv_file"') &&
                        str.includes('name="mode"') &&
@@ -86,7 +86,7 @@ describe('Manual Dub', () => {
         form.append('dubbing_studio', 'true');
         form.append('csv_file', new File(['speaker,start,end,text,text'], 'input.csv'));
 
-        await fetch(`${API}/v1/dubbing`, { method: 'POST', body: form });
+        await fetch(`${API}/dubbing`, { method: 'POST', body: form });
 
         expect(scope.isDone()).toBe(true);
     });


### PR DESCRIPTION
## Summary
- zentrale API-Konstante `API` in JS-Dateien
- Endpunkte nutzen nun `${API}` statt festen Links
- Tests passen sich an die neue URL an
- Dokumentation und Version auf **1.20.1** aktualisiert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bc90533cc8327ab1023af0fd5882b