### PR TITLE
Update Node.js version range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 
+## 🛠️ Patch in 1.37.3
+* `package.json` verlangt jetzt Node 18–21.
+
 ## 🛠️ Patch in 1.37.2
-* `start_tool.py` und `start_tool.js` pruefen die installierte Node-Version und erwarten Node 18 bis 21.
+* `start_tool.py` und `start_tool.js` pruefen die installierte Node-Version und erwarten Node 18–21.
 
 ## 🛠️ Patch in 1.37.1
 * `start_tool.py` erkennt nun automatisch, ob es im Repository oder davor gestartet wurde.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.37.2-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.37.3-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -89,7 +89,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **JavaScript aktiviert**
 * **Lokaler Dateizugriff** für Audio‑Wiedergabe
 * **Empfohlener Speicher:** 2+ GB freier RAM für große Projekte
-* **Node.js 18 bis 21** wird benötigt (u.a. für ElevenLabs-Dubbing; nutzt `fetch` und `FormData`)
+* **Node.js 18–21** wird benötigt (u.a. für ElevenLabs-Dubbing; nutzt `fetch` und `FormData`)
 
 ### Desktop-Version (Electron)
 1. Im Hauptverzeichnis `npm install` ausführen, damit benötigte Pakete wie `chokidar` vorhanden sind
@@ -174,7 +174,7 @@ Ab Version 1.36.11 gibt das Python-Startskript bei einem Fehler von `npm start` 
 Ab Version 1.36.12 protokollieren die Start-Skripte die UID und ob Electron mit oder ohne Sandbox startet.
 Ab Version 1.37.0 zeigt das Debug-Fenster weitere Systeminformationen wie Fenstergröße und Sandbox-Status an.
 Ab Version 1.37.1 kann `start_tool.py` sowohl im Repository-Ordner als auch davor gestartet werden.
-Ab Version 1.37.2 pruefen `start_tool.py` und `start_tool.js`, ob Node 18 bis 21 installiert ist.
+Ab Version 1.37.2 pruefen `start_tool.py` und `start_tool.js`, ob Node 18–21 installiert ist.
 Die Meldung "Electron-API nicht verfügbar" weist darauf hin, dass das Tool im Browser ausgeführt wird. Pfad-Informationen sind nur in der Desktop-Version sichtbar.
 Für diesen Zweck gibt es das Node-Skript `cliRedownload.js`.
 Es wird so aufgerufen:
@@ -212,7 +212,7 @@ Ab Version 1.20.2 protokolliert das Fenster zudem `detail.message` und `error` a
 ### Version aktualisieren
 
 1. In `package.json` die neue Versionsnummer eintragen.
-2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.37.2`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
+2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.37.3`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
 
 ---
 
@@ -510,7 +510,9 @@ Das Debug-Fenster liefert nun zusätzliche Informationen wie Fenstergröße, Bil
 **Version 1.37.1 - Flexibler Start**
 `start_tool.py` erkennt nun automatisch, ob es im Repository oder im darüberliegenden Ordner ausgeführt wird.
 **Version 1.37.2 - Node-Pruefung**
-`start_tool.py` und `start_tool.js` stellen sicher, dass Node 18 bis 21 verwendet wird.
+`start_tool.py` und `start_tool.js` stellen sicher, dass Node 18–21 verwendet wird.
+**Version 1.37.3 - Aktualisiertes Node-Fenster**
+`package.json` erwartet jetzt Node 18–21.
 **Version 1.36.11 - Bessere Fehleranzeige**
 Beim Starten der Anwendung erscheint nun eine verständliche Meldung, falls `npm start` fehlschlägt. Der Fehler wird zusätzlich in `setup.log` protokolliert.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.37.2",
+  "version": "1.37.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.37.2",
+      "version": "1.37.3",
       "dependencies": {
         "chokidar": "^4.0.3"
       },
@@ -17,7 +17,7 @@
         "nock": "^14.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18 <22"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.37.2",
+  "version": "1.37.3",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",
@@ -8,7 +8,7 @@
     "nock": "^14.0.5"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18 <22"
   },
   "scripts": {
     "pretest": "npm install",

--- a/start_tool.js
+++ b/start_tool.js
@@ -46,7 +46,7 @@ try {
     log(`Gefundene Node-Version: ${output}`);
     const major = parseInt(output.replace(/^v/, '').split('.')[0], 10);
     if (isNaN(major) || major < 18 || major >= 22) {
-        console.error(`[Fehler] Node.js Version ${output} wird nicht unterstuetzt. Bitte Node 18 bis 21 installieren.`);
+        console.error(`[Fehler] Node.js Version ${output} wird nicht unterstuetzt. Bitte Node 18–21 installieren.`);
         log('Unpassende Node-Version');
         process.exit(1);
     }

--- a/start_tool.py
+++ b/start_tool.py
@@ -58,7 +58,7 @@ try:
     except ValueError:
         major = None
     if major is None or major < 18 or major >= 22:
-        print(f"[Fehler] Node.js Version {output} wird nicht unterstuetzt. Bitte Node 18 bis 21 installieren.")
+        print(f"[Fehler] Node.js Version {output} wird nicht unterstuetzt. Bitte Node 18–21 installieren.")
         log("Unpassende Node-Version")
         sys.exit(1)
 except subprocess.CalledProcessError as e:

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -444,7 +444,7 @@
     <div id="toastContainer"></div>
 
     <!-- Versionsanzeige -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.37.2</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.37.3</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -64,7 +64,7 @@ let undoStack          = [];
 let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
-const APP_VERSION = '1.37.2';
+const APP_VERSION = '1.37.3';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 


### PR DESCRIPTION
## Summary
- update Node.js engines field to `>=18 <22`
- mention Node.js 18–21 in README and changelog
- bump version to 1.37.3
- synchronise version references across code
- adjust Node error messages in start scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c7c7284fc8327a6af3329425997ff