### PR TITLE
Add environment checker and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## ✨ Neue Features in 1.38.0
+* Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.37.6-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.38.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -100,6 +100,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 6. Kopieren Sie Ihre Originaldateien in `web/sounds/EN` und legen Sie Übersetzungen in `web/sounds/DE` ab
 7. Während des Setups erzeugen alle Skripte (`start_tool.bat`, `start_tool.js` und `start_tool.py`) die Logdatei `setup.log`, in der alle Schritte gespeichert werden. Bei Fehlern weist die Konsole nun explizit auf diese Datei hin.
 8. Die Skripte verwerfen lokale Änderungen, **ohne** den Ordner `web/sounds` anzutasten – Projektdaten bleiben somit erhalten
+9. `node check_environment.js` prueft Node- und npm-Version, installiert Abhaengigkeiten und startet einen kurzen Electron-Test. Ergebnisse stehen in `setup.log`.
 
 ### ElevenLabs-Dubbing
 
@@ -212,7 +213,7 @@ Ab Version 1.20.2 protokolliert das Fenster zudem `detail.message` und `error` a
 ### Version aktualisieren
 
 1. In `package.json` die neue Versionsnummer eintragen.
-2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.37.6`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
+2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.38.0`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
 
 ---
 

--- a/check_environment.js
+++ b/check_environment.js
@@ -1,0 +1,127 @@
+const { execSync, spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const https = require('https');
+const { WebSocket } = require('ws');
+
+const LOGFILE = path.join(__dirname, 'setup.log');
+
+function log(msg) {
+  const timestamp = new Date().toISOString().replace('T', ' ').split('.')[0];
+  fs.appendFileSync(LOGFILE, `${timestamp} ${msg}\n`);
+}
+
+function run(cmd, options = {}) {
+  log(`Führe aus: ${cmd}`);
+  return execSync(cmd, { stdio: 'inherit', ...options });
+}
+
+function fetchJson(url) {
+  if (typeof fetch === 'function') {
+    return fetch(url).then(res => res.json());
+  }
+  return new Promise((resolve, reject) => {
+    const client = url.startsWith('https') ? https : http;
+    client.get(url, res => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try { resolve(JSON.parse(data)); } catch (e) { reject(e); }
+      });
+    }).on('error', reject);
+  });
+}
+
+(async () => {
+  log('Umgebungsprüfung gestartet');
+  try {
+    if (!fs.existsSync('package.json') || !fs.existsSync('electron')) {
+      console.error('Bitte im Hauptverzeichnis ausführen.');
+      log('Falsches Arbeitsverzeichnis');
+      process.exit(1);
+    }
+    const nodeVer = execSync('node --version').toString().trim();
+    log(`Node-Version: ${nodeVer}`);
+    const major = parseInt(nodeVer.replace(/^v/, '').split('.')[0], 10);
+    if (isNaN(major) || major < 18 || major >= 23) {
+      console.error('Node-Version nicht unterstützt (18–22 erwartet).');
+      log('Unpassende Node-Version erkannt');
+      process.exit(1);
+    }
+    const npmVer = execSync('npm --version').toString().trim();
+    log(`npm-Version: ${npmVer}`);
+  } catch (err) {
+    log('Fehler beim Prüfen von Node oder npm');
+    log(err.toString());
+    process.exit(1);
+  }
+
+  try {
+    log('Installiere Abhängigkeiten im Hauptverzeichnis');
+    run('npm ci');
+  } catch (err) {
+    log('npm ci im Hauptverzeichnis fehlgeschlagen');
+    log(err.toString());
+    process.exit(1);
+  }
+
+  try {
+    log('Installiere Abhängigkeiten im electron-Ordner');
+    run('npm ci', { cwd: path.join(__dirname, 'electron') });
+  } catch (err) {
+    log('npm ci im electron-Ordner fehlgeschlagen');
+    log(err.toString());
+    process.exit(1);
+  }
+
+  try {
+    const version = execSync('npx electron --version --no-sandbox', { cwd: path.join(__dirname, 'electron') }).toString().trim();
+    log(`Gefundene Electron-Version: ${version}`);
+  } catch (err) {
+    log('Electron-Version konnte nicht ermittelt werden');
+    log(err.toString());
+  }
+
+  log('Starte Testlauf von Electron');
+  const electronProcess = spawn('npx', ['electron', '.', '--disable-gpu', '--no-sandbox', '--remote-debugging-port=9223'], { cwd: path.join(__dirname, 'electron') });
+  electronProcess.stderr.on('data', d => fs.appendFileSync(LOGFILE, d));
+  electronProcess.stdout.on('data', d => fs.appendFileSync(LOGFILE, d));
+
+  let apiResult = false;
+  try {
+    // auf Debug-Port warten
+    for (let i = 0; i < 10; i++) {
+      try {
+        await fetchJson('http://localhost:9223/json/list');
+        break;
+      } catch {
+        await new Promise(r => setTimeout(r, 500));
+      }
+    }
+    const list = await fetchJson('http://localhost:9223/json/list');
+    const wsUrl = list[0].webSocketDebuggerUrl;
+    await new Promise((resolve, reject) => {
+      const ws = new WebSocket(wsUrl);
+      ws.on('open', () => {
+        ws.send(JSON.stringify({ id: 1, method: 'Runtime.evaluate', params: { expression: 'typeof window.electronAPI !== "undefined"' } }));
+      });
+      ws.on('message', data => {
+        const msg = JSON.parse(data);
+        if (msg.id === 1) {
+          apiResult = msg.result && msg.result.result && msg.result.result.value;
+          ws.close();
+        }
+      });
+      ws.on('close', resolve);
+      ws.on('error', err => { reject(err); });
+    });
+  } catch (err) {
+    log('Abfrage von window.electronAPI fehlgeschlagen');
+    log(err.toString());
+  }
+
+  electronProcess.kill('SIGTERM');
+  log(`ElectronAPI verfügbar: ${apiResult}`);
+  console.log('Ergebnis der Prüfung:', apiResult ? 'OK' : 'FEHLER');
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.37.6",
+  "version": "1.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.37.6",
+      "version": "1.38.0",
       "dependencies": {
         "chokidar": "^4.0.3"
       },
@@ -14,7 +14,8 @@
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",
         "jsdom": "^26.1.0",
-        "nock": "^14.0.5"
+        "nock": "^14.0.5",
+        "ws": "^8.17.0"
       },
       "engines": {
         "node": ">=18 <23"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.37.6",
+  "version": "1.38.0",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",
     "jsdom": "^26.1.0",
-    "nock": "^14.0.5"
+    "nock": "^14.0.5",
+    "ws": "^8.17.0"
   },
   "engines": {
     "node": ">=18 <23"

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -445,7 +445,7 @@
 
     <!-- Versionsanzeige -->
     <!-- Verlinkung zur aktuellen Version -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.37.6</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.38.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -65,7 +65,7 @@ let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
 // Aktuelle Programmversion
-const APP_VERSION = '1.37.6';
+const APP_VERSION = '1.38.0';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 


### PR DESCRIPTION
## Summary
- add `check_environment.js` for automatic environment setup
- document the new script in the README
- bump version to 1.38.0 and update placeholders
- note new version in CHANGELOG

## Testing
- `npm test`
- `npm run update-version`

------
https://chatgpt.com/codex/tasks/task_e_684c833d55008327825f11b9e3b02dbf