### PR TITLE
npm ci in Startskripten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 
+## 🛠️ Patch in 1.37.6
+* Start-Skripte verwenden nun `npm ci` anstelle von `npm install`.
+
 ## 🛠️ Patch in 1.37.5
 * Nach einem erfolgreichen `npm install` im `electron`-Ordner pruefen die Start-Skripte, ob das Electron-Modul fehlt und installieren es gegebenenfalls nach.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.37.5-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.37.6-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -92,8 +92,8 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Node.js 18–22** wird benötigt (u.a. für ElevenLabs-Dubbing; nutzt `fetch` und `FormData`)
 
 ### Desktop-Version (Electron)
-1. Im Hauptverzeichnis `npm install` ausführen, damit benötigte Pakete wie `chokidar` vorhanden sind
-2. In das Verzeichnis `electron/` wechseln und `npm install` ausführen. Fehlt npm (z.B. bei Node 22), `npm install -g npm` oder `corepack enable` nutzen
+1. Im Hauptverzeichnis `npm ci` ausführen, damit benötigte Pakete wie `chokidar` vorhanden sind
+2. In das Verzeichnis `electron/` wechseln und `npm ci` ausführen. Fehlt npm (z.B. bei Node 22), `npm install -g npm` oder `corepack enable` nutzen
 3. Mit `npm start` startet die Desktop-App ohne Browserdialog
 4. Alternativ kann `start_tool.bat` (Windows), `start_tool.js` (plattformunabhängig) oder `start_tool.py` (Python-Version) aus jedem Verzeichnis ausgeführt werden. Fehlt das Repository, wird es automatisch geklont; andernfalls werden die neuesten Änderungen geladen und die Desktop-App gestartet. `start_tool.py` erkennt dabei automatisch, ob es im Repository oder davor gestartet wurde.
 5. Beim Start werden die Ordner `web/sounds/EN` und `web/sounds/DE` automatisch erstellt und eingelesen
@@ -212,7 +212,7 @@ Ab Version 1.20.2 protokolliert das Fenster zudem `detail.message` und `error` a
 ### Version aktualisieren
 
 1. In `package.json` die neue Versionsnummer eintragen.
-2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.37.5`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
+2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.37.6`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
 
 ---
 
@@ -471,7 +471,7 @@ Alle Pfade nutzen nun `path.resolve`. Bei fehlenden Dubbings erscheint die Meldu
 **Version 1.34.2 - Chokidar-Fix**
 Behebt ein fehlendes `chokidar`-Modul in der Desktop-Version.
 **Version 1.34.3 - Auto-Install**
-Start-Skripte führen nun `npm install` im Hauptordner aus.
+Start-Skripte führen nun `npm ci` im Hauptordner aus.
 **Version 1.34.4 - Backup-Fallback**
 Der Backup-Button öffnet nun auch im Browser den `backups`-Ordner.
 **Version 1.34.5 - Backup-Kompatibilität**
@@ -515,8 +515,10 @@ Das Debug-Fenster liefert nun zusätzliche Informationen wie Fenstergröße, Bil
 `package.json` erwartet jetzt Node 18–21.
 **Version 1.37.4 - Node 22-Unterstützung**
 `start_tool.py` und `start_tool.js` akzeptieren nun Node 22.
+**Version 1.37.6 - Verbesserte Installation**
+Start-Skripte nutzen nun `npm ci` statt `npm install`.
 **Version 1.37.5 - Electron-Fallback**
-Fehlt nach `npm install` das Electron-Modul, wird es automatisch nachinstalliert.
+Fehlt nach `npm ci` das Electron-Modul, wird es automatisch nachinstalliert.
 **Version 1.36.11 - Bessere Fehleranzeige**
 Beim Starten der Anwendung erscheint nun eine verständliche Meldung, falls `npm start` fehlschlägt. Der Fehler wird zusätzlich in `setup.log` protokolliert.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.37.5",
+  "version": "1.37.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.37.5",
+      "version": "1.37.6",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.37.5",
+  "version": "1.37.6",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/start_tool.bat
+++ b/start_tool.bat
@@ -92,15 +92,15 @@ IF ERRORLEVEL 1 (
 )
 
 REM ----------------------- Haupt-Abhaengigkeiten installieren -----------------
-call :log "npm install (root) starten"
+call :log "npm ci (root) starten"
 echo Abhaengigkeiten im Hauptverzeichnis werden installiert...
-npm install
+npm ci
 IF ERRORLEVEL 1 (
-    call :log "npm install (root) fehlgeschlagen"
+    call :log "npm ci (root) fehlgeschlagen"
     pause
     exit /b 1
 ) ELSE (
-    call :log "npm install (root) erfolgreich"
+    call :log "npm ci (root) erfolgreich"
 )
 
 REM Sicherstellen, dass der Electron-Ordner existiert
