### PR TITLE
Fix dubbing timeout hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.22.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.22.1-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -11,6 +11,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ---
 
 ## 📋 Inhaltsverzeichnis
+* [✨ Neue Features in 1.22.1](#-neue-features-in-1.22.1)
 * [✨ Neue Features in 1.22.0](#-neue-features-in-1.22.0)
 * [✨ Neue Features in 1.21.0](#-neue-features-in-1.21.0)
 * [✨ Neue Features in 1.20.3](#-neue-features-in-1.20.3)
@@ -35,6 +36,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * [📝 Changelog](#-changelog)
 
 ---
+## ✨ Neue Features in 1.22.1
+
+|  Kategorie                 |  Beschreibung |
+| -------------------------- | ----------------------------------------------- |
+| **Hinweis bei Timeout**    | `waitForDubbing` meldet jetzt "target_lang nicht gesetzt?" wenn die Sprache fehlt. |
+
 ## ✨ Neue Features in 1.22.0
 
 |  Kategorie                 |  Beschreibung |
@@ -517,6 +524,9 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 * ▶ **Ursache:** Die gewählte Sprachspur wurde noch nicht erzeugt.
 * ▶ **Lösung:** Beim Anlegen `target_lang:"<sprache>"` setzen und Datei unter `/audio/<sprache>` abrufen.
 
+**❓ target_lang nicht gesetzt?**
+* ▶ **Hinweis:** Diese Meldung erscheint, wenn `waitForDubbing` im Fortschritt keine Zielsprache findet.
+
 
 **🔄 Duplikate in Datenbank**
 * ▶ **Lösung:** „🧹 Duplikate bereinigen" verwenden
@@ -539,7 +549,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.22.0 (aktuell)
+### 1.22.1 (aktuell)
+
+**✨ Neue Features:**
+* waitForDubbing meldet bei fehlender Sprache "target_lang nicht gesetzt?"
+
+### 1.22.0
 
 **✨ Neue Features:**
 * `cliRedownload.js` nimmt optional eine Sprache entgegen.
@@ -857,7 +872,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 1.22.0 - CLI erweitert
+**Version 1.22.1 - Hinweis bei Timeout
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/elevenlabs.js
+++ b/elevenlabs.js
@@ -68,8 +68,9 @@ async function getDubbingStatus(apiKey, dubbingId) {
  */
 async function waitForDubbing(apiKey, dubbingId, lang = 'de', timeout = 180) {
     const start = Date.now();
+    let info = null; // Letzte Status-Info merken
     while (Date.now() - start < timeout * 1000) {
-        const info = await getDubbingStatus(apiKey, dubbingId);
+        info = await getDubbingStatus(apiKey, dubbingId);
         const status = info.status;
         if (status === 'failed') {
             const reason = info.detail?.message || info.error || 'Server meldet failed';
@@ -77,6 +78,10 @@ async function waitForDubbing(apiKey, dubbingId, lang = 'de', timeout = 180) {
         }
         if (status === 'dubbed') return;
         await new Promise(r => setTimeout(r, 3000));
+    }
+    // Falls kein Eintrag für die Sprache existiert, Hinweis ausgeben
+    if (!info?.progress?.langs || !info.progress.langs[lang]) {
+        console.error('target_lang nicht gesetzt?');
     }
     throw new Error('Dubbing nicht fertig');
 }

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.22.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.22.1</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.22.0",
+      "version": "1.22.1",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.22.0';
+const APP_VERSION = '1.22.1';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 

--- a/tests/elevenlabs.test.js
+++ b/tests/elevenlabs.test.js
@@ -186,4 +186,15 @@ describe('ElevenLabs API', () => {
 
         await expect(waitForDubbing('key', 'slow', 'de', 3)).rejects.toThrow('Dubbing nicht fertig');
     });
+
+    test('waitForDubbing meldet fehlendes target_lang', async () => {
+        nock(API)
+            .get('/dubbing/nolang')
+            .reply(200, { status: 'dubbing', progress: {} });
+
+        const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        await expect(waitForDubbing('key', 'nolang', 'de', 3)).rejects.toThrow('Dubbing nicht fertig');
+        expect(errSpy).toHaveBeenCalledWith('target_lang nicht gesetzt?');
+        errSpy.mockRestore();
+    });
 });


### PR DESCRIPTION
## Summary
- warn if `waitForDubbing` ends without target language
- document new warning in README
- bump version to 1.22.1
- add regression test for the warning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bd1fb3d608327a399fb95239b8403