### PR TITLE
Add renderLanguage API helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.22.7-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.22.8-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -11,6 +11,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ---
 
 ## 📋 Inhaltsverzeichnis
+* [✨ Neue Features in 1.22.8](#-neue-features-in-1.22.8)
 * [✨ Neue Features in 1.22.7](#-neue-features-in-1.22.7)
 * [✨ Neue Features in 1.22.6](#-neue-features-in-1.22.6)
 * [✨ Neue Features in 1.22.5](#-neue-features-in-1.22.5)
@@ -41,6 +42,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * [📝 Changelog](#-changelog)
 
 ---
+## ✨ Neue Features in 1.22.8
+
+| Kategorie | Beschreibung |
+| ---------- | ------------- |
+| **API** | Neue Funktion `renderLanguage` rendert eine Sprache mit gewünschtem Format. |
+
 ## ✨ Neue Features in 1.22.7
 
 | Kategorie | Beschreibung |
@@ -589,7 +596,12 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 ## 📝 Changelog
 
-### 1.22.7 (aktuell)
+### 1.22.8 (aktuell)
+
+**✨ Neue Features:**
+* Neue Funktion `renderLanguage` rendert eine Sprache in gewünschtem Format.
+
+### 1.22.7
 
 **✨ Neue Features:**
 * `target_lang` ist immer `de` und `disable_voice_cloning` wird ohne Voice-ID gesetzt.
@@ -938,7 +950,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 1.22.7 - Deutsches Dubbing ohne Voice-ID
+**Version 1.22.8 - Neue Funktion renderLanguage
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/elevenlabs.js
+++ b/elevenlabs.js
@@ -161,6 +161,26 @@ async function getDefaultVoiceSettings(apiKey) {
 }
 // =========================== GETDEFAULTVOICESETTINGS END ==================
 
+// =========================== RENDERLANGUAGE START ==========================
+// Rendert eine Sprache eines bestehenden Dubbings neu
+async function renderLanguage(dubbingId, targetLang = 'de', renderType = 'wav', apiKey) {
+    const res = await fetch(`${API}/dubbing/${dubbingId}/render/${targetLang}`, {
+        method: 'POST',
+        headers: {
+            'xi-api-key': apiKey,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ render_type: renderType })
+    });
+
+    if (!res.ok) {
+        throw new Error(`Render language failed: ${res.status} ${await res.text()}`);
+    }
+
+    return await res.json();
+}
+// =========================== RENDERLANGUAGE END ============================
+
 // =========================== DUBSEGMENTS START ============================
 // Vertont alle Segmente eines Projekts im Studio-Workflow
 async function dubSegments(apiKey, resourceId, languages = ['de']) {
@@ -241,5 +261,6 @@ module.exports = {
     getDubbingStatus,
     downloadDubbingAudio,
     getDefaultVoiceSettings,
-    waitForDubbing
+    waitForDubbing,
+    renderLanguage
 };

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.22.7</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.22.8</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.22.7",
+  "version": "1.22.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.22.7",
+      "version": "1.22.8",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.22.7",
+  "version": "1.22.8",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/elevenlabs.js
+++ b/src/elevenlabs.js
@@ -65,3 +65,21 @@ export async function downloadDubbingAudio(apiKey, id, lang = 'de') {
     if (!res.ok) throw new Error(await res.text());
     return await res.blob();
 }
+
+// Rendert eine bestimmte Sprache neu
+export async function renderLanguage(dubbingId, targetLang = 'de', renderType = 'wav', apiKey) {
+    const res = await fetch(`${API}/dubbing/${dubbingId}/render/${targetLang}`, {
+        method: 'POST',
+        headers: {
+            'xi-api-key': apiKey,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ render_type: renderType })
+    });
+
+    if (!res.ok) {
+        throw new Error(`Render language failed: ${res.status} ${await res.text()}`);
+    }
+
+    return await res.json();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -64,19 +64,20 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.22.7';
+const APP_VERSION = '1.22.8';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 
 // Gemeinsame Funktionen aus elevenlabs.js laden
-let createDubbing, waitForDubbing, downloadDubbingAudio;
+let createDubbing, waitForDubbing, downloadDubbingAudio, renderLanguage;
 if (typeof module !== 'undefined' && module.exports) {
-    ({ createDubbing, waitForDubbing, downloadDubbingAudio } = require('../elevenlabs'));
+    ({ createDubbing, waitForDubbing, downloadDubbingAudio, renderLanguage } = require('../elevenlabs'));
 } else {
     import('./elevenlabs.js').then(mod => {
         createDubbing = mod.createDubbing;
         waitForDubbing = mod.waitForDubbing;
         downloadDubbingAudio = mod.downloadDubbingAudio;
+        renderLanguage = mod.renderLanguage;
     });
 }
 

--- a/tests/elevenlabs.test.js
+++ b/tests/elevenlabs.test.js
@@ -5,7 +5,7 @@ const path = require('path');
 // Tests dürfen länger dauern, da Downloads bis zu 10 Versuche brauchen
 jest.setTimeout(30000);
 
-const { createDubbing, getDubbingStatus, downloadDubbingAudio, getDefaultVoiceSettings, waitForDubbing } = require('../elevenlabs');
+const { createDubbing, getDubbingStatus, downloadDubbingAudio, getDefaultVoiceSettings, waitForDubbing, renderLanguage } = require('../elevenlabs');
 
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
@@ -222,5 +222,22 @@ describe('ElevenLabs API', () => {
         await expect(waitForDubbing('key', 'nolang', 'de', 3)).rejects.toThrow('Dubbing nicht fertig');
         expect(errSpy).toHaveBeenCalledWith('target_lang nicht gesetzt?');
         errSpy.mockRestore();
+    });
+
+    test('renderLanguage ruft korrektes Endpoint auf', async () => {
+        nock(API)
+            .post('/dubbing/321/render/de', { render_type: 'wav' })
+            .reply(200, { task_id: 'abc' });
+
+        const res = await renderLanguage('321', 'de', 'wav', 'key');
+        expect(res).toEqual({ task_id: 'abc' });
+    });
+
+    test('renderLanguage wirft Fehler bei 500', async () => {
+        nock(API)
+            .post('/dubbing/321/render/de', { render_type: 'wav' })
+            .reply(500, 'kaputt');
+
+        await expect(renderLanguage('321', 'de', 'wav', 'key')).rejects.toThrow('Render language failed');
     });
 });


### PR DESCRIPTION
## Summary
- implement `renderLanguage` in browser and Node modules
- expose `renderLanguage` through main module
- test the new API call with nock
- document new helper and bump version to 1.22.8

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684beaf363c8832787700c1a2f1ecd44