### PR TITLE
Fix DevTools visibility in browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht a
 
 * Backup-Dateien lassen sich im Browser hochladen und sofort wiederherstellen
 
+## 🛠️ Bugfix in 1.35.1
+
+* DevTools-Button wird wieder dauerhaft angezeigt
+
+
 ## ✨ Neue Features in 1.34.0
 
 * Neue Spalte "Dub-Status" mit farbigen Punkten

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.35.0-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.35.1-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -155,8 +155,8 @@ Ab Version 1.34.2 behebt die Desktop-Version ein fehlendes `chokidar`-Modul.
 Ab Version 1.34.3 installieren die Start-Skripte automatisch die Haupt-Abhängigkeiten.
 Ab Version 1.34.4 öffnet der Button "Ordner öffnen" den Backup-Ordner auch im Browser.
 Ab Version 1.34.5 erkennt das Tool auch Backups im alten Ordner `backups`.
-Ab Version 1.34.6 wird der DevTools-Button im Browser ausgeblendet.
 Ab Version 1.35.0 lassen sich Backups im Browser hochladen und wiederherstellen.
+Seit Version 1.35.1 wird der DevTools-Knopf wieder im Browser angezeigt.
 
 Für diesen Zweck gibt es das Node-Skript `cliRedownload.js`.
 Es wird so aufgerufen:
@@ -458,8 +458,8 @@ Start-Skripte führen nun `npm install` im Hauptordner aus.
 Der Backup-Button öffnet nun auch im Browser den `backups`-Ordner.
 **Version 1.34.5 - Backup-Kompatibilität**
 Backups aus dem alten Ordner `backups` werden wieder erkannt.
-**Version 1.34.6 - DevTools-Button**
-In Browsern wird der DevTools-Knopf jetzt ausgeblendet.
+**Version 1.35.1 - DevTools-Button wieder sichtbar**
+Im Browser wird der DevTools-Knopf dauerhaft angezeigt.
 **Version 1.35.0 - Backup-Upload**
 Backups können im Browser hochgeladen und sofort wiederhergestellt werden.
 **Version 1.26.0 - Studio-Workflow**

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -444,7 +444,7 @@
     <div id="toastContainer"></div>
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.35.0</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.35.1</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.35.0",
+      "version": "1.35.1",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.35.0';
+const APP_VERSION = '1.35.1';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 
@@ -187,12 +187,8 @@ function stopCurrentPlayback() {
 // =========================== DOM READY INITIALISIERUNG ===========================
 document.addEventListener('DOMContentLoaded', async () => {
     loadProjects();
+    // DevTools-Knopf wird immer eingeblendet
 
-    // DevTools-Knopf ausblenden, falls keine Electron-Umgebung vorhanden ist
-    const devBtn = document.getElementById('devToolsButton');
-    if (devBtn && !window.electronAPI) {
-        devBtn.style.display = 'none';
-    }
 
     // Desktop-Version: automatisch EN- und DE-Ordner einlesen
     if (window.electronAPI) {


### PR DESCRIPTION
## Summary
- DevTools-Knopf nicht mehr ausblenden
- Version auf 1.35.1 erhöht
- Änderungsnotizen und Changelog angepasst

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c3b2457a083279982f1a153f96b0c