### PR TITLE
DevTools-Knopf im Browser ausblenden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht a
 
 * Backups aus dem alten Ordner `backups` werden wieder erkannt
 
+## 🛠️ Bugfix in 1.34.6
+
+* DevTools-Button wird im Browser ausgeblendet
+
 ## ✨ Neue Features in 1.33.0
 
 * Ordnerüberwachung für manuell heruntergeladene Audios

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.34.5-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.34.6-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -155,6 +155,7 @@ Ab Version 1.34.2 behebt die Desktop-Version ein fehlendes `chokidar`-Modul.
 Ab Version 1.34.3 installieren die Start-Skripte automatisch die Haupt-Abhängigkeiten.
 Ab Version 1.34.4 öffnet der Button "Ordner öffnen" den Backup-Ordner auch im Browser.
 Ab Version 1.34.5 erkennt das Tool auch Backups im alten Ordner `backups`.
+Ab Version 1.34.6 wird der DevTools-Button im Browser ausgeblendet.
 
 Für diesen Zweck gibt es das Node-Skript `cliRedownload.js`.
 Es wird so aufgerufen:
@@ -456,6 +457,8 @@ Start-Skripte führen nun `npm install` im Hauptordner aus.
 Der Backup-Button öffnet nun auch im Browser den `backups`-Ordner.
 **Version 1.34.5 - Backup-Kompatibilität**
 Backups aus dem alten Ordner `backups` werden wieder erkannt.
+**Version 1.34.6 - DevTools-Button**
+In Browsern wird der DevTools-Knopf jetzt ausgeblendet.
 **Version 1.26.0 - Studio-Workflow**
 Öffnet nach jedem Dubbing automatisch das ElevenLabs Studio und zeigt einen Hinweis mit OK-Button an.
 

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -47,7 +47,7 @@
                         <div class="settings-item" onclick="repairProjectFolders()">🔧 Ordner reparieren</div>
                     </div>
                 </div>
-                <button class="btn btn-secondary" onclick="toggleDevTools()">🐞 DevTools</button>
+                <button id="devToolsButton" class="btn btn-secondary" onclick="toggleDevTools()">🐞 DevTools</button>
                 <button class="btn btn-secondary" onclick="openDubbingLog()">📝 Protokoll</button>
             </div>
 			
@@ -442,7 +442,7 @@
     <div id="toastContainer"></div>
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.34.5</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.34.6</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.34.5",
+  "version": "1.34.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.34.5",
+      "version": "1.34.6",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.34.5",
+  "version": "1.34.6",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.34.5';
+const APP_VERSION = '1.34.6';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 
@@ -187,6 +187,12 @@ function stopCurrentPlayback() {
 // =========================== DOM READY INITIALISIERUNG ===========================
 document.addEventListener('DOMContentLoaded', async () => {
     loadProjects();
+
+    // DevTools-Knopf ausblenden, falls keine Electron-Umgebung vorhanden ist
+    const devBtn = document.getElementById('devToolsButton');
+    if (devBtn && !window.electronAPI) {
+        devBtn.style.display = 'none';
+    }
 
     // Desktop-Version: automatisch EN- und DE-Ordner einlesen
     if (window.electronAPI) {


### PR DESCRIPTION
## Zusammenfassung
- blende den DevTools-Knopf im Browser automatisch aus
- Update der Dokumentation und CHANGELOG
- Versionsbump auf 1.34.6

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c37f713508327a958fcc9e77802a7