### PR TITLE
Patch: clarify missing Electron API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 
+## 🛠️ Patch in 1.36.6
+* Fehlende Electron-API wird im Debug-Fenster erklärt.
+
 ## 🛠️ Patch in 1.36.5
 * Debug-Button zeigt nun Pfad-Informationen an.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.36.5-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.36.6-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -166,7 +166,8 @@ Ab Version 1.36.1 werden die lokalen Ordner `web/sounds`, `web/backups` und `web
 Ab Version 1.36.2 verwerfen die Start-Skripte beim Zurücksetzen auch keine Backups mehr.
 Ab Version 1.36.3 erkennt die Desktop-Version auch Ordner mit großem Anfangsbuchstaben.
 Ab Version 1.36.4 entfernen die Start-Skripte automatisch überflüssige Dateien (ohne `web/sounds` und `web/backups`).
-Ab Version 1.36.5 zeigt der Debug-Button nun ein Fenster mit Pfadinformationen.
+Ab Version 1.36.6 erscheint beim Debug-Button ein Hinweis, wenn die Electron-API fehlt.
+Die Meldung "Electron-API nicht verfügbar" weist darauf hin, dass das Tool im Browser ausgeführt wird. Pfad-Informationen sind nur in der Desktop-Version sichtbar.
 Für diesen Zweck gibt es das Node-Skript `cliRedownload.js`.
 Es wird so aufgerufen:
 
@@ -203,7 +204,7 @@ Ab Version 1.20.2 protokolliert das Fenster zudem `detail.message` und `error` a
 ### Version aktualisieren
 
 1. In `package.json` die neue Versionsnummer eintragen.
-2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.36.5`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
+2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.36.6`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
 
 ---
 
@@ -485,6 +486,8 @@ Die Desktop-Version erkennt nun auch `web/Sounds` und `web/Backups`.
 Die Start-Skripte entfernen nicht mehr benötigte Dateien. `web/sounds` und `web/backups` bleiben dabei erhalten.
 **Version 1.36.5 - Neues Debug-Fenster**
 Der Debug-Button zeigt nun eine Übersicht der erwarteten Pfade.
+**Version 1.36.6 - Browser-Hinweis**
+Fehlt die Electron-API, erscheint nun ein erklärender Hinweis.
 
 **Version 1.35.0 - Backup-Upload**
 Backups können im Browser hochgeladen und sofort wiederhergestellt werden.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.36.5",
+  "version": "1.36.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.36.5",
+      "version": "1.36.6",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.36.5",
+  "version": "1.36.6",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -444,7 +444,7 @@
     <div id="toastContainer"></div>
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.36.5</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.36.6</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.36.5';
+const APP_VERSION = '1.36.6';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 
@@ -6077,7 +6077,8 @@ function executeCleanup(cleanupPlan, totalToDelete) {
             if (window.electronAPI && window.electronAPI.getDebugInfo) {
                 info = await window.electronAPI.getDebugInfo();
             } else {
-                info = { Fehler: 'Electron-API nicht verfügbar' };
+                // Hinweis anzeigen, wenn die App im Browser läuft und keine Electron-API hat
+                info = { Fehler: 'Electron-API nicht verfügbar. Wahrscheinlich läuft die Browser-Version.' };
             }
             let html = '<h3>Debug-Informationen</h3><ul>';
             for (const [key, value] of Object.entries(info)) {


### PR DESCRIPTION
## Summary
- clarify debug info message if Electron API is unavailable
- document this hint in README and changelog
- bump version to 1.36.6

## Testing
- `npm run update-version`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c61c809048327a1cecf0eb1f56c9a