### PR TITLE
Add admin status to debug info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 ## 🛠️ Patch in 1.38.6
 * Debug-Fenster zeigt nun ausfuehrliche System- und Pfadinformationen sowie die letzten Zeilen aus `setup.log`.
 
+## 🛠️ Patch in 1.38.7
+* Debug-Fenster meldet jetzt, ob das Programm mit Administratorrechten gestartet wurde.
+
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 
 ## 🛠️ Patch in 1.37.6

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.38.6-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.38.7-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -214,7 +214,7 @@ Ab Version 1.20.2 protokolliert das Fenster zudem `detail.message` und `error` a
 ### Version aktualisieren
 
 1. In `package.json` die neue Versionsnummer eintragen.
-2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.38.6`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
+2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.38.7`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
 
 ---
 
@@ -531,6 +531,8 @@ Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigke
 `check_environment.js` kann jetzt mit `--tool-check` einen kurzen Start der Desktop-App per `python start_tool.py --check` ausfuehren.
 **Version 1.38.6 - Erweiterte Debug-Infos**
 Das Debug-Fenster zeigt nun ausführliche System- und Pfadinformationen sowie die letzten Zeilen aus `setup.log`.
+**Version 1.38.7 - Admin-Erkennung**
+Das Debug-Fenster informiert nun, ob das Programm mit Administratorrechten läuft.
 **Version 1.38.3 - Node-Check in start_tool.bat**
 Die Batch-Datei prueft nun die installierte Node-Version und verlangt Node 18 bis 22.
 **Version 1.38.2 - Zuverlaessiges Electron-Modul**

--- a/electron/main.js
+++ b/electron/main.js
@@ -185,6 +185,19 @@ app.whenReady().then(() => {
     const soundsPath = path.resolve(projectRoot, soundsDirName);
     const backupsPath = path.resolve(projectRoot, backupsDirName);
 
+    // Helper zum Pruefen, ob das Programm mit Adminrechten laeuft
+    function isElevated() {
+      if (process.platform === 'win32') {
+        try {
+          execSync('net session', { stdio: 'ignore' });
+          return true;
+        } catch {
+          return false;
+        }
+      }
+      return process.getuid && process.getuid() === 0;
+    }
+
     // Pfade zu wichtigen Dateien
     const pkgPath = path.join(projectRoot, 'package.json');
     const nodeModulesPath = path.join(projectRoot, 'node_modules');
@@ -248,6 +261,7 @@ app.whenReady().then(() => {
       gitCommit,
       startArgs: process.argv.join(' '),
       setupLog,
+      admin: isElevated(),
     };
   });
   // =========================== DEBUG-INFO END ===============================

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.38.6",
+  "version": "1.38.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.38.6",
+      "version": "1.38.7",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.38.6",
+  "version": "1.38.7",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -445,7 +445,7 @@
 
     <!-- Versionsanzeige -->
     <!-- Verlinkung zur aktuellen Version -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.38.6</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.38.7</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -65,7 +65,7 @@ let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
 // Aktuelle Programmversion
-const APP_VERSION = '1.38.6';
+const APP_VERSION = '1.38.7';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 
@@ -6088,7 +6088,8 @@ function executeCleanup(cleanupPlan, totalToDelete) {
                     URL: location.href,
                     Plattform: navigator.platform,
                     Sprache: navigator.language,
-                    'Electron-API vorhanden': typeof window.electronAPI !== 'undefined'
+                    'Electron-API vorhanden': typeof window.electronAPI !== 'undefined',
+                    'Im Browser gestartet': true
                 };
 
                 // Zusätzliche Infos, wenn ein Node-Process existiert
@@ -6122,7 +6123,9 @@ function executeCleanup(cleanupPlan, totalToDelete) {
             info['Benutzeragent'] = navigator.userAgent;
             info['Verwendete Sprache'] = navigator.language;
             info.URL = location.href;
-            info['Electron-API vorhanden'] = typeof window.electronAPI !== 'undefined';
+            const hasElectron = typeof window.electronAPI !== 'undefined';
+            info['Electron-API vorhanden'] = hasElectron;
+            info['Im Browser gestartet'] = !hasElectron;
 
             // Debug-Konsole auslesen
             const debugText = document.getElementById('debugConsole')?.textContent || '';


### PR DESCRIPTION
## Summary
- detect Adminrechte in Electron Hauptprozess und an Debug-Fenster melden
- zeigen, ob das Tool im Browser gestartet wurde
- update Dokumentation und Version auf 1.38.7

## Testing
- `npm test`
- `npm run update-version`

------
https://chatgpt.com/codex/tasks/task_e_684c960cd4bc832794e13e2b17f6e59b