### PR TITLE
Add browser backup upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 
+## ✨ Neue Features in 1.35.0
+
+* Backup-Dateien lassen sich im Browser hochladen und sofort wiederherstellen
+
 ## ✨ Neue Features in 1.34.0
 
 * Neue Spalte "Dub-Status" mit farbigen Punkten

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.34.6-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.35.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -156,6 +156,7 @@ Ab Version 1.34.3 installieren die Start-Skripte automatisch die Haupt-Abhängig
 Ab Version 1.34.4 öffnet der Button "Ordner öffnen" den Backup-Ordner auch im Browser.
 Ab Version 1.34.5 erkennt das Tool auch Backups im alten Ordner `backups`.
 Ab Version 1.34.6 wird der DevTools-Button im Browser ausgeblendet.
+Ab Version 1.35.0 lassen sich Backups im Browser hochladen und wiederherstellen.
 
 Für diesen Zweck gibt es das Node-Skript `cliRedownload.js`.
 Es wird so aufgerufen:
@@ -459,6 +460,8 @@ Der Backup-Button öffnet nun auch im Browser den `backups`-Ordner.
 Backups aus dem alten Ordner `backups` werden wieder erkannt.
 **Version 1.34.6 - DevTools-Button**
 In Browsern wird der DevTools-Knopf jetzt ausgeblendet.
+**Version 1.35.0 - Backup-Upload**
+Backups können im Browser hochgeladen und sofort wiederhergestellt werden.
 **Version 1.26.0 - Studio-Workflow**
 Öffnet nach jedem Dubbing automatisch das ElevenLabs Studio und zeigt einen Hinweis mit OK-Button an.
 

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -296,6 +296,7 @@
             </div>
             <div class="dialog-buttons">
                 <button class="btn btn-secondary" onclick="createBackup(true)">Backup erstellen</button>
+                <button class="btn btn-secondary" onclick="initiateBackupUpload()">Backup hochladen</button>
                 <button class="btn btn-secondary" onclick="openBackupFolder()">Ordner öffnen</button>
                 <button class="btn btn-secondary" onclick="closeBackupDialog()">Schließen</button>
             </div>
@@ -428,6 +429,7 @@
     <!-- Audio Player -->
     <audio id="audioPlayer"></audio>
     <input type="file" id="deUploadInput" style="display:none" accept=".mp3,.wav,.ogg" onchange="handleDeUpload(this)">
+    <input type="file" id="backupUploadInput" style="display:none" accept=".json" onchange="handleBackupUpload(this)">
 
     <!-- Umschaltbare Debug-Konsole -->
     <details id="debugConsoleWrapper" style="margin:10px 0;">
@@ -442,7 +444,7 @@
     <div id="toastContainer"></div>
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.34.6</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.35.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.34.6",
+  "version": "1.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.34.6",
+      "version": "1.35.0",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.34.6",
+  "version": "1.35.0",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.34.6';
+const APP_VERSION = '1.35.0';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 
@@ -5337,6 +5337,25 @@ function checkFileAccess() {
                 const url = new URL('backups/', window.location.href).toString();
                 window.open(url, '_blank');
             }
+        }
+
+        // Backup aus Datei laden
+        function initiateBackupUpload() {
+            document.getElementById('backupUploadInput').click();
+        }
+
+        // Eingelesene Backup-Datei verarbeiten
+        async function handleBackupUpload(input) {
+            const file = input.files[0];
+            if (!file) return;
+            try {
+                const text = await file.text();
+                const backup = JSON.parse(text);
+                applyBackupData(backup);
+            } catch (err) {
+                alert('Fehler beim Importieren: ' + err.message);
+            }
+            input.value = '';
         }
 
         // =========================== SHOWAPIDIALOG START ======================


### PR DESCRIPTION
## Summary
- allow uploading of backup files in the browser
- bump version to 1.35.0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c39adafe08327b2b909715d842467