### PR TITLE
Add fallback electron install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 
+## 🛠️ Patch in 1.37.5
+* Nach einem erfolgreichen `npm install` im `electron`-Ordner pruefen die Start-Skripte, ob das Electron-Modul fehlt und installieren es gegebenenfalls nach.
+
 ## 🛠️ Patch in 1.37.4
 * Node 22 wird jetzt unterstuetzt. `start_tool.py` und `start_tool.js` akzeptieren diese Version.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.37.4-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.37.5-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -212,7 +212,7 @@ Ab Version 1.20.2 protokolliert das Fenster zudem `detail.message` und `error` a
 ### Version aktualisieren
 
 1. In `package.json` die neue Versionsnummer eintragen.
-2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.37.4`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
+2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.37.5`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
 
 ---
 
@@ -515,6 +515,8 @@ Das Debug-Fenster liefert nun zusätzliche Informationen wie Fenstergröße, Bil
 `package.json` erwartet jetzt Node 18–21.
 **Version 1.37.4 - Node 22-Unterstützung**
 `start_tool.py` und `start_tool.js` akzeptieren nun Node 22.
+**Version 1.37.5 - Electron-Fallback**
+Fehlt nach `npm install` das Electron-Modul, wird es automatisch nachinstalliert.
 **Version 1.36.11 - Bessere Fehleranzeige**
 Beim Starten der Anwendung erscheint nun eine verständliche Meldung, falls `npm start` fehlschlägt. Der Fehler wird zusätzlich in `setup.log` protokolliert.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.37.4",
+  "version": "1.37.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.37.4",
+      "version": "1.37.5",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.37.4",
+  "version": "1.37.5",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/start_tool.js
+++ b/start_tool.js
@@ -156,6 +156,20 @@ try {
     process.exit(1);
 }
 
+// Nach der Installation pruefen, ob das Electron-Modul existiert
+if (!fs.existsSync(path.join('node_modules', 'electron'))) {
+    console.log('Electron-Modul fehlt, wird nachinstalliert...');
+    log('Electron-Modul fehlt - versuche "npm install electron"');
+    try {
+        run('npm install electron');
+        log('npm install electron erfolgreich');
+    } catch (err) {
+        console.error('npm install electron fehlgeschlagen. Weitere Details siehe setup.log');
+        log('npm install electron fehlgeschlagen');
+        log(err.toString());
+    }
+}
+
 console.log('Anwendung wird gestartet...');
 log('Starte Anwendung');
 // UID ermitteln und Start-Parameter entsprechend setzen

--- a/start_tool.py
+++ b/start_tool.py
@@ -179,6 +179,18 @@ except subprocess.CalledProcessError:
     log(str(sys.exc_info()[1]))
     sys.exit(1)
 
+# Nach der Installation pruefen, ob das Electron-Modul existiert
+if not os.path.isdir(os.path.join("node_modules", "electron")):
+    print("Electron-Modul fehlt, wird nachinstalliert...")
+    log("Electron-Modul fehlt - versuche 'npm install electron'")
+    try:
+        run("npm install electron")
+        log("npm install electron erfolgreich")
+    except subprocess.CalledProcessError as e:
+        print("npm install electron fehlgeschlagen. Weitere Details siehe setup.log")
+        log("npm install electron fehlgeschlagen")
+        log(str(e))
+
 print("Anwendung wird gestartet...")
 log("Starte Anwendung")
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -445,7 +445,7 @@
 
     <!-- Versionsanzeige -->
     <!-- Verlinkung zur aktuellen Version -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.37.4</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.37.5</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -65,7 +65,7 @@ let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
 // Aktuelle Programmversion
-const APP_VERSION = '1.37.4';
+const APP_VERSION = '1.37.5';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 


### PR DESCRIPTION
## Summary
- patch version bump 1.37.5
- add fallback install for Electron in Node & Python starters
- document new feature

## Testing
- `npm run update-version`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c804b10bc8327b35357f19513a1b9