### PR TITLE
Bugfix: Fehlerdetails anzeigen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.20.1-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.20.2-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -11,6 +11,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ---
 
 ## 📋 Inhaltsverzeichnis
+* [✨ Neue Features in 1.20.2](#-neue-features-in-1.20.2)
 * [✨ Neue Features in 1.20.1](#-neue-features-in-1.20.1)
 * [✨ Neue Features in 1.19.4](#-neue-features-in-1.19.4)
 * [✨ Neue Features in 1.19.2](#-neue-features-in-1.19.2)
@@ -31,6 +32,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * [📝 Changelog](#-changelog)
 
 ---
+## ✨ Neue Features in 1.20.2
+
+|  Kategorie                 |  Beschreibung |
+| -------------------------- | ----------------------------------------------- |
+| **Fehler-Protokoll**       | Detaillierte Meldungen aus `detail.message` und `error` werden angezeigt. |
+
 ## ✨ Neue Features in 1.20.1
 
 |  Kategorie                 |  Beschreibung |
@@ -301,6 +308,7 @@ speaker,start_time,end_time,transcription,translation
 
 Nach jedem Start eines Dubbing-Vorgangs öffnet sich automatisch das Fenster **Dubbing-Protokoll**. Dort sind jetzt ausführliche Fehlermeldungen sichtbar, inklusive HTTP-Code und Server-Antwort. Das Protokoll lässt sich jederzeit über den Schließen-Button beenden oder kopieren.
 Bei einem Upload-Fehler mit Status 400 wird zusätzlich ein Ausschnitt der erzeugten CSV angezeigt. So lässt sich schnell prüfen, ob die Daten korrekt formatiert sind.
+Ab Version 1.20.2 protokolliert das Fenster zudem `detail.message` und `error` aus der Server-Antwort.
 
 ### Version aktualisieren
 
@@ -508,7 +516,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.20.1 (aktuell)
+### 1.20.2 (aktuell)
+
+**✨ Neue Features:**
+* Fehlermeldungen aus `detail.message` und `error` im Dubbing-Protokoll
+
+### 1.20.1
 
 **✨ Neue Features:**
 * Alle API-Aufrufe nutzen nun die Variable `API`.
@@ -806,7 +819,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 1.20.1 - Zentrale API-Konstante
+**Version 1.20.2 - Zentrale API-Konstante
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/elevenlabs.js
+++ b/elevenlabs.js
@@ -74,7 +74,8 @@ async function waitForDubbing(apiKey, dubbingId, lang = 'de', timeout = 180) {
         const langInfo = info.progress && info.progress.langs && info.progress.langs[lang];
         const finished = langInfo && (langInfo.state === 'finished' || langInfo.progress === 100);
         if (status === 'failed') {
-            throw new Error('Dubbing fehlgeschlagen: ' + (info.error || 'unknown'));
+            const reason = info.detail?.message || info.error || 'Server meldet failed';
+            throw new Error('Dubbing fehlgeschlagen: ' + reason);
         }
         if (status === 'dubbed' && finished) return;
         await new Promise(r => setTimeout(r, 3000));

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.20.1</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.20.2</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.20.1",
+      "version": "1.20.2",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",
@@ -3228,7 +3228,7 @@
         "jest-pnp-resolver": "^1.2.2",
         "jest-util": "^29.7.0",
         "jest-validate": "^29.7.0",
-        "resolve": "^1.20.1",
+        "resolve": "^1.20.2",
         "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.20.1';
+const APP_VERSION = '1.20.2';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 
@@ -6387,7 +6387,8 @@ async function waitForDubbing(apiKey, dubbingId, lang = 'de', timeout = 180) {
                 if (typeof addDubbingLog === 'function') addDubbingLog('Polling: ' + status);
                 if (status === 'dubbed' && langDone) return;
                 if (status === 'failed') {
-                    throw new Error(js.error || 'Server meldet failed');
+                    const reason = js.detail?.message || js.error || 'Server meldet failed';
+                    throw new Error(reason);
                 }
             }
         } catch (e) {
@@ -6558,8 +6559,13 @@ async function startDubbing(fileId, settings = {}, targetLang = 'de') {
         }
     }
     if (!audioRes || !audioRes.ok) {
+        let reason = errText;
+        try {
+            const js = JSON.parse(errText);
+            reason = js.detail?.message || js.error || reason;
+        } catch {}
         updateStatus('Download fehlgeschlagen');
-        addDubbingLog(`Endgültig fehlgeschlagen: ${errText}`);
+        addDubbingLog(`Endgültig fehlgeschlagen: ${reason}`);
         return;
     }
     const dubbedBlob = await audioRes.blob();
@@ -6621,8 +6627,13 @@ async function redownloadDubbing(fileId) {
     }
 
     if (!audioRes || !audioRes.ok) {
+        let reason = errText;
+        try {
+            const js = JSON.parse(errText);
+            reason = js.detail?.message || js.error || reason;
+        } catch {}
         updateStatus('Download fehlgeschlagen');
-        addDubbingLog(`Endgültig fehlgeschlagen: ${errText}`);
+        addDubbingLog(`Endgültig fehlgeschlagen: ${reason}`);
         return;
     }
     const dubbedBlob = await audioRes.blob();


### PR DESCRIPTION
## Summary
- Fehlernachrichten aus der API genauer auslesen
- Download-Fehler geben jetzt detail.message oder error aus
- Hinweis zum erweiterten Fehlerprotokoll im README
- Versionsnummer auf 1.20.2 angehoben

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bca83a1288327a421cb61ab1e88a4