### PR TITLE
Fix Kapitelreihenfolge beim Laden

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Ein Watcher überwacht automatisch den Ordner `web/Download` im Projekt. Taucht 
 Seit Patch 1.40.7 merkt sich das Tool außerdem den fertigen Status dauerhaft. Auch nach einem erneuten Download bleibt der grüne Haken erhalten.
 Seit Patch 1.40.8 werden Dateien auch dann korrekt verschoben, wenn sich Download- und Projektordner auf unterschiedlichen Laufwerken befinden.
 Seit Patch 1.40.9 merkt sich der Level-Dialog die zuletzt genutzten fünf Farben und bietet eine Schnellwahl unter dem Farbpicker.
+Seit Patch 1.40.10 sortiert sich die Kapitel-Liste in der Projekt-Ansicht sofort korrekt.
 
 
 Beispiel einer gültigen CSV:

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -236,7 +236,6 @@ function stopCurrentPlayback() {
 
 // =========================== DOM READY INITIALISIERUNG ===========================
 document.addEventListener('DOMContentLoaded', async () => {
-    loadProjects();
     // DevTools-Knopf wird immer eingeblendet
 
 
@@ -340,6 +339,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (savedChapterColors) {
         chapterColors = JSON.parse(savedChapterColors);
     }
+
+    // Wichtig: Kapitel-Daten müssen vor dem Laden der Projekte vorhanden sein,
+    // sonst sortiert sich die Liste beim ersten Start falsch
+    loadProjects();
 
     initializeEventListeners();
 


### PR DESCRIPTION
## Summary
- lade Projekte erst nach den Kapiteldaten
- Dokumentation um Hinweis auf gefixten Sortierfehler ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dcdc4c9188327a3d7496eaeafb433