### PR TITLE
Fix CSV handling for multiline translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Renderer prüft die Verfügbarkeit der Electron-API über `window.electronAPI`.
 ## 🛠️ Patch in 1.40.5
 * Manuell heruntergeladene Dateien werden nun auch nach einem Neustart automatisch erkannt und importiert.
+## 🛠️ Patch in 1.40.6
+* `validateCsv` kommt jetzt mit Zeilenumbrüchen in Übersetzungen zurecht.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Beispiel einer gültigen CSV:
 speaker,start_time,end_time,transcription,translation
 0,0.000,1.000,"Hello","Hallo"
 ```
-*Hinweis:* Die Datei schließt mit CRLF (`\r\n`). Vor dem Upload prüft das Tool, dass ein Zeilenumbruch vorhanden ist und alle Felder korrekt in Anführungszeichen stehen.
+*Hinweis:* Die Datei schließt mit CRLF (`\r\n`). Vor dem Upload prüft das Tool, dass ein Zeilenumbruch vorhanden ist und alle Felder korrekt in Anführungszeichen stehen. Seit Version 1.40.6 werden auch Zeilenumbrüche innerhalb der Übersetzung unterstützt.
 
 ### Dubbing-Protokoll
 

--- a/tests/manualDub.test.js
+++ b/tests/manualDub.test.js
@@ -156,6 +156,11 @@ describe('Manual Dub', () => {
         expect(text).toContain('"Hallo ""Bob"""');
     });
 
+    test('validateCsv akzeptiert Zeilenumbrüche in Übersetzungen', () => {
+        const csv = 'speaker,start_time,end_time,transcription,translation\n0,0.000,1.000,"Hello","Hallo\nWelt"\n';
+        expect(validateCsv(csv)).toBe(true);
+    });
+
     test('validateCsv lehnt fehlerhafte CSV ab', () => {
         const csv = 'speaker,start_time,end_time,transcription,translation\n0,0.000,1.000';
         expect(validateCsv(csv)).toBe(false);

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -6815,9 +6815,37 @@ function createDubbingCSV(file, durationMs, lang = 'de') {
 }
 
 // Prüft den Aufbau einer CSV-Datei für Manual Dub
+// Zerlegt einen CSV-Text in Zeilen, wobei Zeilenumbrüche in Anführungszeichen
+// ignoriert werden
+function splitCsvLines(text) {
+    const lines = [];
+    let current = '';
+    let inQuotes = false;
+    for (let i = 0; i < text.length; i++) {
+        const c = text[i];
+        if (c === '"') {
+            if (inQuotes && text[i + 1] === '"') {
+                current += '"';
+                i++;
+            } else {
+                inQuotes = !inQuotes;
+            }
+        } else if ((c === '\n' || c === '\r') && !inQuotes) {
+            if (c === '\r' && text[i + 1] === '\n') i++;
+            lines.push(current);
+            current = '';
+        } else {
+            current += c;
+        }
+    }
+    if (current.length > 0) lines.push(current);
+    return lines.filter(l => l.length > 0);
+}
+
+// Prüft den Aufbau einer CSV-Datei für Manual Dub
 function validateCsv(csvText) {
     // Zeilen aufteilen (Leerzeilen ignorieren)
-    const lines = csvText.trim().split(/\r?\n/).filter(l => l.length > 0);
+    const lines = splitCsvLines(csvText.trim());
     if (lines.length < 2) return false;
     // Kopfzeile muss exakt passen
     if (lines[0].trim() !== 'speaker,start_time,end_time,transcription,translation') {


### PR DESCRIPTION
## Summary
- verbessere validateCsv bei Zeilenumbrüchen
- teste neue CSV-Fälle
- README und Changelog aktualisiert

## Testing
- `npx jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d57da61748327b95df5e734c345df