### PR TITLE
Fix Backup-Folder Button and add sounds fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht a
 
 * Start-Skripte installieren automatisch die Haupt-Abhängigkeiten
 
+## ✨ Neue Features in 1.34.4
+
+* Backup-Ordner lässt sich jetzt auch im Browser öffnen
+* Fallback auf Standardordner `sounds`, falls kein Directory Picker vorhanden ist
+
 ## ✨ Neue Features in 1.33.0
 
 * Ordnerüberwachung für manuell heruntergeladene Audios

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.34.3-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.34.4-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -153,6 +153,7 @@ Ab Version 1.33.0 überwacht das Tool den Download-Ordner und importiert Dateien
 Ab Version 1.34.1 verwendet das Tool `path.resolve` für alle Pfade und meldet "Spur manuell generieren oder Beta freischalten" bei fehlendem Download.
 Ab Version 1.34.2 behebt die Desktop-Version ein fehlendes `chokidar`-Modul.
 Ab Version 1.34.3 installieren die Start-Skripte automatisch die Haupt-Abhängigkeiten.
+Ab Version 1.34.4 öffnet der Button "Ordner öffnen" den Backup-Ordner auch im Browser.
 
 Für diesen Zweck gibt es das Node-Skript `cliRedownload.js`.
 Es wird so aufgerufen:
@@ -450,6 +451,8 @@ Alle Pfade nutzen nun `path.resolve`. Bei fehlenden Dubbings erscheint die Meldu
 Behebt ein fehlendes `chokidar`-Modul in der Desktop-Version.
 **Version 1.34.3 - Auto-Install**
 Start-Skripte führen nun `npm install` im Hauptordner aus.
+**Version 1.34.4 - Backup-Fallback**
+Der Backup-Button öffnet nun auch im Browser den `backups`-Ordner.
 **Version 1.26.0 - Studio-Workflow**
 Öffnet nach jedem Dubbing automatisch das ElevenLabs Studio und zeigt einen Hinweis mit OK-Button an.
 

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -442,7 +442,7 @@
     <div id="toastContainer"></div>
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.34.3</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.34.4</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.34.3",
+  "version": "1.34.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.34.3",
+      "version": "1.34.4",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.34.3",
+  "version": "1.34.4",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.34.3';
+const APP_VERSION = '1.34.4';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 
@@ -253,7 +253,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     cleanupOrphanCustomizations();
 
     if (!window.electronAPI) {
-        // 👉 Zuletzt verwendeten Projektordner laden (Browser-Version)
+        // 👉 Browser-Version
+        if (!window.showDirectoryPicker) {
+            // Fallback ohne File-System-API: Standardordner 'sounds' verwenden
+            projektOrdnerHandle = { name: 'sounds' };
+            updateProjectFolderPathDisplay();
+        }
+        // Zuletzt verwendeten Projektordner laden (wenn File-System-API verfuegbar)
         const savedHandle = await loadProjectFolderHandle();
         if (savedHandle) {
             let perm = await savedHandle.queryPermission({ mode: 'read' });
@@ -5321,7 +5327,9 @@ function checkFileAccess() {
             if (window.electronAPI && window.electronAPI.openBackupFolder) {
                 window.electronAPI.openBackupFolder();
             } else {
-                alert('Nur in der Desktop-Version verfügbar');
+                // Fallback fuer Browser-Version: oeffnet den Unterordner "backups" im neuen Tab
+                const url = new URL('backups/', window.location.href).toString();
+                window.open(url, '_blank');
             }
         }
 


### PR DESCRIPTION
## Summary
- allow backup-folder button in browser to open local `backups` directory
- use `sounds` folder as fallback when `showDirectoryPicker` is unavailable
- document new browser backup behaviour
- bump version to 1.34.4

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c2fc52e948327b42dcae84076dbc8