### PR TITLE
Dev-Tools verbessern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht a
 
 * Browser-Version erkennt den Ordner `sounds` jetzt automatisch
 
+## 🛠️ Verbesserung in 1.35.4
+
+* Dev-Button zeigt nun JavaScript-Fehler im Debug-Bereich an
+
 
 ## ✨ Neue Features in 1.34.0
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.35.3-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.35.4-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -158,6 +158,7 @@ Ab Version 1.34.5 erkennt das Tool auch Backups im alten Ordner `backups`.
 Ab Version 1.35.0 lassen sich Backups im Browser hochladen und wiederherstellen.
 Seit Version 1.35.2 öffnet der Dev-Button zusätzlich die eingebaute Debug-Konsole.
 Ab Version 1.35.3 wird der Ordner `sounds` automatisch erkannt.
+Ab Version 1.35.4 zeigt der Dev-Button nun JavaScript-Fehler in der Debug-Konsole an.
 
 Für diesen Zweck gibt es das Node-Skript `cliRedownload.js`.
 Es wird so aufgerufen:
@@ -463,6 +464,8 @@ Backups aus dem alten Ordner `backups` werden wieder erkannt.
 Der Dev-Button öffnet nun die eingebaute Debug-Konsole und in der Desktop-Version zusätzlich die DevTools.
 **Version 1.35.3 - Fester Sounds-Pfad**
 Die Browser-Version nutzt nun automatisch den Ordner `sounds` neben der HTML-Datei.
+**Version 1.35.4 - Besseres Debugging**
+Der Dev-Button öffnet die Debug-Konsole jetzt automatisch und zeigt JavaScript-Fehler an.
 **Version 1.35.0 - Backup-Upload**
 Backups können im Browser hochgeladen und sofort wiederhergestellt werden.
 **Version 1.26.0 - Studio-Workflow**

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -444,7 +444,7 @@
     <div id="toastContainer"></div>
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.35.3</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.35.4</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.35.3",
+  "version": "1.35.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.35.3",
+      "version": "1.35.4",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.35.3",
+  "version": "1.35.4",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.35.3';
+const APP_VERSION = '1.35.4';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 
@@ -96,6 +96,19 @@ function debugLog(...args) {
         div.scrollTop = div.scrollHeight;
     }
 }
+
+// =========================== ERROR-HANDLING START ===========================
+// Leitet JavaScript-Fehler in die Debug-Konsole um
+window.addEventListener('error', (event) => {
+    debugLog('FEHLER:', event.message);
+});
+// Ergänzt console.error, damit Fehler im Debug-Bereich auftauchen
+const origConsoleError = console.error;
+console.error = function(...args) {
+    origConsoleError.apply(console, args);
+    debugLog('FEHLER:', ...args);
+};
+// =========================== ERROR-HANDLING END =============================
 
 // =========================== DUBBING-LOG START ===========================
 // Aktuelles Dubbing-Protokoll
@@ -6051,6 +6064,7 @@ function executeCleanup(cleanupPlan, totalToDelete) {
             if (wrapper) {
                 wrapper.open = true; // Zeigt die eingebettete Konsole an
             }
+            debugLog('Dev-Button aktiviert');
             if (window.electronAPI) {
                 window.electronAPI.toggleDevTools();
             }


### PR DESCRIPTION
## Summary
- leitet JavaScript-Fehler in die Debug-Konsole um
- zeigt per Dev-Button sofort die Debug-Ausgabe an
- Versionsnummer auf 1.35.4 erhöhen und Dokumentation anpassen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c41f4987083278309bba8410d5d9d