### PR TITLE
Add reset script and bump version to 1.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 ## 🛠️ Patch in 1.38.8
 * Debug-Fenster zeigt nun die App-, Node-, Electron- und Chrome-Version an.
 
+## ✨ Neue Features in 1.39.0
+* Neues Skript `reset_repo.py` setzt das Repository per Doppelklick zurueck und holt Updates.
+
 Alle wesentlichen Änderungen des Projekts. Die jeweils aktuelle Version steht an erster Stelle.
 
 ## 🛠️ Patch in 1.37.6

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.38.8-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.39.0-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -102,6 +102,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 8. Die Skripte verwerfen lokale Änderungen, **ohne** den Ordner `web/sounds` anzutasten – Projektdaten bleiben somit erhalten
 9. `node check_environment.js` prueft Node- und npm-Version, installiert Abhaengigkeiten und startet einen kurzen Electron-Test. Mit `--tool-check` fuehrt das Skript zusaetzlich `python start_tool.py --check` aus, um die Desktop-App kurz zu testen. Ergebnisse stehen in `setup.log`.
 10. Alle Start-Skripte kontrollieren nun die installierte Node-Version und brechen bei Abweichungen ab.
+11. Bei Problemen mit lokalen Aenderungen kann `reset_repo.py` diese verwerfen und das Repository aktualisieren.
 
 ### ElevenLabs-Dubbing
 
@@ -214,7 +215,7 @@ Ab Version 1.20.2 protokolliert das Fenster zudem `detail.message` und `error` a
 ### Version aktualisieren
 
 1. In `package.json` die neue Versionsnummer eintragen.
-2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.38.8`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
+2. Danach `npm run update-version` ausführen. Das Skript ersetzt alle `1.39.0`-Platzhalter in `README.md`, `web/src/main.js` und `web/hla_translation_tool.html` durch die aktuelle Nummer.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.38.8",
+  "version": "1.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.38.8",
+      "version": "1.39.0",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.38.8",
+  "version": "1.39.0",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/reset_repo.py
+++ b/reset_repo.py
@@ -1,0 +1,35 @@
+"""reset_repo.py
+Einfaches Skript, um das Git-Repository des HLA Translation Tools komplett
+zurueckzusetzen und die neuesten Aenderungen zu holen.
+Nur doppelklicken und warten.
+"""
+
+import os
+import subprocess
+
+
+def run(cmd: str) -> None:
+    """Hilfsfunktion zum Ausfuehren eines Befehls."""
+    print(f"Fuehre aus: {cmd}")
+    subprocess.check_call(cmd, shell=True)
+
+
+def main() -> None:
+    # Verzeichnis dieses Skripts ermitteln
+    repo_dir = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(repo_dir)
+
+    try:
+        run("git reset --hard HEAD")
+        run("git clean -fd")
+        run("git pull")
+    except subprocess.CalledProcessError as e:
+        print(f"Fehler: {e}")
+    else:
+        print("Repository wurde erfolgreich aktualisiert.")
+    finally:
+        input("Fertig. Mit Enter schliessen...")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -445,7 +445,7 @@
 
     <!-- Versionsanzeige -->
     <!-- Verlinkung zur aktuellen Version -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.38.8</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.39.0</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -65,7 +65,7 @@ let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
 // Aktuelle Programmversion
-const APP_VERSION = '1.38.8';
+const APP_VERSION = '1.39.0';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 


### PR DESCRIPTION
## Summary
- add `reset_repo.py` for einfaches Zurücksetzen des Repos
- Versionsnummer auf 1.39.0 aktualisiert
- README und CHANGELOG mit neuem Skript ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c9bc2d0e48327a5e5c03c836a85fe