### PR TITLE
Add watcher test

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ Ein neuer GitHub-Workflow (`node-test.yml`) führt nach jedem Push oder Pull Req
 
 Die wichtigsten Tests befinden sich im Ordner `tests/` und prüfen unter
 anderem die Funktion `calculateProjectStats`. Neu sind Tests für die
-ElevenLabs‑Anbindung (z. B. `getDubbingStatus`) und `manualDub.test.js`, der `csv_file` und `voice_id` überprüft. Zudem prüft ein Test `showDubbingSettings`, ob der Dialog im DOM erscheint.
+ElevenLabs‑Anbindung (z. B. `getDubbingStatus`) und `manualDub.test.js`, der `csv_file` und `voice_id` überprüft. Zudem prüft ein Test `showDubbingSettings`, ob der Dialog im DOM erscheint. Ebenfalls neu ist `watcher.test.js`, der das Anlegen einer Datei im Download‑Ordner simuliert und den entsprechenden Callback testet.
 Ab Version 1.40.3 nutzt `manualDub.test.js` einen kleinen Polyfill, damit der `File`-Konstruktor auch in Node-Umgebungen verfügbar ist.
 Ab Version 1.40.4 funktioniert der Dev-Button wieder in jeder Version, weil seine Funktion global bereitsteht.
 Ab Version 1.40.5 führt das `pretest`-Skript nun `npm ci` statt `npm install` aus.

--- a/tests/watcher.test.js
+++ b/tests/watcher.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Testet, ob watchDownloadFolder den Callback bei einer neuen Datei auslöst
+
+describe('watchDownloadFolder', () => {
+  test('reagiert auf angelegte Datei', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'watch-'));
+
+    const onAddCallbacks = [];
+
+    // Module-Cache leeren und Abhängigkeiten mocken
+    jest.resetModules();
+    jest.doMock('../web/src/config.js', () => ({ DL_WATCH_PATH: tmpDir }), { virtual: false });
+    jest.doMock('chokidar', () => ({
+      watch: jest.fn(() => ({
+        on: jest.fn((event, cb) => {
+          if (event === 'add') onAddCallbacks.push(cb);
+        })
+      }))
+    }));
+
+    const { watchDownloadFolder } = require('../web/src/watcher.js');
+
+    const callback = jest.fn();
+    watchDownloadFolder(callback);
+
+    const file = path.join(tmpDir, 'neu.txt');
+    onAddCallbacks.forEach(cb => cb(file));
+
+    expect(callback).toHaveBeenCalledWith(file);
+  });
+});


### PR DESCRIPTION
## Summary
- add watcher.test.js using mocks for chokidar and config
- document new test in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cac4988208327b9ec10d4696f97cc