### PR TITLE
Fix AbortError spam when audio playback is paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Ctrl+Leertaste:** Audio‑Playback direkt im Textfeld
 * **Copy‑Buttons:** 📋 neben jedem Textfeld für direktes Kopieren
 * **Projekt-Playback:** ▶/⏸/⏹ spielt verfügbare DE-Dateien nacheinander ab
+* **Stabileres Audio-Playback:** Unterbrochene Wiedergabe erzeugt keine Fehlermeldungen mehr
 * **Automatischer History-Eintrag:** Beim Lautstärkeabgleich wird das Original gespeichert
 
 ### 🔍 Suche & Import

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -3472,6 +3472,10 @@ function playAudio(fileId) {
             currentlyPlaying = null;
         };
     }).catch(err => {
+        if (err && err.name === 'AbortError') {
+            // Unterbrochene Wiedergabe ist kein echter Fehler
+            return;
+        }
         console.error('[PLAYAUDIO] Playback failed:', err);
         debugLog('[PLAYAUDIO] Playback failed:', err);
         updateStatus(`Fehler beim Abspielen: ${file.filename}`);
@@ -3556,6 +3560,10 @@ async function playDeAudio(fileId, onEnded = null) {
             if (previousEnded) previousEnded();
         };
     }).catch(err => {
+        if (err && err.name === 'AbortError') {
+            // Wird play() durch pause() unterbrochen, ignorieren wir den Fehler
+            return;
+        }
         console.error('DE-Playback fehlgeschlagen', err);
         updateStatus('Fehler beim Abspielen der DE-Datei');
         if (url) URL.revokeObjectURL(url);
@@ -4848,6 +4856,10 @@ function deleteFolderFromDatabase(folderName) {
                         currentlyPlaying = null;
                     };
                 }).catch(err => {
+                    if (err && err.name === 'AbortError') {
+                        // Fehler ignorieren, wenn play() frühzeitig gestoppt wurde
+                        return;
+                    }
                     console.error('Playback failed:', err);
                     updateStatus(`Fehler beim Abspielen`);
                     if (url) URL.revokeObjectURL(url);


### PR DESCRIPTION
## Summary
- ignore `AbortError` when audio playback is interrupted
- update README with note about more stable audio playback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df69bf0c483278829a5aa9dea1573