### PR TITLE
Implement Studio overlay after dubbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 
+## ✨ Neue Features in 1.26.0
+
+* Öffnet nach dem Starten des Dubbings automatisch das ElevenLabs Studio
+* Neues Overlay hält den Vorgang an, bis der Benutzer "OK" klickt
+
 ## ✨ Neue Features in 1.25.0
 
 * API-Modul nutzt ausschließlich `/dubbing/{id}`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.25.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.26.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -410,6 +410,9 @@ Der komplette Verlauf steht in [CHANGELOG.md](CHANGELOG.md).
 ---
 
 © 2025 Half‑Life: Alyx Translation Tool – Alle Rechte vorbehalten.
+
+**Version 1.26.0 - Studio-Workflow**
+Öffnet nach jedem Dubbing automatisch das ElevenLabs Studio und zeigt einen Hinweis mit OK-Button an.
 
 **Version 1.25.0 - API-Bereinigung
 🎮 Speziell entwickelt für Half‑Life: Alyx Übersetzungsprojekte

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -435,7 +435,7 @@
 
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.25.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.26.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.25.0",
+      "version": "1.26.0",
       "devDependencies": {
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.25.0';
+const APP_VERSION = '1.26.0';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 
@@ -6320,6 +6320,30 @@ function resetStoredVoiceSettings() {
     }
 }
 
+// Zeigt einen Hinweis an, dass das Studio geöffnet wurde
+function showStudioOverlay() {
+    const ov = document.createElement('div');
+    ov.className = 'dialog-overlay';
+    ov.id = 'studioNoticeDialog';
+    ov.style.display = 'flex';
+    ov.innerHTML = `
+        <div class="dialog">
+            <h3>🎧 ElevenLabs Studio</h3>
+            <p>Das Studio ist in einem neuen Tab geöffnet.<br>
+               Klicken Sie dort auf „Generate Audio" und danach auf OK.</p>
+            <div class="dialog-buttons">
+                <button class="btn btn-success" onclick="closeStudioOverlay()">OK</button>
+            </div>
+        </div>`;
+    document.body.appendChild(ov);
+}
+
+// Schließt den Studio-Hinweis
+function closeStudioOverlay() {
+    const ov = document.getElementById('studioNoticeDialog');
+    if (ov) ov.remove();
+}
+
 // Hilfsfunktion für das Manual Dubbing
 // Wandelt Millisekunden in Sekundenwerte mit drei Nachkommastellen um
 function msToSeconds(ms) {
@@ -6509,9 +6533,10 @@ async function startDubbing(fileId, settings = {}, targetLang = 'de') {
     file.dubbingId = id;
     saveCurrentProject();
     renderFileTable();
-const studioUrl = `https://elevenlabs.io/studio/dubbing/${id}`;
+    const studioUrl = `https://elevenlabs.io/studio/dubbing/${id}`;
     window.open(studioUrl, '_blank');
-    updateStatus('Bitte im Studio „Generate Audio“ klicken.');
+    showStudioOverlay();
+    updateStatus('Studio geöffnet – bitte dort „Generate Audio“ anklicken.');
 }
 // =========================== STARTDUBBING END ===============================
 


### PR DESCRIPTION
## Summary
- open Studio link after creating a dubbing
- show dialog until user confirms
- document new feature and bump version to 1.26.0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c146b8c7c832782b2940c39876ed8