### PR TITLE
Status-Checks im halbautomatischen Modus deaktiviert

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Nach erfolgreichem Download merkt sich das Projekt die zugehörige **Dubbing-ID*
 So können Sie das Ergebnis später erneut herunterladen oder neu generieren.
 Beim erneuten Download fragt das Tool nun ebenfalls, ob die Beta-API oder der halbautomatische Modus genutzt werden soll.
 
-Ein Watcher überwacht automatisch den Ordner `web/Download` im Projekt. Taucht dort eine fertig gerenderte Datei auf, meldet das Tool „Datei gefunden“ und verschiebt sie nach `web/sounds/DE`. Seit Version 1.40.5 klappt das auch nach einem Neustart: Legen Sie die Datei einfach in den Ordner, sie wird anhand der Dubbing‑ID automatisch der richtigen Zeile zugeordnet. Der Status springt anschließend auf *fertig*. Alle 15 Sekunden erfolgt zusätzlich eine Status-Abfrage der offenen Jobs. Beta-Jobs werden nun automatisch aus dieser Liste entfernt, sobald sie fertig sind. Der Download-Ordner wird zu Beginn jedes neuen Dubbings und nach dem Import automatisch geleert.
+Ein Watcher überwacht automatisch den Ordner `web/Download` im Projekt. Taucht dort eine fertig gerenderte Datei auf, meldet das Tool „Datei gefunden“ und verschiebt sie nach `web/sounds/DE`. Seit Version 1.40.5 klappt das auch nach einem Neustart: Legen Sie die Datei einfach in den Ordner, sie wird anhand der Dubbing‑ID automatisch der richtigen Zeile zugeordnet. Der Status springt anschließend auf *fertig*. Alle 15 Sekunden erfolgt zusätzlich eine Status-Abfrage der offenen Jobs, allerdings nur im Beta-Modus. Beta-Jobs werden nun automatisch aus dieser Liste entfernt, sobald sie fertig sind. Der halbautomatische Modus verzichtet auf diese Abfrage. Der Download-Ordner wird zu Beginn jedes neuen Dubbings und nach dem Import automatisch geleert.
 
 
 Beispiel einer gültigen CSV:

--- a/electron/main.js
+++ b/electron/main.js
@@ -410,6 +410,8 @@ app.whenReady().then(() => {
   setInterval(async () => {
     for (let i = pendingDubs.length - 1; i >= 0; i--) {
       const job = pendingDubs[i];
+      // Halbautomatische Jobs werden hier nicht abgefragt
+      if (job.mode === 'manual') continue;
       try {
         const ready = await isDubReady(job.id, 'de', apiKey);
         if (mainWindow) {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2851,7 +2851,8 @@ async function updateDubStatusForFiles() {
 
 // Prüft nur Dateien mit gelbem Icon erneut
 async function updatePendingDubStatuses() {
-    const pending = files.filter(f => f.dubbingId && f.dubReady === false);
+    // Nur Jobs abfragen, die nicht auf manuellen Import warten
+    const pending = files.filter(f => f.dubbingId && f.dubReady === false && !f.waitingForManual);
     for (const f of pending) {
         try {
             f.dubReady = await isDubReady(f.dubbingId);


### PR DESCRIPTION
## Zusammenfassung
- Status-Abfrage im Hauptprozess überspringt nun Jobs im Modus `manual`
- auch das Frontend prüft nur noch Dateien, die nicht auf manuellen Import warten
- README über das Verhalten im Halbautomatik-Modus aktualisiert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d71b4e9388327b1580f12eb5e816a