### PR TITLE
Check for require in preload

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ Ab Version 1.40.6 stürzt das Debug-Fenster im Browser nicht mehr ab, wenn kein 
 Ab Version 1.40.7 kann `reset_repo.py` das Repository komplett aktualisieren, alle Abhängigkeiten installieren und anschließend die Desktop-App starten.
 Ab Version 1.40.8 nutzt das Preload-Skript `node:path`, damit Electron-Pakete fehlerfrei starten.
 Ab Version 1.40.9 meldet `findAudioInFilePathCache` beim Suchen den kompletten Pfad in der Debug-Konsole.
+Ab Version 1.40.10 pr\u00fcft das Preload-Skript, ob `require` vorhanden ist und bricht andernfalls mit einer Warnung ab.
 
 ## ▶️ E2E-Test
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,30 +1,35 @@
-const { contextBridge, ipcRenderer } = require('electron');
-// 'node:path' nutzen, damit das integrierte Modul auch nach dem Packen gefunden wird
-const path = require('node:path');
-// Konfiguration dynamisch laden, damit der Pfad auch nach dem Packen stimmt
-const { DL_WATCH_PATH } = require(path.join(__dirname, '..', 'web', 'src', 'config.js'));
-contextBridge.exposeInMainWorld('electronAPI', {
-  scanFolders: () => ipcRenderer.invoke('scan-folders'),
-  // Befehl an Hauptprozess senden, um DevTools umzuschalten
-  toggleDevTools: () => ipcRenderer.send('toggle-devtools'),
-  // Datei speichern (z.B. Backup)
-  saveFile: (data, defaultPath) => ipcRenderer.invoke('save-file', { data, defaultPath }),
-  // DE-Datei im Projektordner speichern
-  saveDeFile: (relPath, data) => ipcRenderer.invoke('save-de-file', { relPath, data }),
-  backupDeFile: (relPath) => ipcRenderer.invoke('backup-de-file', relPath),
-  restoreDeFile: (relPath) => ipcRenderer.invoke('restore-de-file', relPath),
-  deleteDeBackupFile: (relPath) => ipcRenderer.invoke('delete-de-backup-file', relPath),
-  listDeHistory: (relPath) => ipcRenderer.invoke('list-de-history', relPath),
-  restoreDeHistory: (relPath, name) => ipcRenderer.invoke('restore-de-history', { relPath, name }),
-  // Backup-Funktionen
-  listBackups: () => ipcRenderer.invoke('list-backups'),
-  saveBackup: (data) => ipcRenderer.invoke('save-backup', data),
-  readBackup: (name) => ipcRenderer.invoke('read-backup', name),
-  deleteBackup: (name) => ipcRenderer.invoke('delete-backup', name),
-  openBackupFolder: () => ipcRenderer.invoke('open-backup-folder'),
-  moveFile: (src, dest) => ipcRenderer.invoke('move-file', { src, dest }),
-  onManualFile: (cb) => ipcRenderer.on('manual-file', (e, file) => cb(file)),
-  getDownloadPath: () => DL_WATCH_PATH,
-  // Liefert Pfad-Informationen für das Debug-Fenster
-  getDebugInfo: () => ipcRenderer.invoke('get-debug-info'),
-});
+// Vorab pruefen, ob 'require' verfuegbar ist
+if (typeof require !== 'function') {
+  console.warn('Preload-Skript: "require" ist nicht verf\u00fcgbar. Das Skript wird beendet.');
+} else {
+  const { contextBridge, ipcRenderer } = require('electron');
+  // 'node:path' nutzen, damit das integrierte Modul auch nach dem Packen gefunden wird
+  const path = require('node:path');
+  // Konfiguration dynamisch laden, damit der Pfad auch nach dem Packen stimmt
+  const { DL_WATCH_PATH } = require(path.join(__dirname, '..', 'web', 'src', 'config.js'));
+  contextBridge.exposeInMainWorld('electronAPI', {
+    scanFolders: () => ipcRenderer.invoke('scan-folders'),
+    // Befehl an Hauptprozess senden, um DevTools umzuschalten
+    toggleDevTools: () => ipcRenderer.send('toggle-devtools'),
+    // Datei speichern (z.B. Backup)
+    saveFile: (data, defaultPath) => ipcRenderer.invoke('save-file', { data, defaultPath }),
+    // DE-Datei im Projektordner speichern
+    saveDeFile: (relPath, data) => ipcRenderer.invoke('save-de-file', { relPath, data }),
+    backupDeFile: (relPath) => ipcRenderer.invoke('backup-de-file', relPath),
+    restoreDeFile: (relPath) => ipcRenderer.invoke('restore-de-file', relPath),
+    deleteDeBackupFile: (relPath) => ipcRenderer.invoke('delete-de-backup-file', relPath),
+    listDeHistory: (relPath) => ipcRenderer.invoke('list-de-history', relPath),
+    restoreDeHistory: (relPath, name) => ipcRenderer.invoke('restore-de-history', { relPath, name }),
+    // Backup-Funktionen
+    listBackups: () => ipcRenderer.invoke('list-backups'),
+    saveBackup: (data) => ipcRenderer.invoke('save-backup', data),
+    readBackup: (name) => ipcRenderer.invoke('read-backup', name),
+    deleteBackup: (name) => ipcRenderer.invoke('delete-backup', name),
+    openBackupFolder: () => ipcRenderer.invoke('open-backup-folder'),
+    moveFile: (src, dest) => ipcRenderer.invoke('move-file', { src, dest }),
+    onManualFile: (cb) => ipcRenderer.on('manual-file', (e, file) => cb(file)),
+    getDownloadPath: () => DL_WATCH_PATH,
+    // Liefert Pfad-Informationen für das Debug-Fenster
+    getDebugInfo: () => ipcRenderer.invoke('get-debug-info'),
+  });
+}


### PR DESCRIPTION
## Summary
- sichere Abfrage in `electron/preload.js`, ob `require` existiert
- deutscher Warnhinweis und Abbruch des Skripts falls nicht vorhanden
- README mit neuem Versionshinweis ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d2cae46048327ab7a09810be17bfb