### PR TITLE
Use German audio in project playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Tab/Shift+Tab Navigation** zwischen Textfeldern und Zeilen
 * **Ctrl+Leertaste:** Audio‑Playback direkt im Textfeld
 * **Copy‑Buttons:** 📋 neben jedem Textfeld für direktes Kopieren
-* **Projekt-Playback:** ▶/⏸/⏹ spielt alle Dateien nacheinander ab
+* **Projekt-Playback:** ▶/⏸/⏹ spielt verfügbare DE-Dateien nacheinander ab
 * **Automatischer History-Eintrag:** Beim Lautstärkeabgleich wird das Original gespeichert
 
 ### 🔍 Suche & Import
@@ -248,7 +248,7 @@ Bei einem Upload-Fehler mit Status 400 wird zusätzlich ein Ausschnitt der erzeu
 |  Aktion                    |  Bedienung |
 | -------------------------- | ----------------------------------------------- |
 | **Audio abspielen**       | ▶ Button oder Leertaste (bei ausgewaehlter Zeile) |
-| **Projekt-Playback**      | ▶/⏸/⏹ rechts im Projekt |
+| **Projekt-Playback**      | ▶/⏸/⏹ spielt nur vorhandene DE-Dateien |
 | **Audio im Textfeld**     | `Ctrl + Leertaste` |
 | **Text kopieren**         | 📋 Button neben Textfeld |
 | **Zwischen Feldern**      | `Tab` / `Shift + Tab` |

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -3583,8 +3583,18 @@ function clearProjectRowHighlight() {
 function playCurrentProjectFile() {
     if (projectPlayIndex >= files.length) { stopProjectPlayback(); return; }
     const file = files[projectPlayIndex];
+    // Wenn keine DE-Datei existiert, überspringen wir diese Datei
+    if (!getDeFilePath(file)) {
+        projectPlayIndex++;
+        if (projectPlayState === 'playing') {
+            playCurrentProjectFile();
+        }
+        return;
+    }
+
     highlightProjectRow(file.id);
-    playAudio(file.id);
+    // Deutsche Version abspielen
+    playDeAudio(file.id);
     const audio = document.getElementById('audioPlayer');
     const oldEnded = audio.onended;
     audio.onended = () => {


### PR DESCRIPTION
## Summary
- Spiele beim Projekt-Playback die vorhandenen deutschen Audiodateien ab
- Überspringe Dateien ohne deutsche Aufnahme
- Dokumentation entsprechend angepasst

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df4ba6480832781057d68688ffe6f