### PR TITLE
Letzte Level-Farben merken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 * Der fertige Dubbing-Status wird jetzt dauerhaft im Projekt gespeichert.
 ## 🛠️ Patch in 1.40.8
 * Verschieben heruntergeladener Dateien klappt nun auch über Laufwerksgrenzen hinweg.
+## 🛠️ Patch in 1.40.9
+* Level-Dialog zeigt die letzten fünf gewählten Farben zur schnellen Auswahl.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Beim erneuten Download fragt das Tool nun ebenfalls, ob die Beta-API oder der ha
 Ein Watcher überwacht automatisch den Ordner `web/Download` im Projekt. Taucht dort eine fertig gerenderte Datei auf, meldet das Tool „Datei gefunden“ und verschiebt sie nach `web/sounds/DE`. Seit Version 1.40.5 klappt das auch nach einem Neustart: Legen Sie die Datei einfach in den Ordner, sie wird anhand der Dubbing‑ID automatisch der richtigen Zeile zugeordnet. Der Status springt anschließend auf *fertig*. Alle 15 Sekunden erfolgt zusätzlich eine Status-Abfrage der offenen Jobs, allerdings nur im Beta-Modus. Beta-Jobs werden nun automatisch aus dieser Liste entfernt, sobald sie fertig sind. Der halbautomatische Modus verzichtet auf diese Abfrage. Der Download-Ordner wird zu Beginn jedes neuen Dubbings und nach dem Import automatisch geleert.
 Seit Patch 1.40.7 merkt sich das Tool außerdem den fertigen Status dauerhaft. Auch nach einem erneuten Download bleibt der grüne Haken erhalten.
 Seit Patch 1.40.8 werden Dateien auch dann korrekt verschoben, wenn sich Download- und Projektordner auf unterschiedlichen Laufwerken befinden.
+Seit Patch 1.40.9 merkt sich der Level-Dialog die zuletzt genutzten fünf Farben und bietet eine Schnellwahl unter dem Farbpicker.
 
 
 Beispiel einer gültigen CSV:

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -3,6 +3,7 @@ let projects               = [];
 let levelColors            = {}; // ⬅️ NEU: globale Level-Farben
 let levelOrders            = {}; // ⬅️ NEU: Reihenfolge der Level
 let levelIcons             = {}; // ⬅️ NEU: Icon je Level
+let levelColorHistory     = JSON.parse(localStorage.getItem('hla_levelColorHistory') || '[]'); // ➡️ Merkt letzte 5 Farben
 let currentProject         = null;
 let files                  = [];
 let textDatabase           = {};
@@ -440,6 +441,23 @@ function saveLevelIcons() {
     }
 }
 // =========================== SAVELEVELICONS END =============================
+/* =========================== LEVEL-COLOR-HISTORY START ===================== */
+function updateLevelColorHistory(color) {
+    const idx = levelColorHistory.indexOf(color);
+    if (idx !== -1) levelColorHistory.splice(idx, 1);
+    levelColorHistory.unshift(color);
+    if (levelColorHistory.length > 5) levelColorHistory.pop();
+    saveLevelColorHistory();
+}
+
+function saveLevelColorHistory() {
+    try {
+        localStorage.setItem('hla_levelColorHistory', JSON.stringify(levelColorHistory));
+    } catch (e) {
+        console.error('[saveLevelColorHistory] Speichern fehlgeschlagen:', e);
+    }
+}
+/* =========================== LEVEL-COLOR-HISTORY END ======================= */
 
 
 
@@ -8930,6 +8948,7 @@ function showLevelCustomization(levelName, ev) {
       <div class="customize-field">
         <label>Farbe:</label>
         <input type="color" id="lvlColor" value="${color}">
+        <div id="lvlHistory" class="color-history"></div>
       </div>
 
       <div class="customize-field">
@@ -8961,6 +8980,17 @@ function showLevelCustomization(levelName, ev) {
             if(iconSelect.value) iconInput.value = iconSelect.value;
         };
     }
+    const colorInput = pop.querySelector('#lvlColor');
+    const histDiv = pop.querySelector('#lvlHistory');
+    if(histDiv && colorInput){
+        levelColorHistory.forEach(col => {
+            const btn = document.createElement('button');
+            btn.className = 'color-swatch';
+            btn.style.background = col;
+            btn.onclick = () => { colorInput.value = col; };
+            histDiv.appendChild(btn);
+        });
+    }
 
     pop.querySelector('#lvlCancel').onclick = () => document.body.removeChild(ov);
 
@@ -8991,6 +9021,7 @@ function showLevelCustomization(levelName, ev) {
         if (levelIcons[levelName]  && levelName !== newName) delete levelIcons[levelName];
 
         levelColors[newName] = newColor;
+        updateLevelColorHistory(newColor);
         levelIcons[newName]  = newIcon;
         // Reihenfolge immer speichern
         setLevelOrder(newName, newOrder);

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1479,6 +1479,20 @@ th:nth-child(6) {
             color: #e0e0e0;
             font-size: 14px;
         }
+        .color-history {
+            display: flex;
+            gap: 5px;
+            margin-top: 5px;
+        }
+
+        .color-swatch {
+            width: 20px;
+            height: 20px;
+            border: 1px solid #444;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
 
         .api-key-field {
             display: flex;


### PR DESCRIPTION
## Summary
- speichere Farbverlauf `levelColorHistory` im LocalStorage
- Level-Einstellungen zeigen schnelle Farbauswahl
- Notiz zu neuer Funktion in README und CHANGELOG
- Styles für Farbhistorie

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dc4861d4c83278b6da61dcaa7303c