### PR TITLE
Kapitelverwaltung für Level

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ### 🎯 Kernfunktionen
 
 * **Mehrere Projekte** mit Icon, Farbe, Level‑Namen & Teil‑Nummer
+* **Level-Kapitel** zur besseren Gruppierung und ein-/ausklappbaren Bereichen
 * **Intelligenter Ordner‑Scan** mit Duplikat‑Prävention und Auto‑Normalisierung
 * **Eingebettete Audio‑Wiedergabe** (MP3 / WAV / OGG) direkt im Browser
 * **Live‑Statistiken:** EN‑%, DE‑%, Completion‑%, Globale Textzahlen (EN/DE/BEIDE/∑)
@@ -403,6 +404,7 @@ Der komplette Verlauf steht in [CHANGELOG.md](CHANGELOG.md).
 * **📋 Level‑Namen verwenden:** Strukturieren Sie Projekte nach Spiel‑Leveln
 * **🔢 Teil‑Nummern vergeben:** Für große Level mehrere Teile erstellen
 * **🎨 Farb‑Coding:** Ähnliche Level mit gleichen Farben markieren
+* **📂 Kapitel:** Mehrere Level zu Kapiteln gruppieren und zusammenklappen
 
 ### Übersetzungs‑Workflow
 

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2040,6 +2040,20 @@ th:nth-child(6) {
     color: #4caf50;
 }
 
+/* =========================== CHAPTER-GROUP STYLES START ==================== */
+.chapter-group { margin-bottom: 14px; }
+.chapter-header {
+    padding: 8px 10px;
+    background: #222;
+    color: #fff;
+    font-weight: 700;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-bottom: 6px;
+}
+.chapter-group.collapsed .chapter-levels { display: none; }
+/* =========================== CHAPTER-GROUP STYLES END ====================== */
+
 /* =========================== LEVEL-GROUP STYLES END ========================= */
 
 /* Versionsnummer oben links */


### PR DESCRIPTION
## Summary
- Level können jetzt Kapiteln zugeordnet werden
- neue Kapitel-Gruppierung samt Aufklappfunktion in der Projektübersicht
- Leveldialog ermöglicht Auswahl oder Anlage eines Kapitels
- Styles für Kapitel-Gruppen ergänzt
- README um Hinweis auf Kapitelverwaltung erweitert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dc700f0e0832787c9d2cce3fa5ca0