### PR TITLE
Fix cross-drive move for dubbing download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 * `validateCsv` kommt jetzt mit Zeilenumbrüchen in Übersetzungen zurecht.
 ## 🛠️ Patch in 1.40.7
 * Der fertige Dubbing-Status wird jetzt dauerhaft im Projekt gespeichert.
+## 🛠️ Patch in 1.40.8
+* Verschieben heruntergeladener Dateien klappt nun auch über Laufwerksgrenzen hinweg.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Beim erneuten Download fragt das Tool nun ebenfalls, ob die Beta-API oder der ha
 
 Ein Watcher überwacht automatisch den Ordner `web/Download` im Projekt. Taucht dort eine fertig gerenderte Datei auf, meldet das Tool „Datei gefunden“ und verschiebt sie nach `web/sounds/DE`. Seit Version 1.40.5 klappt das auch nach einem Neustart: Legen Sie die Datei einfach in den Ordner, sie wird anhand der Dubbing‑ID automatisch der richtigen Zeile zugeordnet. Der Status springt anschließend auf *fertig*. Alle 15 Sekunden erfolgt zusätzlich eine Status-Abfrage der offenen Jobs, allerdings nur im Beta-Modus. Beta-Jobs werden nun automatisch aus dieser Liste entfernt, sobald sie fertig sind. Der halbautomatische Modus verzichtet auf diese Abfrage. Der Download-Ordner wird zu Beginn jedes neuen Dubbings und nach dem Import automatisch geleert.
 Seit Patch 1.40.7 merkt sich das Tool außerdem den fertigen Status dauerhaft. Auch nach einem erneuten Download bleibt der grüne Haken erhalten.
+Seit Patch 1.40.8 werden Dateien auch dann korrekt verschoben, wenn sich Download- und Projektordner auf unterschiedlichen Laufwerken befinden.
 
 
 Beispiel einer gültigen CSV:

--- a/watcher.js
+++ b/watcher.js
@@ -70,7 +70,17 @@ function watchDownloadFolder(callback, opts = {}) {
                 const zielRel = path.posix.join('sounds', 'DE', job.relPath.replace(/\.(mp3|wav|ogg)$/i, '.wav'));
                 const ziel = path.join(projectRoot, zielRel);
                 fs.mkdirSync(path.dirname(ziel), { recursive: true });
-                fs.renameSync(file, ziel);
+                try {
+                    fs.renameSync(file, ziel);
+                } catch (err) {
+                    // Bei unterschiedlichen Laufwerken schlägt renameSync fehl
+                    if (err.code === 'EXDEV') {
+                        fs.copyFileSync(file, ziel);
+                        fs.unlinkSync(file);
+                    } else {
+                        throw err;
+                    }
+                }
                 pending.splice(idx, 1);
                 onDone({ id: job.id, fileId: job.fileId, dest: zielRel });
                 // Nach erfolgreichem Verschieben den Download-Ordner leeren


### PR DESCRIPTION
## Summary
- verhindern, dass der automatisierte Import im Download-Ordner bei unterschiedlichen Laufwerken scheitert
- README und Changelog aktualisieren

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d76eaf6888327bff53e727e97bf2d