### PR TITLE
Entferne .env.local und erweitere Anleitung

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Beispiel-Konfiguration für ElevenLabs
+ELEVEN_API_KEY=<dein-Key>
+

--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,0 @@
-ELEVEN_API_KEY=<dein-Key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 
+## 🛠️ Verbesserung in 1.35.7
+
+* `.env.example` als Vorlage für `.env.local`
+
 ## 🛠️ Aufräumarbeiten in 1.35.5
 
 * Überflüssige TypeScript-Dateien entfernt
@@ -151,7 +155,7 @@ Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht a
 
 | Kategorie | Beschreibung |
 | ---------- | ------------- |
-| **Konfiguration** | `.env.local` mit `ELEVEN_API_KEY` nutzen. |
+| **Konfiguration** | `.env.example` als Vorlage für `.env.local` nutzen. |
 
 ## ✨ Neue Features in 1.22.5
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-__VERSION__-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.35.7-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -106,7 +106,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 1. API-Schlüssel bei [ElevenLabs](https://elevenlabs.io) erstellen.
 2. Den Schlüssel als Umgebungsvariable `ELEVEN_API_KEY` setzen oder beim Aufruf der Funktionen eingeben.
-3. Alternativ die Datei `.env.local` mit `ELEVEN_API_KEY=<dein-Key>` anlegen.
+3. Kopieren Sie `.env.example` zu `.env.local` und tragen Sie Ihren Schlüssel in `ELEVEN_API_KEY=` ein.
 4. Beispielhafte Nutzung (neue Reihenfolge):
 
 ```javascript
@@ -197,7 +197,7 @@ Ab Version 1.20.2 protokolliert das Fenster zudem `detail.message` und `error` a
 ### Version aktualisieren
 
 1. In `package.json` die neue Versionsnummer eintragen.
-2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `__VERSION__`-Platzhalter in `README.md`, `src/main.js` und `hla_translation_tool.html` durch die aktuelle Nummer.
+2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.35.7`-Platzhalter in `README.md`, `src/main.js` und `hla_translation_tool.html` durch die aktuelle Nummer.
 
 ---
 

--- a/hla_translation_tool.html
+++ b/hla_translation_tool.html
@@ -444,7 +444,7 @@
     <div id="toastContainer"></div>
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v__VERSION__</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.35.7</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.35.6",
+  "version": "1.35.7",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '__VERSION__';
+const APP_VERSION = '1.35.7';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 


### PR DESCRIPTION
## Zusammenfassung
- entferne `.env.local` aus der Versionskontrolle
- erstelle `.env.example` als Vorlage
- dokumentiere Beispiel-Datei und aktualisiere CHANGELOG
- aktualisiere Version auf 1.35.7

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c4a73f9288327a2783bfda847dff2