### PR TITLE
Implementiert History-Eintrag beim Lautstärkeabgleich

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Tab/Shift+Tab Navigation** zwischen Textfeldern und Zeilen
 * **Ctrl+Leertaste:** Audio‑Playback direkt im Textfeld
 * **Copy‑Buttons:** 📋 neben jedem Textfeld für direktes Kopieren
+* **Automatischer History-Eintrag:** Beim Lautstärkeabgleich wird das Original gespeichert
 
 ### 🔍 Suche & Import
 
@@ -453,4 +454,5 @@ Die wichtigsten Tests befinden sich im Ordner `tests/` und prüfen die Funktione
 * **`backup-de-file(relPath)`** – kopiert eine vorhandene deutsche Audiodatei nach `DE-Backup`, sofern dort noch keine Sicherung existiert.
 * **`delete-de-backup-file(relPath)`** – löscht eine Sicherung aus `DE-Backup` und entfernt leere Unterordner.
 * **`restore-de-file(relPath)`** – stellt eine deutsche Audiodatei aus dem Backup wieder her.
+* **`saveDeHistoryBuffer(relPath, data)`** – legt einen Buffer als neue History-Version ab.
 * **`calculateProjectStats(project)`** – ermittelt pro Projekt den Übersetzungs‑ und Audio‑Fortschritt. Diese Funktion wird auch in den Tests ausführlich geprüft.

--- a/electron/main.js
+++ b/electron/main.js
@@ -358,6 +358,11 @@ app.whenReady().then(() => {
   ipcMain.handle('restore-de-history', async (event, { relPath, name }) => {
     return historyUtils.switchVersion(deHistoryPath, relPath, name, dePath);
   });
+
+  // Speichert einen übergebenen Buffer als neue History-Version
+  ipcMain.handle('save-de-history-buffer', async (event, { relPath, data }) => {
+    return historyUtils.saveBufferVersion(deHistoryPath, relPath, Buffer.from(data));
+  });
   // =========================== SAVE-DE-FILE END =============================
 
   // DevTools per IPC ein-/ausblenden

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -32,6 +32,7 @@ if (typeof require !== 'function') {
     deleteDeBackupFile: (relPath) => ipcRenderer.invoke('delete-de-backup-file', relPath),
     listDeHistory: (relPath) => ipcRenderer.invoke('list-de-history', relPath),
     restoreDeHistory: (relPath, name) => ipcRenderer.invoke('restore-de-history', { relPath, name }),
+    saveDeHistoryBuffer: (relPath, data) => ipcRenderer.invoke('save-de-history-buffer', { relPath, data }),
     // Backup-Funktionen
     listBackups: () => ipcRenderer.invoke('list-backups'),
     saveBackup: (data) => ipcRenderer.invoke('save-backup', data),

--- a/historyUtils.js
+++ b/historyUtils.js
@@ -23,6 +23,27 @@ function saveVersion(historyRoot, relPath, sourceFile, limit = 10) {
     return target;
 }
 
+// Speichert direkt einen Buffer als History-Version
+function saveBufferVersion(historyRoot, relPath, buffer, limit = 10) {
+    const ext = path.extname(relPath);
+    const historyDir = path.join(historyRoot, relPath);
+    fs.mkdirSync(historyDir, { recursive: true });
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    let target = path.join(historyDir, `${timestamp}${ext}`);
+    let counter = 1;
+    while (fs.existsSync(target)) {
+        target = path.join(historyDir, `${timestamp}-${counter}${ext}`);
+        counter++;
+    }
+    fs.writeFileSync(target, buffer);
+    let files = fs.readdirSync(historyDir).filter(f => f.endsWith(ext)).sort();
+    while (files.length > limit) {
+        const remove = files.shift();
+        fs.unlinkSync(path.join(historyDir, remove));
+    }
+    return target;
+}
+
 // Gibt die vorhandenen Versionen eines Pfades zurück
 function listVersions(historyRoot, relPath) {
     const historyDir = path.join(historyRoot, relPath);
@@ -54,4 +75,4 @@ function switchVersion(historyRoot, relPath, name, targetRoot, limit = 10) {
     return target;
 }
 
-module.exports = { saveVersion, listVersions, restoreVersion, switchVersion };
+module.exports = { saveVersion, listVersions, restoreVersion, switchVersion, saveBufferVersion };

--- a/tests/historyFunctions.test.js
+++ b/tests/historyFunctions.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { saveVersion, listVersions, restoreVersion, switchVersion } = require('../historyUtils');
+const { saveVersion, listVersions, restoreVersion, switchVersion, saveBufferVersion } = require('../historyUtils');
 
 describe('history utils', () => {
     test('keeps maximal zehn Versionen', () => {
@@ -51,5 +51,16 @@ describe('history utils', () => {
         expect(histFiles.length).toBe(1);
         const histInhalt = fs.readFileSync(path.join(historyRoot, relPath, histFiles[0]), 'utf8');
         expect(histInhalt).toBe('neu');
+    });
+
+    test('saveBufferVersion speichert Daten korrekt', () => {
+        const historyRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-'));
+        const relPath = 'buf/test.wav';
+        const data = Buffer.from('xyz');
+        saveBufferVersion(historyRoot, relPath, data, 10);
+        const list = listVersions(historyRoot, relPath);
+        expect(list.length).toBe(1);
+        const stored = fs.readFileSync(path.join(historyRoot, relPath, list[0]));
+        expect(stored.toString()).toBe('xyz');
     });
 });

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -7569,11 +7569,19 @@ window.onmouseup = () => { editDragging = null; };
 
 // =========================== APPLYVOLUMEMATCH START =======================
 // Führt den Lautstärkeabgleich einmalig aus
-function applyVolumeMatch() {
+// Beim ersten Aufruf wird das Original in die Historie geschrieben
+async function applyVolumeMatch() {
     if (!volumeMatchedBuffer && savedOriginalBuffer && editEnBuffer) {
         volumeMatchedBuffer = matchVolume(savedOriginalBuffer, editEnBuffer);
     }
     if (volumeMatchedBuffer) {
+        if (!isVolumeMatched && window.electronAPI && window.electronAPI.saveDeHistoryBuffer) {
+            const relPath = getFullPath(currentEditFile);
+            const blob = bufferToWav(savedOriginalBuffer);
+            const buf = await blob.arrayBuffer();
+            await window.electronAPI.saveDeHistoryBuffer(relPath, new Uint8Array(buf));
+            await updateHistoryCache(relPath);
+        }
         originalEditBuffer = volumeMatchedBuffer;
         isVolumeMatched = true;
         editDurationMs = originalEditBuffer.length / originalEditBuffer.sampleRate * 1000;


### PR DESCRIPTION
## Notes
Keine besonderen Hinweise.

## Summary
- Neuer Helper `saveBufferVersion` speichert beliebige Daten als History-Version
- IPC `save-de-history-buffer` ermöglicht den Aufruf aus dem Renderer
- Preload und Frontend nutzen die neue Funktion, um beim ersten Lautstärkeabgleich das Original abzulegen
- Dokumentation in README ergänzt
- Test für `saveBufferVersion` hinzugefügt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d7e06ad8883279f714c8a0e336388