### PR TITLE
API vereinfacht und Version erhöht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 
+## ✨ Neue Features in 1.25.0
+
+* API-Modul nutzt ausschließlich `/dubbing/{id}`
+* `renderLanguage` und Studio-Endpunkte entfernt
+
 ## ✨ Neue Features in 1.24.0
 
 * Halb-manueller Studio-Workflow ohne `renderLanguage`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.24.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.25.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -411,7 +411,7 @@ Der komplette Verlauf steht in [CHANGELOG.md](CHANGELOG.md).
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
 
-**Version 1.24.0 - Halb-manueller Studio-Workflow
+**Version 1.25.0 - API-Bereinigung
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte
 
 ## 🧪 Tests

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.24.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.25.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.24.0",
+      "version": "1.25.0",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/elevenlabs.js
+++ b/src/elevenlabs.js
@@ -43,25 +43,27 @@ export async function createDubbing({
 export async function waitForDubbing(apiKey, id, targetLang = 'de', timeout = 180, onProgress = () => {}, logger = () => {}) {
     const start = Date.now();
     let info = null;
+
     while (Date.now() - start < timeout * 1000) {
-        logger(`GET ${API}/dubbing/resource/${id}`);
-        const res = await fetch(`${API}/dubbing/resource/${id}`, {
-            headers: { 'xi-api-key': apiKey }
-        });
+        logger(`GET ${API}/dubbing/${id}`);
+        const res  = await fetch(`${API}/dubbing/${id}`, { headers: { 'xi-api-key': apiKey } });
         const text = await res.text();
         logger(`Antwort (${res.status}): ${text}`);
         if (!res.ok) throw new Error(text);
         info = JSON.parse(text);
         onProgress(info.status);
-        const state = info.renders?.[targetLang]?.status;
-        if (state === 'complete') return;
-        if (state === 'failed') {
-            const reason = info.renders?.[targetLang]?.error || 'Server meldet failed';
+
+        const ready = info.status === 'dubbed' && (info.target_languages || []).includes(targetLang);
+        if (ready) return;
+        if (info.status === 'failed') {
+            const reason = info.error || 'Server meldet failed';
             throw new Error(reason);
         }
+
         await new Promise(r => setTimeout(r, WAIT_INTERVAL_MS));
     }
-    if (!info?.renders || !info.renders[targetLang]) {
+
+    if (info && info.status === 'dubbed' && !(info.target_languages || []).includes(targetLang)) {
         console.error('target_lang nicht gesetzt?');
     }
     throw new Error('Dubbing nicht fertig');
@@ -79,7 +81,7 @@ export async function downloadDubbingAudio(apiKey, id, targetLang = 'de', logger
 }
 
 // Prüft, ob ein Dubbing bereits generiert wurde
-export async function isDubReady(id, lang = 'de', apiKey, logger = () => {}) {
+export async function isDubReady(id, lang = 'de', apiKey = import.meta.env.ELEVEN_API_KEY, logger = () => {}) {
     logger(`GET ${API}/dubbing/${id}`);
     const res = await fetch(`${API}/dubbing/${id}`, { headers: { 'xi-api-key': apiKey } });
     const text = await res.text();
@@ -89,9 +91,8 @@ export async function isDubReady(id, lang = 'de', apiKey, logger = () => {}) {
     return meta.status === 'dubbed' && (meta.target_languages || []).includes(lang);
 }
 
-// Rendert eine bestimmte Sprache neu
-export async function renderLanguage(dubbingId, targetLang = 'de', renderType = 'wav', apiKey, logger = () => {}) {
-    // Funktion deaktiviert – Studio-Workflow nutzt kein Rendering mehr
-    logger('renderLanguage wird nicht mehr verwendet');
-    return {};
-}
+// export async function renderLanguage(dubbingId, targetLang = 'de', renderType = 'wav', apiKey, logger = () => {}) {
+//     // Funktion wurde entfernt, da der Studio-Workflow das manuelle Rendering uebernimmt
+//     logger('renderLanguage wird nicht mehr verwendet');
+//     return {};
+// }

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.24.0';
+const APP_VERSION = '1.25.0';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 

--- a/tests/elevenlabs.test.js
+++ b/tests/elevenlabs.test.js
@@ -68,8 +68,8 @@ describe('ElevenLabs API', () => {
 
     test('Download-Fehler', async () => {
         nock(API)
-            .get('/dubbing/resource/abc')
-            .reply(200, { renders: { de: { status: 'complete' } } });
+            .get('/dubbing/abc')
+            .reply(200, { status: 'dubbed', target_languages: ['de'] });
         nock(API)
             .get('/dubbing/abc/audio/de')
             .times(4)
@@ -82,8 +82,8 @@ describe('ElevenLabs API', () => {
     test('Download erfolgreich', async () => {
         const outPath = path.join(__dirname, 'out.mp3');
         nock(API)
-            .get('/dubbing/resource/xyz')
-            .reply(200, { renders: { de: { status: 'complete' } } });
+            .get('/dubbing/xyz')
+            .reply(200, { status: 'dubbed', target_languages: ['de'] });
         nock(API)
             .get('/dubbing/xyz/audio/de')
             .reply(200, 'sound');
@@ -98,8 +98,8 @@ describe('ElevenLabs API', () => {
     test('Download klappt nach zweitem Versuch', async () => {
         const outPath = path.join(__dirname, 'retry.mp3');
         nock(API)
-            .get('/dubbing/resource/retry')
-            .reply(200, { renders: { de: { status: 'complete' } } });
+            .get('/dubbing/retry')
+            .reply(200, { status: 'dubbed', target_languages: ['de'] });
         nock(API)
             .get('/dubbing/retry/audio/de')
             .reply(500, 'dubbing_not_found')
@@ -191,40 +191,40 @@ describe('ElevenLabs API', () => {
 
     test('waitForDubbing beendet sich bei Erfolg', async () => {
         nock(API)
-            .get('/dubbing/resource/success')
-            .reply(200, { renders: { de: { status: 'complete' } } });
+            .get('/dubbing/success')
+            .reply(200, { status: 'dubbed', target_languages: ['de'] });
 
         await expect(waitForDubbing('key', 'success', 'de', 3)).resolves.toBeUndefined();
     });
 
     test('waitForDubbing nutzt targetLang-Parameter', async () => {
         nock(API)
-            .get('/dubbing/resource/frjob')
-            .reply(200, { renders: { fr: { status: 'complete' } } });
+            .get('/dubbing/frjob')
+            .reply(200, { status: 'dubbed', target_languages: ['fr'] });
 
         await expect(waitForDubbing('key', 'frjob', 'fr', 3)).resolves.toBeUndefined();
     });
 
     test('waitForDubbing wirft bei failed', async () => {
         nock(API)
-            .get('/dubbing/resource/bad')
-            .reply(200, { renders: { de: { status: 'failed', error: 'kaputt' } } });
+            .get('/dubbing/bad')
+            .reply(200, { status: 'failed', error: 'kaputt' });
 
         await expect(waitForDubbing('key', 'bad', 'de', 3)).rejects.toThrow('kaputt');
     });
 
     test('waitForDubbing gibt Timeout zurück', async () => {
         nock(API)
-            .get('/dubbing/resource/slow')
-            .reply(200, { renders: { de: { status: 'in-progress' } } });
+            .get('/dubbing/slow')
+            .reply(200, { status: 'dubbing', target_languages: [] });
 
         await expect(waitForDubbing('key', 'slow', 'de', 3)).rejects.toThrow('Dubbing nicht fertig');
     });
 
     test('waitForDubbing meldet fehlendes target_lang', async () => {
         nock(API)
-            .get('/dubbing/resource/nolang')
-            .reply(200, { renders: {} });
+            .get('/dubbing/nolang')
+            .reply(200, { status: 'dubbed', target_languages: [] });
 
         const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
         await expect(waitForDubbing('key', 'nolang', 'de', 3)).rejects.toThrow('Dubbing nicht fertig');


### PR DESCRIPTION
## Zusammenfassung
- ElevenLabs-API von `/dubbing/resource`-Aufrufen befreit
- neue Funktion `isDubReady` nutzt nun `import.meta.env` für den API-Key
- `waitForDubbing` prüft Status über `/dubbing/{id}`
- Tests entsprechend angepasst und neue Version 1.25.0 gesetzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c12c81ea8832795613127c0c519ad