### PR TITLE
Fix path module resolution in Electron preload

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ Ab Version 1.40.4 funktioniert der Dev-Button wieder in jeder Version, weil sein
 Ab Version 1.40.5 führt das `pretest`-Skript nun `npm ci` statt `npm install` aus.
 Ab Version 1.40.6 stürzt das Debug-Fenster im Browser nicht mehr ab, wenn kein Node-Prozess vorhanden ist.
 Ab Version 1.40.7 kann `reset_repo.py` das Repository komplett aktualisieren, alle Abhängigkeiten installieren und anschließend die Desktop-App starten.
+Ab Version 1.40.8 nutzt das Preload-Skript `node:path`, damit Electron-Pakete fehlerfrei starten.
 
 ## ▶️ E2E-Test
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,5 +1,6 @@
 const { app, BrowserWindow, ipcMain, globalShortcut, dialog, shell } = require('electron');
-const path = require('path'); // Pfadmodul einbinden
+// 'node:path' nutzen, damit das integrierte Modul auch nach dem Packen gefunden wird
+const path = require('node:path'); // Pfadmodul einbinden
 const fs = require('fs');
 const { execSync } = require('child_process');
 // Lade Konfiguration relativ zum aktuellen Verzeichnis

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,5 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron');
-const path = require('path');
+// 'node:path' nutzen, damit das integrierte Modul auch nach dem Packen gefunden wird
+const path = require('node:path');
 // Konfiguration dynamisch laden, damit der Pfad auch nach dem Packen stimmt
 const { DL_WATCH_PATH } = require(path.join(__dirname, '..', 'web', 'src', 'config.js'));
 contextBridge.exposeInMainWorld('electronAPI', {


### PR DESCRIPTION
## Summary
- use `node:path` in Electron files so bundlers resolve the built-in module
- document the new requirement in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cb8a02bb88327b889687fdac66810