### PR TITLE
Renderer-Erkennung vereinheitlicht

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ Ab Version 1.40.12 lädt `main.js` die HTML-Datei über einen absoluten Pfad, da
 Ab Version 1.40.13 protokolliert das Preload-Skript Fehler und meldet "erfolgreich geladen". Die Renderer-Logik prüft jetzt `window.electronAPI`.
 Ab Version 1.40.14 protokolliert das Preload-Skript jetzt seinen Startzeitpunkt.
 Ab Version 1.40.15 öffnet die Desktop-Version die DevTools automatisch und zeigt im Preload `[PRELOAD] start` an.
+Ab Version 1.40.16 prüft der Renderer die Electron-Umgebung nur noch über `window.electronAPI` und speichert das Ergebnis in `isElectron`.
 
 ## ▶️ E2E-Test
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -14,8 +14,8 @@ let folderCustomizations   = {}; // Speichert Icons/Farben pro Ordner
 let isDirty                = false;
 
 // Verfügbarkeit der Electron-API einmalig prüfen
-const hasElectron = !!window.electronAPI;
-if (!hasElectron) {
+const isElectron = !!window.electronAPI;
+if (!isElectron) {
     console.warn('🚫 Electron-API nicht verfügbar – Fallback auf Browser-Modus');
 }
 
@@ -6072,7 +6072,7 @@ function executeCleanup(cleanupPlan, totalToDelete) {
                     URL: location.href,
                     Plattform: navigator.platform,
                     Sprache: navigator.language,
-                    'Electron-API vorhanden': hasElectron,
+                    'Electron-API vorhanden': isElectron,
                     'Im Browser gestartet': true
                 };
 
@@ -6107,8 +6107,8 @@ function executeCleanup(cleanupPlan, totalToDelete) {
             info['Benutzeragent'] = navigator.userAgent;
             info['Verwendete Sprache'] = navigator.language;
             info.URL = location.href;
-            info['Electron-API vorhanden'] = hasElectron;
-            info['Im Browser gestartet'] = !hasElectron;
+            info['Electron-API vorhanden'] = isElectron;
+            info['Im Browser gestartet'] = !isElectron;
 
             // Debug-Konsole auslesen
             const debugText = document.getElementById('debugConsole')?.textContent || '';


### PR DESCRIPTION
## Summary
- Electron-Check im Frontend ueber `isElectron` vereinheitlicht
- README um Hinweis zu `isElectron` ergaenzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d4388ec548327a54f2a3cb4e87fa2