### PR TITLE
Add display of stored dubbing defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Seit dem neuen Layout werden alle Werte über komfortable Slider eingestellt. Ei
 Die Standardwerte werden über `getDefaultVoiceSettings` geladen und nach dem Speichern dauerhaft im Browser hinterlegt.
 
 Beim Öffnen des Dubbing-Dialogs werden gespeicherte Werte automatisch geladen.
+Im Dialog **🔊 ElevenLabs API** gibt es nun einen Bereich, der die aktuell gespeicherten Standardwerte anzeigt.
 Über den Button **Reset** lassen sich diese wieder auf die API-Defaults zurücksetzen.
 
 Nach erfolgreichem Download merkt sich das Projekt die zugehörige **Dubbing-ID** in der jeweiligen Datei (`dubbingId`).

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -317,6 +317,8 @@
             </div>
             <div id="voiceIdList" class="voice-id-list"></div>
             <div id="customVoicesList" class="custom-voices-list"></div>
+            <h4>Aktuelle Dubbing-Standardwerte</h4>
+            <ul id="voiceSettingsDisplay" class="voice-defaults-list"></ul>
             <div class="dialog-buttons">
                 <button class="btn" onclick="testVoiceIds()">Voice-IDs testen</button>
                 <button class="btn" onclick="clearAllVoiceIds()">Alle zurücksetzen</button>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -60,6 +60,29 @@ let availableVoices    = [];
 let customVoices       = JSON.parse(localStorage.getItem('hla_customVoices') || '[]');
 // Gespeicherte Voice-Settings aus dem LocalStorage laden
 let storedVoiceSettings = JSON.parse(localStorage.getItem('hla_voiceSettings') || 'null');
+
+// Aktualisiert die Anzeige der gespeicherten Dubbing-Parameter im API-Dialog
+function updateVoiceSettingsDisplay() {
+    const list = document.getElementById('voiceSettingsDisplay');
+    if (!list) return;
+    list.innerHTML = '';
+    if (!storedVoiceSettings) {
+        list.textContent = 'Keine gespeichert';
+        return;
+    }
+    const entries = [
+        ['Stability', storedVoiceSettings.stability],
+        ['Similarity Boost', storedVoiceSettings.similarity_boost],
+        ['Style', storedVoiceSettings.style],
+        ['Speed', storedVoiceSettings.speed],
+        ['Speaker-Boost', storedVoiceSettings.use_speaker_boost]
+    ];
+    entries.forEach(([label, val]) => {
+        const li = document.createElement('li');
+        li.textContent = `${label}: ${val}`;
+        list.appendChild(li);
+    });
+}
 // Bevorzugtes Zeilenende für CSV-Dateien
 let csvLineEnding = localStorage.getItem('hla_lineEnding') || 'LF';
 // Merkt die Datei, für die der Dubbing-Dialog geöffnet wurde
@@ -5435,8 +5458,8 @@ function checkFileAccess() {
                 list.appendChild(details);
             });
 
-            const customList = document.getElementById('customVoicesList');
-            customList.innerHTML = '';
+        const customList = document.getElementById('customVoicesList');
+        customList.innerHTML = '';
             customVoices.forEach(v => {
                 const item = document.createElement('div');
                 item.className = 'custom-voice-item';
@@ -5465,6 +5488,8 @@ function checkFileAccess() {
                 item.appendChild(delBtn);
                 customList.appendChild(item);
             });
+
+            updateVoiceSettingsDisplay();
 
             document.getElementById('apiKeyInput').focus();
         }
@@ -6710,6 +6735,7 @@ async function confirmDubbingSettings(fileId) {
     // Gewählte Einstellungen persistent speichern
     localStorage.setItem('hla_voiceSettings', JSON.stringify(settings));
     storedVoiceSettings = settings;
+    updateVoiceSettingsDisplay();
     await startDubbing(fileId, settings, 'de', currentDubMode);
     closeDubbingSettings();
 }
@@ -6718,6 +6744,7 @@ async function confirmDubbingSettings(fileId) {
 function resetStoredVoiceSettings() {
     localStorage.removeItem('hla_voiceSettings');
     storedVoiceSettings = null;
+    updateVoiceSettingsDisplay();
     closeDubbingSettings();
     if (currentDubbingFileId !== null) {
         showDubbingSettings(currentDubbingFileId);

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1540,6 +1540,17 @@ th:nth-child(6) {
             width: 100%;
         }
 
+        .voice-defaults-list {
+            margin-top: 15px;
+            list-style: none;
+            padding-left: 0;
+            font-size: 14px;
+        }
+
+        .voice-defaults-list li {
+            margin-bottom: 4px;
+        }
+
         .customize-buttons {
             display: flex;
             gap: 10px;


### PR DESCRIPTION
## Summary
- show default dubbing values inside the ElevenLabs API dialog
- update UI styles for the new list
- keep display in sync when settings change
- document the new section in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d7a95cea483279c19990d1ed75aa2