@@ -118,16 +118,16 @@ IF NOT EXIST "electron" (
 
 REM ======================= Electron-Setup ================================
 cd electron
-call :log "npm install starten"
+call :log "npm ci starten"
 
 echo Abhaengigkeiten werden installiert...
-npm install
+npm ci
 IF ERRORLEVEL 1 (
-    call :log "npm install fehlgeschlagen"
+    call :log "npm ci fehlgeschlagen"
     pause
     exit /b 1
 ) ELSE (
-    call :log "npm install erfolgreich"
+    call :log "npm ci erfolgreich"
 )
 
 echo Anwendung wird gestartet...

--- a/start_tool.js
+++ b/start_tool.js
@@ -115,14 +115,14 @@ try {
 }
 
 // ----------------------- Haupt-Abhängigkeiten installieren --------------------
-log('npm install (root) starten');
+log('npm ci (root) starten');
 console.log('Abhaengigkeiten im Hauptverzeichnis werden installiert...');
 try {
-    run('npm install');
-    log('npm install (root) erfolgreich');
+    run('npm ci');
+    log('npm ci (root) erfolgreich');
 } catch (err) {
-    console.error('npm install im Hauptverzeichnis fehlgeschlagen. Weitere Details siehe setup.log');
-    log('npm install (root) fehlgeschlagen');
+    console.error('npm ci im Hauptverzeichnis fehlgeschlagen. Weitere Details siehe setup.log');
+    log('npm ci (root) fehlgeschlagen');
     log(err.toString());
     process.exit(1);
 }
@@ -144,14 +144,14 @@ if (!fs.existsSync('electron')) {
 
 // ----------------------- Electron-Setup --------------------
 process.chdir('electron');
-log('npm install starten');
+log('npm ci starten');
 console.log('Abhaengigkeiten werden installiert...');
 try {
-    run('npm install');
-    log('npm install erfolgreich');
+    run('npm ci');
+    log('npm ci erfolgreich');
 } catch (err) {
-    console.error('npm install fehlgeschlagen. Weitere Details siehe setup.log');
-    log('npm install fehlgeschlagen');
+    console.error('npm ci fehlgeschlagen. Weitere Details siehe setup.log');
+    log('npm ci fehlgeschlagen');
     log(err.toString());
     process.exit(1);
 }

--- a/start_tool.py
+++ b/start_tool.py
@@ -142,14 +142,14 @@ except subprocess.CalledProcessError:
     log(str(sys.exc_info()[1]))
 
 # ----------------------- Haupt-Abhaengigkeiten installieren -----------------
-log("npm install (root) starten")
+log("npm ci (root) starten")
 print("Abhaengigkeiten im Hauptverzeichnis werden installiert...")
 try:
-    run("npm install")
-    log("npm install (root) erfolgreich")
+    run("npm ci")
+    log("npm ci (root) erfolgreich")
 except subprocess.CalledProcessError as e:
-    print("npm install im Hauptverzeichnis fehlgeschlagen. Weitere Details siehe setup.log")
-    log("npm install (root) fehlgeschlagen")
+    print("npm ci im Hauptverzeichnis fehlgeschlagen. Weitere Details siehe setup.log")
+    log("npm ci (root) fehlgeschlagen")
     log(str(e))
     sys.exit(1)
 
@@ -168,14 +168,14 @@ if not os.path.isdir("electron"):
 
 # ----------------------- Electron-Setup --------------------
 os.chdir("electron")
-log("npm install starten")
+log("npm ci starten")
 print("Abhaengigkeiten werden installiert...")
 try:
-    run("npm install")
-    log("npm install erfolgreich")
+    run("npm ci")
+    log("npm ci erfolgreich")
 except subprocess.CalledProcessError:
-    print("npm install fehlgeschlagen. Weitere Details siehe setup.log")
-    log("npm install fehlgeschlagen")
+    print("npm ci fehlgeschlagen. Weitere Details siehe setup.log")
+    log("npm ci fehlgeschlagen")
     log(str(sys.exc_info()[1]))
     sys.exit(1)
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -445,7 +445,7 @@
 
     <!-- Versionsanzeige -->
     <!-- Verlinkung zur aktuellen Version -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.37.5</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.37.6</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -65,7 +65,7 @@ let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
 // Aktuelle Programmversion
-const APP_VERSION = '1.37.5';
+const APP_VERSION = '1.37.6';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 


### PR DESCRIPTION
## Summary
- nutze `npm ci` anstatt `npm install` in allen Startskripten
- passe Dokumentation und Changelog an
- erhöhe Version auf **1.37.6**

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c81a0c9908327a0d1f0ef388e37b6