### PR TITLE
Fix ElevenLabs language params and update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.22.6-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.22.7-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -11,6 +11,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ---
 
 ## 📋 Inhaltsverzeichnis
+* [✨ Neue Features in 1.22.7](#-neue-features-in-1.22.7)
 * [✨ Neue Features in 1.22.6](#-neue-features-in-1.22.6)
 * [✨ Neue Features in 1.22.5](#-neue-features-in-1.22.5)
 * [✨ Neue Features in 1.22.4](#-neue-features-in-1.22.4)
@@ -40,6 +41,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * [📝 Changelog](#-changelog)
 
 ---
+## ✨ Neue Features in 1.22.7
+
+| Kategorie | Beschreibung |
+| ---------- | ------------- |
+| **Deutsches Dubbing** | `target_lang` und `target_languages` sind nun immer `de`. |
+
 ## ✨ Neue Features in 1.22.6
 
 | Kategorie | Beschreibung |
@@ -316,11 +323,14 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ```javascript
 const { createDubbing, getDubbingStatus, downloadDubbingAudio } = require('./elevenlabs.js');
 const apiKey = process.env.ELEVEN_API_KEY;
-const job = await createDubbing(apiKey, 'sounds/EN/beispiel.wav', 'fr', {
-    speed: 1.2
+const job = await createDubbing({
+    audioFile: 'sounds/EN/beispiel.wav',
+    csvContent: csvData,
+    voiceId: '',
+    apiKey
 });
 const status = await getDubbingStatus(apiKey, job.dubbing_id);
-await downloadDubbingAudio(apiKey, job.dubbing_id, 'fr', 'sounds/FR/beispiel_fr.mp3');
+await downloadDubbingAudio(apiKey, job.dubbing_id, 'de', 'sounds/DE/beispiel_de.mp3');
 ```
 
 Ein Klick auf **Dubbing** öffnet zunächst ein Einstellungsfenster. Dort lassen sich folgende Parameter anpassen:
@@ -579,7 +589,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.22.6 (aktuell)
+### 1.22.7 (aktuell)
+
+**✨ Neue Features:**
+* `target_lang` ist immer `de` und `disable_voice_cloning` wird ohne Voice-ID gesetzt.
+
+### 1.22.6
 
 **✨ Neue Features:**
 * `.env.local` speichert den API-Schlüssel.
@@ -923,7 +938,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 1.22.6 - Deutsches Dubbing ohne Voice-ID
+**Version 1.22.7 - Deutsches Dubbing ohne Voice-ID
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/elevenlabs.js
+++ b/elevenlabs.js
@@ -8,11 +8,13 @@ const API = 'https://api.elevenlabs.io/v1';
  * Startet einen Dubbing-Auftrag bei ElevenLabs und gibt die Antwort zurueck.
  * @param {string} apiKey - Eigener API-Schluessel.
  * @param {string} audioPath - Pfad zur englischen Audiodatei.
- * @param {string} [targetLang='de'] - Ziel-Sprache fuer das Dubbing.
- * @param {object} [voiceSettings=null] - Optionale Voice-Settings.
+ * @param {string} [voiceId=''] - Optionale Stimme.
+ *
+ * `target_lang` und `target_languages` werden immer auf `de` gesetzt.
  * @returns {Promise<object>} Antwort der API als Objekt.
  */
-async function createDubbing({ audioFile, csvContent, targetLang = 'de', voiceId = '', apiKey }) {
+// Erstellt einen Dubbing-Job bei ElevenLabs
+async function createDubbing({ audioFile, csvContent, voiceId = '', apiKey }) {
     if (!fs.existsSync(audioFile)) {
         throw new Error('Audio-Datei nicht gefunden: ' + audioFile);
     }
@@ -20,8 +22,9 @@ async function createDubbing({ audioFile, csvContent, targetLang = 'de', voiceId
     const form = new FormData();
     form.append('file', fs.createReadStream(audioFile));
     form.append('csv_file', new Blob([csvContent], { type: 'text/csv' }), 'script.csv');
-    form.append('target_lang', targetLang);
-    form.append('target_languages', JSON.stringify([targetLang]));
+    const lang = 'de';
+    form.append('target_lang', lang);
+    form.append('target_languages', JSON.stringify([lang]));
     form.append('mode', 'manual');
     form.append('dubbing_studio', 'true');
 

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.22.6</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.22.7</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.22.6",
+  "version": "1.22.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.22.6",
+      "version": "1.22.7",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.22.6",
+  "version": "1.22.7",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/elevenlabs.js
+++ b/src/elevenlabs.js
@@ -2,10 +2,10 @@ const API = 'https://api.elevenlabs.io/v1';
 const WAIT_INTERVAL_MS = 5000;
 
 // Erstellt ein Dubbing-Projekt bei ElevenLabs
+// target_lang und target_languages sind fest auf "de" gesetzt
 export async function createDubbing({
     audioFile,
     csvContent,
-    targetLang = 'de',
     voiceId = '',
     apiKey
 }) {
@@ -13,8 +13,9 @@ export async function createDubbing({
 
     form.append('file', audioFile);
     form.append('csv_file', new Blob([csvContent], { type: 'text/csv' }), 'script.csv');
-    form.append('target_lang', targetLang);
-    form.append('target_languages', JSON.stringify([targetLang]));
+    const lang = 'de';
+    form.append('target_lang', lang);
+    form.append('target_languages', JSON.stringify([lang]));
     form.append('mode', 'manual');
     form.append('dubbing_studio', 'true');
 

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.22.6';
+const APP_VERSION = '1.22.7';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 

--- a/tests/elevenlabs.test.js
+++ b/tests/elevenlabs.test.js
@@ -28,16 +28,34 @@ afterEach(() => {
 describe('ElevenLabs API', () => {
     test('erfolgreicher Dubbing-Auftrag ohne Voice-ID', async () => {
         nock(API)
-            .post('/dubbing', body => body.includes('disable_voice_cloning'))
+            .post('/dubbing', body => body.includes('disable_voice_cloning') &&
+                                     body.includes('name="target_lang"') &&
+                                     body.includes('de') &&
+                                     !body.includes('fr'))
             .reply(200, { dubbing_id: '123', expected_duration_sec: 1 });
 
         const result = await createDubbing({
             audioFile: tempAudio,
             csvContent: 'speaker,start_time,end_time,transcription,translation\n',
-            targetLang: 'de',
+            targetLang: 'fr',
             apiKey: 'key'
         });
         expect(result).toEqual({ dubbing_id: '123', expected_duration_sec: 1 });
+    });
+
+    test('Dubbing mit Voice-ID übermittelt voice_id', async () => {
+        nock(API)
+            .post('/dubbing', body => body.includes('voice_id') &&
+                                     !body.includes('disable_voice_cloning'))
+            .reply(200, { dubbing_id: '124', expected_duration_sec: 1 });
+
+        const result = await createDubbing({
+            audioFile: tempAudio,
+            csvContent: 'speaker,start_time,end_time,transcription,translation\n',
+            voiceId: 'abc',
+            apiKey: 'key'
+        });
+        expect(result).toEqual({ dubbing_id: '124', expected_duration_sec: 1 });
     });
 
     test('fehlerhafte Antwort bei createDubbing', async () => {


### PR DESCRIPTION
## Summary
- elevenlabs API wrapper always sends `target_lang` and `target_languages` as `de`
- attach `voice_id` only when given and otherwise disable voice cloning
- adjust tests for these changes
- bump version to 1.22.7 and document new feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684be96e1870832787bc352ee77465d9