### PR TITLE
Update waitForDubbing and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.20.2-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.20.3-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -11,6 +11,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ---
 
 ## 📋 Inhaltsverzeichnis
+* [✨ Neue Features in 1.20.3](#-neue-features-in-1.20.3)
 * [✨ Neue Features in 1.20.2](#-neue-features-in-1.20.2)
 * [✨ Neue Features in 1.20.1](#-neue-features-in-1.20.1)
 * [✨ Neue Features in 1.19.4](#-neue-features-in-1.19.4)
@@ -32,6 +33,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * [📝 Changelog](#-changelog)
 
 ---
+## ✨ Neue Features in 1.20.3
+
+|  Kategorie                 |  Beschreibung |
+| -------------------------- | ----------------------------------------------- |
+| **Polling vereinfacht**    | `waitForDubbing` prüft nur noch `status` und ignoriert `progress`. |
+
 ## ✨ Neue Features in 1.20.2
 
 |  Kategorie                 |  Beschreibung |
@@ -296,6 +303,8 @@ Ab Version 1.10.3 wird beim Dubbing der selbst eingetragene deutsche Text genutz
 
 Bis Version 1.19.1 nutzte das Tool den Studio-Workflow über `resource/dub` und `resource/render`. Ab Version 1.19.2 erfolgt das Dubbing ausschließlich über die Standard-Endpunkte: Nach `POST /v1/dubbing` wird regelmäßig `GET /v1/dubbing/<ID>` aufgerufen und das Ergebnis anschließend via `GET /v1/dubbing/<ID>/audio/<sprache>` heruntergeladen.
 
+Ab Version 1.20.3 wertet `waitForDubbing` nur noch `status` aus. Angaben in `progress.langs` oder `state` werden ignoriert.
+
 Beispiel einer gültigen CSV:
 
 ```csv
@@ -516,7 +525,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.20.2 (aktuell)
+### 1.20.3 (aktuell)
+
+**✨ Neue Features:**
+* `waitForDubbing` nutzt nur noch `status`
+
+### 1.20.2
 
 **✨ Neue Features:**
 * Fehlermeldungen aus `detail.message` und `error` im Dubbing-Protokoll
@@ -819,7 +833,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 1.20.2 - Zentrale API-Konstante
+**Version 1.20.3 - Zentrale API-Konstante
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/elevenlabs.js
+++ b/elevenlabs.js
@@ -71,13 +71,11 @@ async function waitForDubbing(apiKey, dubbingId, lang = 'de', timeout = 180) {
     while (Date.now() - start < timeout * 1000) {
         const info = await getDubbingStatus(apiKey, dubbingId);
         const status = info.status;
-        const langInfo = info.progress && info.progress.langs && info.progress.langs[lang];
-        const finished = langInfo && (langInfo.state === 'finished' || langInfo.progress === 100);
         if (status === 'failed') {
             const reason = info.detail?.message || info.error || 'Server meldet failed';
             throw new Error('Dubbing fehlgeschlagen: ' + reason);
         }
-        if (status === 'dubbed' && finished) return;
+        if (status === 'dubbed') return;
         await new Promise(r => setTimeout(r, 3000));
     }
     throw new Error('Dubbing nicht fertig');

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.20.2</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.20.3</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.20.2",
+      "version": "1.20.3",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.20.2';
+const APP_VERSION = '1.20.3';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 
@@ -6369,7 +6369,6 @@ function validateCsv(csvText) {
 // festgelegt werden. Ohne Erfolg wird ein Fehler geworfen.
 async function waitForDubbing(apiKey, dubbingId, lang = 'de', timeout = 180) {
     let status = '';
-    let langDone = false;
     const maxLoops = Math.ceil(timeout / 3);
     for (let i = 0; i < maxLoops; i++) {
         await new Promise(r => setTimeout(r, 3000));
@@ -6380,12 +6379,8 @@ async function waitForDubbing(apiKey, dubbingId, lang = 'de', timeout = 180) {
             if (st.ok) {
                 const js = await st.json();
                 status = js.status;
-                const langInfo = js.progress && js.progress.langs && js.progress.langs[lang];
-                if (langInfo) {
-                    langDone = langInfo.state === 'finished' || langInfo.progress === 100;
-                }
                 if (typeof addDubbingLog === 'function') addDubbingLog('Polling: ' + status);
-                if (status === 'dubbed' && langDone) return;
+                if (status === 'dubbed') return;
                 if (status === 'failed') {
                     const reason = js.detail?.message || js.error || 'Server meldet failed';
                     throw new Error(reason);

--- a/tests/elevenlabs.test.js
+++ b/tests/elevenlabs.test.js
@@ -166,7 +166,7 @@ describe('ElevenLabs API', () => {
     test('waitForDubbing beendet sich bei Erfolg', async () => {
         nock(API)
             .get('/dubbing/success')
-            .reply(200, { status: 'dubbed', progress: { langs: { de: { state: 'finished' } } } });
+            .reply(200, { status: 'dubbed' });
 
         await expect(waitForDubbing('key', 'success', 'de', 3)).resolves.toBeUndefined();
     });


### PR DESCRIPTION
## Summary
- vereinfachte Logik von `waitForDubbing` in `src/main.js` und `elevenlabs.js`
- angepasste Tests
- Dokumentation zum neuen Ablauf bei ElevenLabs-Dubbing
- Versionsnummer auf 1.20.3 erhöht

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bce36d024832794bcb6a1a6c55116