### PR TITLE
Sort level dropdown numerically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 * Kapitel-Liste sortiert sich in der Projekt-Ansicht sofort korrekt.
 ## 🛠️ Patch in 1.40.11
 * Kapitel-Auswahllisten sind jetzt nach der Kapitelnummer sortiert.
+## 🛠️ Patch in 1.40.12
+* Level-Auswahlliste in den Projekt-Einstellungen folgt nun der Level-Nummer.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Seit Patch 1.40.8 werden Dateien auch dann korrekt verschoben, wenn sich Downloa
 Seit Patch 1.40.9 merkt sich der Level-Dialog die zuletzt genutzten fünf Farben und bietet eine Schnellwahl unter dem Farbpicker.
 Seit Patch 1.40.10 sortiert sich die Kapitel-Liste in der Projekt-Ansicht sofort korrekt.
 Seit Patch 1.40.11 sind die Kapitel-Auswahllisten in den Projekt- und Level-Dialogen ebenfalls nach der Nummer sortiert.
+Seit Patch 1.40.12 ist auch die Level-Auswahl im Projekt-Dialog nach der Level-Nummer sortiert.
 
 
 Beispiel einer gültigen CSV:

--- a/tests/projectLevelDropdownSort.test.js
+++ b/tests/projectLevelDropdownSort.test.js
@@ -1,0 +1,25 @@
+const { expect, test } = require('@jest/globals');
+
+// Beispielprojekte mit unsortierten Levelnamen
+let projects = [
+    { levelName: 'Gamma' },
+    { levelName: 'Alpha' },
+    { levelName: 'Beta' }
+];
+
+// Zuordnung der Level zu ihren Nummern
+let levelOrders = { 'Alpha': 1, 'Beta': 2, 'Gamma': 3 };
+
+function getLevelOrder(name) {
+    return levelOrders[name] || 9999;
+}
+
+// Erzeugt die Level-Liste wie im Projekt-Dialog
+function getKnownLevels() {
+    return [...new Set(projects.map(p => p.levelName).filter(Boolean))]
+        .sort((a, b) => getLevelOrder(a) - getLevelOrder(b));
+}
+
+test('Level-Dropdown sortiert nach Nummer', () => {
+    expect(getKnownLevels()).toEqual(['Alpha', 'Beta', 'Gamma']);
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -8899,7 +8899,9 @@ function showProjectCustomization(id, ev, tempProject) {
     if (!prj) return;
     const isNew = !!tempProject;
 
-    const knownLevels   = [...new Set(projects.map(p => p.levelName).filter(Boolean))];
+    // Levelnamen nach ihrer gespeicherten Nummer sortieren
+    const knownLevels   = [...new Set(projects.map(p => p.levelName).filter(Boolean))]
+        .sort((a, b) => getLevelOrder(a) - getLevelOrder(b));
     // Kapitel nach ihrer Nummer sortieren
     const knownChapters = [...new Set(Object.values(levelChapters).filter(Boolean))]
         .sort((a, b) => getChapterOrder(a) - getChapterOrder(b));


### PR DESCRIPTION
## Summary
- sortiere Level-Liste im Projekt-Dialog nach der Levelnummer
- CHANGELOG und README für Patch 1.40.12 ergänzt
- Test deckt Sortierung des Level-Dropdowns ab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684de50ccc188327a6dc5ddcacdbb36f