### PR TITLE
Fix Download-Ordner Logging und absolute Pfade

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ Ab Version 1.40.7 kann `reset_repo.py` das Repository komplett aktualisieren, al
 Ab Version 1.40.8 nutzt das Preload-Skript `node:path`, damit Electron-Pakete fehlerfrei starten.
 Ab Version 1.40.9 meldet `findAudioInFilePathCache` beim Suchen den kompletten Pfad in der Debug-Konsole.
 Ab Version 1.40.10 pr\u00fcft das Preload-Skript, ob `require` vorhanden ist und bricht andernfalls mit einer Warnung ab.
+Ab Version 1.40.11 gibt `watcher.js` beim Start den überwachten Pfad aus und meldet fehlende Download-Ordner. Zudem liefert `config.js` den absoluten Pfad `SOUNDS_BASE_PATH`.
 
 ## ▶️ E2E-Test
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -4,11 +4,10 @@ const path = require('node:path'); // Pfadmodul einbinden
 const fs = require('fs');
 const { execSync } = require('child_process');
 // Lade Konfiguration relativ zum aktuellen Verzeichnis
-const { DL_WATCH_PATH, projectRoot } = require(path.join(__dirname, '..', 'web', 'src', 'config.js'));
+const { DL_WATCH_PATH, projectRoot, SOUNDS_BASE_PATH, soundsDirName } = require(path.join(__dirname, '..', 'web', 'src', 'config.js'));
 const { chooseExisting } = require('../pathUtils');
 // Nach dem Laden der Projektwurzel pruefen wir auf Gross-/Kleinschreibung.
-// Ist ein Ordner nur mit großem Anfangsbuchstaben vorhanden, wird dieser verwendet.
-const soundsDirName = chooseExisting(projectRoot, ['Sounds', 'sounds']);
+// Backups koennen ebenfalls groß oder klein geschrieben sein.
 const backupsDirName = chooseExisting(projectRoot, ['Backups', 'backups']);
 const historyUtils = require('../historyUtils');
 const { watchDownloadFolder } = require('../web/src/watcher.js');
@@ -109,7 +108,7 @@ app.commandLine.appendSwitch('disable-gpu-shader-disk-cache');
 
 app.whenReady().then(() => {
   // Basis- und Sprachordner relativ zur Projektwurzel bestimmen
-  const projectBase = path.resolve(projectRoot, soundsDirName);
+  const projectBase = SOUNDS_BASE_PATH;
   const enPath = path.resolve(projectBase, 'EN');
   const dePath = path.resolve(projectBase, 'DE');
   const deBackupPath = path.resolve(projectBase, 'DE-Backup');
@@ -184,7 +183,7 @@ app.whenReady().then(() => {
   // =========================== DEBUG-INFO START =============================
   // Liefert Pfad-Informationen für das Debug-Fenster
   ipcMain.handle('get-debug-info', () => {
-    const soundsPath = path.resolve(projectRoot, soundsDirName);
+    const soundsPath = SOUNDS_BASE_PATH;
     const backupsPath = path.resolve(projectRoot, backupsDirName);
 
     // Helper zum Pruefen, ob das Programm mit Adminrechten laeuft

--- a/web/src/config.js
+++ b/web/src/config.js
@@ -1,8 +1,13 @@
 const fs = require('fs');
 const path = require('path');
+const { chooseExisting } = require('../../pathUtils');
 
 // Projektwurzel bestimmen
 const projectRoot = path.resolve(__dirname, '..');
+// Name des Sounds-Ordners ('sounds' oder 'Sounds') automatisch ermitteln
+const soundsDirName = chooseExisting(projectRoot, ['Sounds', 'sounds']);
+// Absoluter Pfad zum Sounds-Ordner
+const SOUNDS_BASE_PATH = path.resolve(projectRoot, soundsDirName);
 // Pfad zum Download-Ordner relativ zur Projektwurzel
 const DL_WATCH_PATH = path.resolve(projectRoot, 'Download');
 
@@ -10,4 +15,4 @@ const DL_WATCH_PATH = path.resolve(projectRoot, 'Download');
 if (!fs.existsSync(DL_WATCH_PATH)) fs.mkdirSync(DL_WATCH_PATH);
 
 // Export für andere Module
-module.exports = { DL_WATCH_PATH, projectRoot };
+module.exports = { DL_WATCH_PATH, projectRoot, SOUNDS_BASE_PATH, soundsDirName };

--- a/web/src/watcher.js
+++ b/web/src/watcher.js
@@ -1,10 +1,16 @@
 // Benötigt das npm-Paket 'chokidar'
 const chokidar = require('chokidar');
+const fs = require('fs');
 const { DL_WATCH_PATH } = require('./config.js');
 
 // Überwacht den Download-Ordner und ruft den Callback
 // für jede neu angelegte Datei auf.
 function watchDownloadFolder(onFile) {
+  if (!fs.existsSync(DL_WATCH_PATH)) {
+    console.warn('Download-Ordner fehlt:', DL_WATCH_PATH);
+  } else {
+    console.log('Beobachte Download-Ordner:', DL_WATCH_PATH);
+  }
   chokidar.watch(DL_WATCH_PATH, { ignoreInitial: true })
     .on('add', filePath => onFile(filePath));
 }


### PR DESCRIPTION
## Zusammenfassung
- uebergebe SOUNDS_BASE_PATH aus `config.js`
- praezisiere Pfadangaben in `electron/main.js`
- melde fehlende Download-Ordner im `watcher`
- Dokumentation aktualisiert

## Testanweisungen
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d3774ab4883279779c74aa41fec3b