### PR TITLE
Update start scripts to protect backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 
+## 🛠️ Patch in 1.36.2
+* Start-Skripte bewahren nun auch `web/backups/` bei `git reset`
+
 ## 🛠️ Patch in 1.36.1
 * `.gitignore` ignoriert nun `web/sounds/`, `web/backups/` und `web/Download/`
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.36.1-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.36.2-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -163,6 +163,7 @@ Ab Version 1.35.5 wurden überflüssige TypeScript-Dateien entfernt.
 
 Ab Version 1.36.0 liegen alle Web-Dateien im Ordner `web/`.
 Ab Version 1.36.1 werden die lokalen Ordner `web/sounds`, `web/backups` und `web/Download` ignoriert.
+Ab Version 1.36.2 verwerfen die Start-Skripte beim Zurücksetzen auch keine Backups mehr.
 Für diesen Zweck gibt es das Node-Skript `cliRedownload.js`.
 Es wird so aufgerufen:
 
@@ -199,7 +200,7 @@ Ab Version 1.20.2 protokolliert das Fenster zudem `detail.message` und `error` a
 ### Version aktualisieren
 
 1. In `package.json` die neue Versionsnummer eintragen.
-2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.36.1`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
+2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.36.2`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
 
 ---
 
@@ -473,6 +474,8 @@ Der Dev-Button öffnet die Debug-Konsole jetzt automatisch und zeigt JavaScript-
 Nicht benötigte TypeScript-Dateien wurden entfernt.
 **Version 1.36.1 - Gitignore-Anpassung**
 Ignoriert jetzt die lokalen Ordner `web/sounds`, `web/backups` und `web/Download`.
+**Version 1.36.2 - Sicheres Reset**
+Die Start-Skripte lassen beim Zurücksetzen auch den Ordner `web/backups` unverändert.
 
 **Version 1.35.0 - Backup-Upload**
 Backups können im Browser hochgeladen und sofort wiederhergestellt werden.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.36.1",
+  "version": "1.36.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.36.1",
+      "version": "1.36.2",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.36.1",
+  "version": "1.36.2",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/start_tool.bat
+++ b/start_tool.bat
@@ -73,8 +73,8 @@ cd hla_translation_tool
 
 REM ----------------------- Lokale Änderungen verwerfen --------------------
 call :log "Verwerfe lokale Änderungen"
-REM Sounds-Ordner nicht überschreiben
-git reset --hard HEAD -- ":!web/sounds"
+REM Sounds- und Backups-Ordner nicht überschreiben
+git reset --hard HEAD -- ":!web/sounds" ":!web/backups"
 IF ERRORLEVEL 1 (
     call :log "git reset fehlgeschlagen"
 ) ELSE (

--- a/start_tool.js
+++ b/start_tool.js
@@ -81,8 +81,8 @@ process.chdir(repoPath);
 // ----------------------- Lokale Änderungen verwerfen --------------------
 log('Verwerfe lokale Änderungen');
 try {
-    // Sounds-Ordner nicht überschreiben
-    run('git reset --hard HEAD -- :!web/sounds');
+    // Sounds- und Backups-Ordner nicht überschreiben
+    run('git reset --hard HEAD -- :!web/sounds :!web/backups');
     log('Lokale Änderungen verworfen');
 } catch (err) {
     console.error('git reset fehlgeschlagen. Weitere Details siehe setup.log');

--- a/start_tool.py
+++ b/start_tool.py
@@ -84,8 +84,8 @@ else:
 # ----------------------- Lokale Änderungen verwerfen --------------------
 log("Verwerfe lokale Änderungen")
 try:
-    # Sounds-Ordner nicht überschreiben
-    run("git reset --hard HEAD -- :!web/sounds")
+    # Sounds- und Backups-Ordner nicht überschreiben
+    run("git reset --hard HEAD -- :!web/sounds :!web/backups")
     log("Lokale Änderungen verworfen")
 except subprocess.CalledProcessError:
     print("git reset fehlgeschlagen. Weitere Details siehe setup.log")

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -444,7 +444,7 @@
     <div id="toastContainer"></div>
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.36.1</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.36.2</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.36.1';
+const APP_VERSION = '1.36.2';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 


### PR DESCRIPTION
## Summary
- preserve `web/backups` on `git reset` in helper scripts
- bump version to 1.36.2
- document the new behaviour in the README and changelog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c582746c88327938b1e6eaf5a3030