### PR TITLE
Add language option for cliRedownload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.21.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.22.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -11,6 +11,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ---
 
 ## 📋 Inhaltsverzeichnis
+* [✨ Neue Features in 1.22.0](#-neue-features-in-1.22.0)
 * [✨ Neue Features in 1.21.0](#-neue-features-in-1.21.0)
 * [✨ Neue Features in 1.20.3](#-neue-features-in-1.20.3)
 * [✨ Neue Features in 1.20.2](#-neue-features-in-1.20.2)
@@ -34,6 +35,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * [📝 Changelog](#-changelog)
 
 ---
+## ✨ Neue Features in 1.22.0
+
+|  Kategorie                 |  Beschreibung |
+| -------------------------- | ----------------------------------------------- |
+| **CLI-Update**             | `cliRedownload.js` akzeptiert jetzt optional einen Sprachparameter. |
+
 ## ✨ Neue Features in 1.21.0
 
 |  Kategorie                 |  Beschreibung |
@@ -299,7 +306,7 @@ Für diesen Zweck gibt es das Node-Skript `cliRedownload.js`.
 Es wird so aufgerufen:
 
 ```bash
-node cliRedownload.js <API-Key> <Dubbing-ID> <Ausgabedatei>
+node cliRedownload.js <API-Key> <Dubbing-ID> <Ausgabedatei> [Sprache]
 ```
 
 Intern nutzt es `downloadDubbingAudio()` aus `elevenlabs.js`.
@@ -532,7 +539,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.21.0 (aktuell)
+### 1.22.0 (aktuell)
+
+**✨ Neue Features:**
+* `cliRedownload.js` nimmt optional eine Sprache entgegen.
+
+### 1.21.0
 
 **✨ Neue Features:**
 * `waitForDubbing` liegt jetzt in `elevenlabs.js` und wird überall genutzt.
@@ -845,7 +857,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 1.21.0 - Zentrale API-Konstante
+**Version 1.22.0 - CLI erweitert
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/cliRedownload.js
+++ b/cliRedownload.js
@@ -4,17 +4,19 @@
 
 const { downloadDubbingAudio } = require('./elevenlabs');
 
-// Parameter auslesen: node cliRedownload.js API-KEY DUBBING-ID AUSGABEDATEI
-const [,, apiKey, dubbingId, outFile] = process.argv;
+// Parameter auslesen: node cliRedownload.js API-KEY DUBBING-ID AUSGABEDATEI [SPRACHE]
+const [,, apiKey, dubbingId, outFile, lang = 'de'] = process.argv;
 
+// Mindestens drei Parameter muessen vorhanden sein
 if (!apiKey || !dubbingId || !outFile) {
-    console.log('Aufruf: node cliRedownload.js <API-Key> <Dubbing-ID> <Ausgabedatei>');
+    console.log('Aufruf: node cliRedownload.js <API-Key> <Dubbing-ID> <Ausgabedatei> [Sprache]');
     process.exit(1);
 }
 
 (async () => {
     try {
-        await downloadDubbingAudio(apiKey, dubbingId, 'de', outFile);
+        // Gewuenschte Sprache an downloadDubbingAudio weiterreichen
+        await downloadDubbingAudio(apiKey, dubbingId, lang, outFile);
         console.log('Download abgeschlossen:', outFile);
     } catch (err) {
         console.error('Fehler:', err.message);

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.21.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.22.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.21.0';
+const APP_VERSION = '1.22.0';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 


### PR DESCRIPTION
## Summary
- let `cliRedownload.js` übernehmen optional die Sprache
- dokumentiere die Option im `README`
- erhöhe die Version auf 1.22.0

## Testing
- `npm run update-version`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bd118e5dc832787b730b53e770632