### PR TITLE
Improve npm start error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 
+## 🛠️ Patch in 1.36.11
+* Fehlermeldungen beim Starten der Anwendung werden verständlich angezeigt und im Log festgehalten.
+
 ## 🛠️ Patch in 1.36.10
 * Python-Startskript hält das Fenster offen, damit Fehlermeldungen sichtbar bleiben.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.36.10-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.36.11-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -171,6 +171,7 @@ Ab Version 1.36.7 zeigt das Debug-Fenster einen Kopierknopf für alle Informatio
 Ab Version 1.36.8 startet Electron immer mit aktivierter Context Isolation.
 Ab Version 1.36.9 zeigt das Debug-Fenster zusätzliche Browser- und Prozessinformationen.
 Ab Version 1.36.10 hält das Python-Startskript das Fenster nach Abschluss offen.
+Ab Version 1.36.11 gibt das Python-Startskript bei einem Fehler von `npm start` eine verständliche Meldung aus und schreibt sie in `setup.log`.
 Die Meldung "Electron-API nicht verfügbar" weist darauf hin, dass das Tool im Browser ausgeführt wird. Pfad-Informationen sind nur in der Desktop-Version sichtbar.
 Für diesen Zweck gibt es das Node-Skript `cliRedownload.js`.
 Es wird so aufgerufen:
@@ -208,7 +209,7 @@ Ab Version 1.20.2 protokolliert das Fenster zudem `detail.message` und `error` a
 ### Version aktualisieren
 
 1. In `package.json` die neue Versionsnummer eintragen.
-2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.36.10`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
+2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.36.11`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
 
 ---
 
@@ -498,6 +499,9 @@ Das Debug-Fenster bietet nun einen Button zum Kopieren aller Informationen.
 Electron startet jetzt immer mit aktiver Context Isolation.
 **Version 1.36.9 - Mehr Debug-Daten**
 Das Debug-Fenster zeigt nun zusätzliche Browser- und Prozessinformationen an.
+
+**Version 1.36.11 - Bessere Fehleranzeige**
+Beim Starten der Anwendung erscheint nun eine verständliche Meldung, falls `npm start` fehlschlägt. Der Fehler wird zusätzlich in `setup.log` protokolliert.
 
 **Version 1.36.10 - Stopp bei Fehlermeldungen**
 Das Python-Startskript hält das Fenster nach Abschluss offen, sodass man Fehler besser erkennen kann.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.36.10",
+  "version": "1.36.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.36.10",
+      "version": "1.36.11",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.36.10",
+  "version": "1.36.11",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/start_tool.py
+++ b/start_tool.py
@@ -159,14 +159,19 @@ log("Starte Anwendung")
 # ob die Funktion vorhanden ist. Wenn sie vorhanden ist und einen
 # Root-User meldet, muss Electron ohne Sandbox gestartet werden.
 geteuid = getattr(os, "geteuid", None)
-if geteuid is not None and geteuid() == 0:
-    run("npm start -- --no-sandbox")
-else:
-    run("npm start")
 
-log("Anwendung beendet")
-print(f"Log gespeichert unter {LOGFILE}")
-print("Vorgang abgeschlossen.")
-
-# Fenster offen halten, damit Fehlermeldungen sichtbar bleiben
-input("Zum Beenden Enter drücken...")
+try:
+    if geteuid is not None and geteuid() == 0:
+        run("npm start -- --no-sandbox")
+    else:
+        run("npm start")
+except subprocess.CalledProcessError as e:
+    print("[Fehler] Anwendung konnte nicht gestartet werden. Weitere Details siehe setup.log")
+    log("Anwendung konnte nicht gestartet werden")
+    log(str(e))
+finally:
+    log("Anwendung beendet")
+    print(f"Log gespeichert unter {LOGFILE}")
+    print("Vorgang abgeschlossen.")
+    # Fenster offen halten, damit Fehlermeldungen sichtbar bleiben
+    input("Zum Beenden Enter drücken...")

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -444,7 +444,7 @@
     <div id="toastContainer"></div>
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.36.10</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.36.11</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.36.10';
+const APP_VERSION = '1.36.11';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 


### PR DESCRIPTION
## Summary
- handle errors when launching app in `start_tool.py`
- document improved error display and bump version to 1.36.11
- update version numbers across project

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c6cba52a88327a5b187e0973f1d2a