### PR TITLE
Switch to internal download folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ if (await isDubReady(job.dubbing_id, 'de', apiKey)) {
 Ein Klick auf **Dubbing** öffnet zunächst ein Einstellungsfenster. Danach fragt das Tool,
 ob die **Beta-API** genutzt oder der **halbautomatische Modus** verwendet werden soll.
 Im halbautomatischen Modus werden Audiodatei und Texte lediglich an ElevenLabs gesendet.
-Anschließend erscheint ein Hinweis, die fertig gerenderte Datei in den Download-Ordner zu legen.
+Anschließend erscheint ein Hinweis, die fertig gerenderte Datei in den projektspezifischen Ordner `web/Download` zu legen.
 Sobald dort eine passende Datei auftaucht, zeigt das Tool „Datei gefunden" mit Namen an und
 wartet auf eine Bestätigung.
 Im Einstellungsfenster lassen sich folgende Parameter anpassen:
@@ -151,7 +151,7 @@ Nach erfolgreichem Download merkt sich das Projekt die zugehörige **Dubbing-ID*
 So können Sie das Ergebnis später erneut herunterladen oder neu generieren.
 Beim erneuten Download fragt das Tool nun ebenfalls, ob die Beta-API oder der halbautomatische Modus genutzt werden soll.
 
-Ein Watcher überwacht automatisch den systemweiten **Download**-Ordner. Taucht dort eine fertig gerenderte Datei auf, meldet das Tool „Datei gefunden“ und verschiebt sie nach `web/sounds/DE`. Der Status springt anschließend auf *fertig*. Alle 15 Sekunden erfolgt zusätzlich eine Status-Abfrage der offenen Jobs.
+Ein Watcher überwacht automatisch den Ordner `web/Download` im Projekt. Taucht dort eine fertig gerenderte Datei auf, meldet das Tool „Datei gefunden“ und verschiebt sie nach `web/sounds/DE`. Der Status springt anschließend auf *fertig*. Alle 15 Sekunden erfolgt zusätzlich eine Status-Abfrage der offenen Jobs.
 
 
 Beispiel einer gültigen CSV:

--- a/electron/main.js
+++ b/electron/main.js
@@ -191,9 +191,10 @@ app.whenReady().then(() => {
     return true;
   });
 
-  // Pfad des systemweiten Download-Ordners liefern
+  // Pfad des projektinternen Download-Ordners liefern
   ipcMain.handle('get-download-path', () => {
-    return app.getPath('downloads');
+    // Der Download-Ordner liegt im Web-Verzeichnis des Projekts
+    return DL_WATCH_PATH;
   });
 
   // =========================== DEBUG-INFO START =============================
@@ -396,7 +397,7 @@ app.whenReady().then(() => {
         if (mainWindow) mainWindow.webContents.send('dub-error', info);
       },
       log: msg => console.log('[Watcher]', msg),
-      path: app.getPath('downloads')
+      // Ohne Pfad-Option nutzt der Watcher automatisch DL_WATCH_PATH
     }
   );
 


### PR DESCRIPTION
## Summary
- use DL_WATCH_PATH for `get-download-path`
- let watcher in Electron observe the project's Download folder
- update docs about the Download folder location

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d545196f08327a3dd39cdf40fc05a