### PR TITLE
Refactor dubbing workflow for studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 
+## ✨ Neue Features in 1.24.0
+
+* Halb-manueller Studio-Workflow ohne `renderLanguage`
+* Neue Funktion `isDubReady` prüft den Status eines Dubbings
+
 ## ✨ Neue Features in 1.23.1
 
 * `renderLanguage` und `waitForDubbing` verwenden nun `/dubbing/resource/...`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.23.1-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.24.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -109,7 +109,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 4. Beispielhafte Nutzung (neue Reihenfolge):
 
 ```javascript
-const { createDubbing, renderLanguage, waitForDubbing, downloadDubbingAudio } = require('./elevenlabs.js');
+const { createDubbing, isDubReady } = require('./elevenlabs.js');
 const apiKey = process.env.ELEVEN_API_KEY;
 const job = await createDubbing({
     audioFile: 'sounds/EN/beispiel.wav',
@@ -117,9 +117,12 @@ const job = await createDubbing({
     voiceId: '',
     apiKey
 });
-await renderLanguage(job.dubbing_id, 'de', 'wav', apiKey);
-await waitForDubbing(apiKey, job.dubbing_id, 'de');
-await downloadDubbingAudio(apiKey, job.dubbing_id, 'de', 'sounds/DE/beispiel_de.mp3');
+const url = `https://elevenlabs.io/studio/dubbing/${job.dubbing_id}`;
+console.log('Im Studio öffnen:', url);
+if (await isDubReady(job.dubbing_id, 'de', apiKey)) {
+    const blob = await fetch(`${API}/dubbing/${job.dubbing_id}/audio/de`, { headers: { 'xi-api-key': apiKey } }).then(r => r.blob());
+    // blob speichern ...
+}
 ```
 
 Ein Klick auf **Dubbing** öffnet zunächst ein Einstellungsfenster. Dort lassen sich folgende Parameter anpassen:
@@ -155,7 +158,7 @@ Bis Version 1.19.1 nutzte das Tool den Studio-Workflow über `resource/dub` und 
 
 Ab Version 1.20.3 wertet `waitForDubbing` nur noch `status` aus. Angaben in `progress.langs` oder `state` werden ignoriert.
 
-Ab Version 1.23.1 rufen `renderLanguage` und `waitForDubbing` intern `/dubbing/resource/...` auf.
+Ab Version 1.24.0 entfällt `renderLanguage`. Erzeugte Projekte werden im Studio manuell gerendert. `isDubReady(id)` prüft dabei, ob die deutsche Spur bereitsteht.
 
 Beispiel einer gültigen CSV:
 
@@ -408,7 +411,7 @@ Der komplette Verlauf steht in [CHANGELOG.md](CHANGELOG.md).
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 1.23.1 - Ausführliche API-Logs
+**Version 1.24.0 - Halb-manueller Studio-Workflow
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/elevenlabs.js
+++ b/elevenlabs.js
@@ -166,6 +166,19 @@ async function downloadDubbingAudio(apiKey, dubbingId, targetLang = 'de', target
 }
 // =========================== DOWNLOADDUBBING END ==========================
 
+// =========================== ISDUBREADY START ==============================
+// Prüft, ob eine Sprache fertig gerendert wurde
+async function isDubReady(id, lang = 'de', apiKey, logger = () => {}) {
+    logger(`GET ${API}/dubbing/${id}`);
+    const res = await fetch(`${API}/dubbing/${id}`, { headers: { 'xi-api-key': apiKey } });
+    const text = await res.text();
+    logger(`Antwort (${res.status}): ${text}`);
+    if (!res.ok) throw new Error(text);
+    const meta = JSON.parse(text);
+    return meta.status === 'dubbed' && (meta.target_languages || []).includes(lang);
+}
+// =========================== ISDUBREADY END ===============================
+
 // =========================== GETDEFAULTVOICESETTINGS START ================
 /**
  * Holt die Standardwerte für Voice-Einstellungen von ElevenLabs.
@@ -191,23 +204,16 @@ async function getDefaultVoiceSettings(apiKey, logger = () => {}) {
 // =========================== RENDERLANGUAGE START ==========================
 // Rendert eine Sprache eines bestehenden Dubbings neu
 async function renderLanguage(dubbingId, targetLang = 'de', renderType = 'wav', apiKey, logger = () => {}) {
-    logger(`POST ${API}/dubbing/resource/${dubbingId}/render/${targetLang} (${renderType})`);
-    const res = await fetch(`${API}/dubbing/resource/${dubbingId}/render/${targetLang}`, {
+    // logger(`POST ${API}/dubbing/resource/${dubbingId}/render/${targetLang} (${renderType})`);
+    /* const res = await fetch(`${API}/dubbing/resource/${dubbingId}/render/${targetLang}`, {
         method: 'POST',
         headers: {
             'xi-api-key': apiKey,
             'Content-Type': 'application/json'
         },
         body: JSON.stringify({ render_type: renderType })
-    });
-    const text = await res.text();
-    logger(`Antwort (${res.status}): ${text}`);
-
-    if (!res.ok) {
-        throw new Error(`Render language failed: ${res.status} ${text}`);
-    }
-
-    return JSON.parse(text);
+    }); */
+    return {};
 }
 // =========================== RENDERLANGUAGE END ============================
 
@@ -243,15 +249,16 @@ async function dubSegments(apiKey, resourceId, languages = ['de']) {
 // =========================== RENDERRESOURCE START ========================
 // Rendert die komplette Audiodatei fuer eine Sprache
 async function renderDubbingResource(apiKey, resourceId, lang = 'de', type = 'mp3') {
-    const res = await fetch(`${API}/dubbing/resource/${resourceId}/render/${lang}`, {
-        method: 'POST',
-        headers: { 'xi-api-key': apiKey, 'Content-Type': 'application/json' },
-        body: JSON.stringify({ render_type: type })
-    });
-    if (!res.ok) {
-        throw new Error('Rendern fehlgeschlagen: ' + await res.text());
-    }
-    return await res.json();
+    // const res = await fetch(`${API}/dubbing/resource/${resourceId}/render/${lang}`, {
+    //     method: 'POST',
+    //     headers: { 'xi-api-key': apiKey, 'Content-Type': 'application/json' },
+    //     body: JSON.stringify({ render_type: type })
+    // });
+    // if (!res.ok) {
+    //     throw new Error('Rendern fehlgeschlagen: ' + await res.text());
+    // }
+    // return await res.json();
+    return {};
 }
 // =========================== RENDERRESOURCE END ==========================
 
@@ -292,5 +299,6 @@ module.exports = {
     downloadDubbingAudio,
     getDefaultVoiceSettings,
     waitForDubbing,
+    isDubReady,
     renderLanguage
 };

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.23.1</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.24.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/elevenlabs.js
+++ b/src/elevenlabs.js
@@ -78,23 +78,20 @@ export async function downloadDubbingAudio(apiKey, id, targetLang = 'de', logger
     return await res.blob();
 }
 
-// Rendert eine bestimmte Sprache neu
-export async function renderLanguage(dubbingId, targetLang = 'de', renderType = 'wav', apiKey, logger = () => {}) {
-    logger(`POST ${API}/dubbing/resource/${dubbingId}/render/${targetLang} (${renderType})`);
-    const res = await fetch(`${API}/dubbing/resource/${dubbingId}/render/${targetLang}`, {
-        method: 'POST',
-        headers: {
-            'xi-api-key': apiKey,
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ render_type: renderType })
-    });
+// Prüft, ob ein Dubbing bereits generiert wurde
+export async function isDubReady(id, lang = 'de', apiKey, logger = () => {}) {
+    logger(`GET ${API}/dubbing/${id}`);
+    const res = await fetch(`${API}/dubbing/${id}`, { headers: { 'xi-api-key': apiKey } });
     const text = await res.text();
     logger(`Antwort (${res.status}): ${text}`);
+    if (!res.ok) throw new Error(text);
+    const meta = JSON.parse(text);
+    return meta.status === 'dubbed' && (meta.target_languages || []).includes(lang);
+}
 
-    if (!res.ok) {
-        throw new Error(`Render language failed: ${res.status} ${text}`);
-    }
-
-    return JSON.parse(text);
+// Rendert eine bestimmte Sprache neu
+export async function renderLanguage(dubbingId, targetLang = 'de', renderType = 'wav', apiKey, logger = () => {}) {
+    // Funktion deaktiviert – Studio-Workflow nutzt kein Rendering mehr
+    logger('renderLanguage wird nicht mehr verwendet');
+    return {};
 }


### PR DESCRIPTION
## Summary
- switch to manual studio workflow
- add `isDubReady` helper
- download check adapted for studio flow
- remove render calls
- update documentation and version to 1.24.0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c0c5014688327974c19f464beac4b