### PR TITLE
Neuer Modus beim erneuten Herunterladen

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Beim Öffnen des Dubbing-Dialogs werden gespeicherte Werte automatisch geladen.
 
 Nach erfolgreichem Download merkt sich das Projekt die zugehörige **Dubbing-ID** in der jeweiligen Datei (`dubbingId`).
 So können Sie das Ergebnis später erneut herunterladen oder neu generieren.
+Beim erneuten Download fragt das Tool nun ebenfalls, ob die Beta-API oder der halbautomatische Modus genutzt werden soll.
 
 Ein Watcher überwacht automatisch den systemweiten **Download**-Ordner. Taucht dort eine fertig gerenderte Datei auf, meldet das Tool „Datei gefunden“ und verschiebt sie nach `web/sounds/DE`. Der Status springt anschließend auf *fertig*. Alle 15 Sekunden erfolgt zusätzlich eine Status-Abfrage der offenen Jobs.
 


### PR DESCRIPTION
## Zusammenfassung
- Auswahlfenster für erneutes Herunterladen hinzugefügt
- `redownloadDubbing` akzeptiert jetzt `mode` und unterstützt Halbautomatik
- README um Beschreibung der neuen Option erweitert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d52bad7088327bd8cae06e5dd225c