### PR TITLE
Add electron module check in environment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.38.3-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.38.4-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -214,7 +214,7 @@ Ab Version 1.20.2 protokolliert das Fenster zudem `detail.message` und `error` a
 ### Version aktualisieren
 
 1. In `package.json` die neue Versionsnummer eintragen.
-2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.38.3`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
+2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.38.4`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
 
 ---
 
@@ -525,6 +525,8 @@ Fehlt nach `npm ci` das Electron-Modul, wird es automatisch nachinstalliert.
 Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und testet Electron.
 **Version 1.38.1 - Einfacherer Reset**
 `git reset --hard HEAD` entfernt lokale Änderungen, ohne `web/sounds` und `web/backups` anzutasten.
+**Version 1.38.4 - Zuverlaessiger Environment-Check**
+`check_environment.js` stellt nach `npm ci` sicher, dass das Electron-Modul vorhanden ist und installiert es sonst nach.
 **Version 1.38.3 - Node-Check in start_tool.bat**
 Die Batch-Datei prueft nun die installierte Node-Version und verlangt Node 18 bis 22.
 **Version 1.38.2 - Zuverlaessiges Electron-Modul**

--- a/check_environment.js
+++ b/check_environment.js
@@ -69,6 +69,29 @@ function fetchJson(url) {
   try {
     log('Installiere Abhängigkeiten im electron-Ordner');
     run('npm ci', { cwd: path.join(__dirname, 'electron') });
+    // Nach der Installation prüfen, ob das Electron-Modul vorhanden ist
+    const electronPath = path.join(__dirname, 'electron', 'node_modules', 'electron');
+    if (!fs.existsSync(electronPath)) {
+      console.log('Electron-Modul fehlt, wird nachinstalliert...');
+      log('Electron-Modul fehlt - versuche "npm install electron"');
+      let installError = false;
+      try {
+        run('npm install electron', { cwd: path.join(__dirname, 'electron') });
+        log('npm install electron erfolgreich');
+      } catch (err) {
+        installError = true;
+        log('npm install electron fehlgeschlagen');
+        log(err.toString());
+      }
+      // Nach der Installation erneut prüfen
+      if (!fs.existsSync(electronPath)) {
+        console.error('[Fehler] Electron-Modul fehlt weiterhin.');
+        log('Electron-Modul weiterhin nicht vorhanden');
+        process.exit(1);
+      } else if (installError) {
+        console.log('Electron wurde installiert, trotz Fehlermeldung.');
+      }
+    }
   } catch (err) {
     log('npm ci im electron-Ordner fehlgeschlagen');
     log(err.toString());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.38.3",
+  "version": "1.38.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.38.3",
+      "version": "1.38.4",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.38.3",
+  "version": "1.38.4",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -445,7 +445,7 @@
 
     <!-- Versionsanzeige -->
     <!-- Verlinkung zur aktuellen Version -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.38.3</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.38.4</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -65,7 +65,7 @@ let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
 // Aktuelle Programmversion
-const APP_VERSION = '1.38.3';
+const APP_VERSION = '1.38.4';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 


### PR DESCRIPTION
## Summary
- check for Electron after `npm ci` in `check_environment.js`
- update version to **1.38.4**
- document the new check in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c8f9f2950832797e9127fe12db456