### PR TITLE
Fix persistenter Dubbing-Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Manuell heruntergeladene Dateien werden nun auch nach einem Neustart automatisch erkannt und importiert.
 ## 🛠️ Patch in 1.40.6
 * `validateCsv` kommt jetzt mit Zeilenumbrüchen in Übersetzungen zurecht.
+## 🛠️ Patch in 1.40.7
+* Der fertige Dubbing-Status wird jetzt dauerhaft im Projekt gespeichert.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ So können Sie das Ergebnis später erneut herunterladen oder neu generieren.
 Beim erneuten Download fragt das Tool nun ebenfalls, ob die Beta-API oder der halbautomatische Modus genutzt werden soll.
 
 Ein Watcher überwacht automatisch den Ordner `web/Download` im Projekt. Taucht dort eine fertig gerenderte Datei auf, meldet das Tool „Datei gefunden“ und verschiebt sie nach `web/sounds/DE`. Seit Version 1.40.5 klappt das auch nach einem Neustart: Legen Sie die Datei einfach in den Ordner, sie wird anhand der Dubbing‑ID automatisch der richtigen Zeile zugeordnet. Der Status springt anschließend auf *fertig*. Alle 15 Sekunden erfolgt zusätzlich eine Status-Abfrage der offenen Jobs, allerdings nur im Beta-Modus. Beta-Jobs werden nun automatisch aus dieser Liste entfernt, sobald sie fertig sind. Der halbautomatische Modus verzichtet auf diese Abfrage. Der Download-Ordner wird zu Beginn jedes neuen Dubbings und nach dem Import automatisch geleert.
+Seit Patch 1.40.7 merkt sich das Tool außerdem den fertigen Status dauerhaft. Auch nach einem erneuten Download bleibt der grüne Haken erhalten.
 
 
 Beispiel einer gültigen CSV:

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -250,6 +250,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 ziel.dubReady = true;
                 ziel.waitingForManual = false;
                 renderFileTable();
+                saveCurrentProject();
                 const name = dest.split('/').pop();
                 showToast(`${name} importiert.`);
                 updateDownloadWaitDialog(name);
@@ -6876,6 +6877,7 @@ async function openStudioAndWait(dubId) {
         currentItem.waitingForManual = true;
         ui.setActiveDubItem(currentItem);
         renderFileTable();
+        saveCurrentProject();
     }
 }
 
@@ -7225,6 +7227,7 @@ async function redownloadDubbing(fileId, mode = 'beta') {
     updateStatus('Download abgeschlossen');
     addDubbingLog('Fertig.');
     renderFileTable();
+    saveCurrentProject();
 }
 // =========================== DOWNLOADDE START ===============================
 // Lädt die fertige DE-Audiodatei ohne Protokoll herunter
@@ -7252,6 +7255,7 @@ async function downloadDe(fileId) {
     file.dubReady = true; // Status auf fertig setzen
     updateStatus('Deutsche Audiodatei gespeichert.');
     renderFileTable();
+    saveCurrentProject();
 }
 // =========================== DOWNLOADDE END =================================
 // =========================== REDOWNLOADDUBBING END ==========================
@@ -9235,6 +9239,7 @@ function showLevelCustomization(levelName, ev) {
             file.dubReady = true;
             file.waitingForManual = false;
             renderFileTable();
+            saveCurrentProject();
         }
 
         window.ui = { getActiveDubItem, markDubAsReady, notify: showToast, showModal, setActiveDubItem };


### PR DESCRIPTION
## Zusammenfassung
- speichere den fertigen Dubbing-Status nach Download und manuellem Import
- merke manuelle Jobs beim Öffnen des Studios
- Dokumentation für Patch 1.40.7 und Hinweis im README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d74f8f4e88327991bf79d4f2770ce