### PR TITLE
Fix File polyfill for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,7 @@ Ein neuer GitHub-Workflow (`node-test.yml`) führt nach jedem Push oder Pull Req
 Die wichtigsten Tests befinden sich im Ordner `tests/` und prüfen unter
 anderem die Funktion `calculateProjectStats`. Neu sind Tests für die
 ElevenLabs‑Anbindung (z. B. `getDubbingStatus`) und `manualDub.test.js`, der `csv_file` und `voice_id` überprüft. Zudem prüft ein Test `showDubbingSettings`, ob der Dialog im DOM erscheint.
+Ab Version 1.40.3 nutzt `manualDub.test.js` einen kleinen Polyfill, damit der `File`-Konstruktor auch in Node-Umgebungen verfügbar ist.
 
 ## ▶️ E2E-Test
 

--- a/tests/manualDub.test.js
+++ b/tests/manualDub.test.js
@@ -1,5 +1,17 @@
 const nock = require('nock');
 
+// Polyfill für die File-API unter Node
+if (typeof File === 'undefined') {
+    const { Blob } = require('buffer');
+    global.File = class File extends Blob {
+        constructor(parts, name, options = {}) {
+            super(parts, options);
+            this.name = name;
+            this.lastModified = options.lastModified || Date.now();
+        }
+    };
+}
+
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 


### PR DESCRIPTION
## Zusammenfassung
- File-Polyfill für Node-Umgebungen in `manualDub.test.js`
- README um Hinweis auf den Polyfill ergänzt

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ca68a564c8327af7fc2b983c132e5