### PR TITLE
Verbessere Reset-Skript

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 8. Die Skripte verwerfen lokale Änderungen, **ohne** den Ordner `web/sounds` anzutasten – Projektdaten bleiben somit erhalten
 9. `node check_environment.js` prueft Node- und npm-Version, installiert Abhaengigkeiten und startet einen kurzen Electron-Test. Mit `--tool-check` fuehrt das Skript zusaetzlich `python start_tool.py --check` aus, um die Desktop-App kurz zu testen. Ergebnisse stehen in `setup.log`.
 10. Alle Start-Skripte kontrollieren nun die installierte Node-Version und brechen bei Abweichungen ab.
-11. Bei Problemen mit lokalen Aenderungen kann `reset_repo.py` diese verwerfen und das Repository aktualisieren.
+11. `reset_repo.py` setzt das Repository nun komplett zurück, installiert alle Abhängigkeiten in beiden Ordnern und startet anschließend automatisch die Desktop-App.
 
 ### ElevenLabs-Dubbing
 
@@ -576,6 +576,7 @@ Ab Version 1.40.3 lädt die Desktop-Version `config.js` auch im gepackten Zustan
 Ab Version 1.40.4 funktioniert der Dev-Button wieder in jeder Version, weil seine Funktion global bereitsteht.
 Ab Version 1.40.5 führt das `pretest`-Skript nun `npm ci` statt `npm install` aus.
 Ab Version 1.40.6 stürzt das Debug-Fenster im Browser nicht mehr ab, wenn kein Node-Prozess vorhanden ist.
+Ab Version 1.40.7 kann `reset_repo.py` das Repository komplett aktualisieren, alle Abhängigkeiten installieren und anschließend die Desktop-App starten.
 
 ## ▶️ E2E-Test
 

--- a/reset_repo.py
+++ b/reset_repo.py
@@ -1,17 +1,16 @@
 """reset_repo.py
-Einfaches Skript, um das Git-Repository des HLA Translation Tools komplett
-zurueckzusetzen und die neuesten Aenderungen zu holen.
-Nur doppelklicken und warten.
+Ein Skript zum Zurücksetzen des Repositories, Installieren aller Abhängigkeiten
+und Starten der Desktop-Version. Nur doppelklicken und warten.
 """
 
 import os
 import subprocess
 
 
-def run(cmd: str) -> None:
-    """Hilfsfunktion zum Ausfuehren eines Befehls."""
-    print(f"Fuehre aus: {cmd}")
-    subprocess.check_call(cmd, shell=True)
+def run(cmd: str, cwd: str | None = None) -> None:
+    """Hilfsfunktion zum Ausführen eines Befehls."""
+    print(f"Führe aus: {cmd}")
+    subprocess.check_call(cmd, shell=True, cwd=cwd)
 
 
 def main() -> None:
@@ -19,14 +18,22 @@ def main() -> None:
     repo_dir = os.path.dirname(os.path.abspath(__file__))
     os.chdir(repo_dir)
 
+    electron_dir = os.path.join(repo_dir, "electron")
+
     try:
         run("git reset --hard HEAD")
-        run("git clean -fd")
+        run("git clean -fd -e web/sounds -e web/Sounds -e web/backups -e web/Backups -e web/Download")
         run("git pull")
+        print("Installiere Abh\u00e4ngigkeiten im Hauptordner...")
+        run("npm ci")
+        print("Installiere Abh\u00e4ngigkeiten im electron-Ordner...")
+        run("npm ci", cwd=electron_dir)
+        print("Starte Desktop-App...")
+        run("npm start", cwd=electron_dir)
     except subprocess.CalledProcessError as e:
         print(f"Fehler: {e}")
     else:
-        print("Repository wurde erfolgreich aktualisiert.")
+        print("Tool wurde erfolgreich gestartet.")
     finally:
         input("Fertig. Mit Enter schliessen...")
 


### PR DESCRIPTION
## Summary
- erweitere `reset_repo.py` um npm-Installation und Start der App
- beschreibe neues Verhalten in der README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cb2cdc8d08327a1cea8392e2732d0