### PR TITLE
Debug-Preload sichtbar und DevTools immer offen

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 * **🔍 Debug‑Spalte:** Zeigt aufgelöste Pfade und Status
 * **📊 Datenquellen‑Analyse:** Console‑Logs für Entwickler
 * **🎯 Access‑Status:** Echtzeit‑Anzeige der Dateiberechtigungen
-* **🔧 Debug-Konsole:** Über das Dropdown "Debug-Konsole" können Sie Logs einsehen. In der Desktop-Version öffnen Sie mit `npm start -- --debug` die DevTools in einem separaten Fenster oder per `Ctrl+Shift+I`.
+* **🔧 Debug-Konsole:** Über das Dropdown "Debug-Konsole" können Sie Logs einsehen. In der Desktop-Version öffnen sich die DevTools jetzt automatisch in einem separaten Fenster oder per `Ctrl+Shift+I`.
 * **📝 Ausführliche API-Logs:** Alle Anfragen und Antworten werden im Dubbing-Log protokolliert
 
 ### Performance‑Tipps
@@ -585,6 +585,7 @@ Ab Version 1.40.12 lädt `main.js` die HTML-Datei über einen absoluten Pfad, da
 
 Ab Version 1.40.13 protokolliert das Preload-Skript Fehler und meldet "erfolgreich geladen". Die Renderer-Logik prüft jetzt `window.electronAPI`.
 Ab Version 1.40.14 protokolliert das Preload-Skript jetzt seinen Startzeitpunkt.
+Ab Version 1.40.15 öffnet die Desktop-Version die DevTools automatisch und zeigt im Preload `[PRELOAD] start` an.
 
 ## ▶️ E2E-Test
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -33,8 +33,6 @@ fs.mkdirSync(sessionDataPath, { recursive: true });
 app.setPath('sessionData', sessionDataPath);
 // =========================== USER-DATA-PFAD END =============================
 
-// Flag, ob die DevTools beim Start geöffnet werden sollen
-const isDebug = process.argv.includes('--debug');
 
 // Pfade zu EN und DE relativ zur HTML-Datei
 
@@ -84,10 +82,8 @@ function createWindow() {
   // HTML-Datei immer über einen absoluten Pfad laden
   win.loadFile(path.join(__dirname, '../web/hla_translation_tool.html'));
 
-  // DevTools optional in separatem Fenster öffnen, wenn das Flag gesetzt ist
-  if (isDebug) {
-    win.webContents.openDevTools({ mode: 'detach' });
-  }
+  // DevTools immer in einem abgekoppelten Fenster öffnen
+  win.webContents.openDevTools({ mode: 'detach' });
 
   // Shortcut zum Ein- und Ausblenden der DevTools
   globalShortcut.register('CommandOrControl+Shift+I', () => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,3 +1,6 @@
+console.log('[PRELOAD] start', __filename);
+process.on('uncaughtException',  e => console.error('[PRELOAD] uncaught', e));
+process.on('unhandledRejection', e => console.error('[PRELOAD] rejected', e));
 // Startzeitpunkt protokollieren
 console.log('[PRELOAD] gestartet', __filename);
 
@@ -12,13 +15,7 @@ if (typeof require !== 'function') {
   // Konfiguration dynamisch laden, damit der Pfad auch nach dem Packen stimmt
   const { DL_WATCH_PATH } = require(path.join(__dirname, '..', 'web', 'src', 'config.js'));
 
-  // Unerwartete Fehler sichtbar machen
-  process.on('uncaughtException', err => {
-    console.error('[Preload] uncaughtException', err);
-  });
-  process.on('unhandledRejection', err => {
-    console.error('[Preload] unhandledRejection', err);
-  });
+  // Unerwartete Fehler werden bereits oben abgefangen
 
   contextBridge.exposeInMainWorld('electronAPI', {
     versions: process.versions,


### PR DESCRIPTION
## Summary
- erweitere `preload.js` um Debug-Logs und Error-Handler
- öffne DevTools automatisch nach dem Fensterstart
- passe Doku zu den DevTools an

## Testing
- `npm test`
- `python start_tool.py` *(fehlgeschlagen: fehlender X-Server)*

------
https://chatgpt.com/codex/tasks/task_e_684d416374a88327b2b890156f5d3009