### PR TITLE
Betone Reihenfolge bei DE-Playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Ctrl+Leertaste:** Audio‑Playback direkt im Textfeld
 * **Copy‑Buttons:** 📋 neben jedem Textfeld für direktes Kopieren
 * **Projekt-Playback:** ▶/⏸/⏹ spielt verfügbare DE-Dateien nacheinander ab
+* **Feste Reihenfolge:** Beim Projekt-Playback wird die Dateiliste strikt von oben nach unten abgespielt, unabhängig vom Dateityp
 * **Stabileres Audio-Playback:** Unterbrochene Wiedergabe erzeugt keine Fehlermeldungen mehr
 * **Automatischer History-Eintrag:** Beim Lautstärkeabgleich wird das Original gespeichert
 
@@ -250,7 +251,7 @@ Bei einem Upload-Fehler mit Status 400 wird zusätzlich ein Ausschnitt der erzeu
 |  Aktion                    |  Bedienung |
 | -------------------------- | ----------------------------------------------- |
 | **Audio abspielen**       | ▶ Button oder Leertaste (bei ausgewaehlter Zeile) |
-| **Projekt-Playback**      | ▶/⏸/⏹ spielt nur vorhandene DE-Dateien |
+| **Projekt-Playback**      | ▶/⏸/⏹ spielt vorhandene DE-Dateien der Reihe nach |
 | **Audio im Textfeld**     | `Ctrl + Leertaste` |
 | **Text kopieren**         | 📋 Button neben Textfeld |
 | **Zwischen Feldern**      | `Tab` / `Shift + Tab` |

--- a/tests/projectPlaybackOrder.test.js
+++ b/tests/projectPlaybackOrder.test.js
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment jsdom
+ */
+const { getProjectPlaybackList, __setFiles, __setDeAudioCache } = require('../web/src/main.js');
+
+test('DE-Playback haelt die Reihenfolge ein', () => {
+    const testFiles = [
+        { id: 1, folder: 'f', filename: 'a.mp3' },
+        { id: 2, folder: 'f', filename: 'b.wav' },
+        { id: 3, folder: 'f', filename: 'c.mp3' }
+    ];
+    const cache = {
+        'f/a.mp3': true,
+        'f/b.wav': true,
+        'f/c.mp3': true
+    };
+    __setFiles(testFiles);
+    __setDeAudioCache(cache);
+
+    const order = getProjectPlaybackList().map(f => f.id);
+    expect(order).toEqual([1, 2, 3]);
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -55,6 +55,7 @@ let chapterColors         = {}; // Farbe pro Kapitel
 // Status für Projekt-Wiedergabe
 let projectPlayState       = 'stopped'; // 'playing', 'paused'
 let projectPlayIndex       = 0;        // Aktuelle Datei im Projekt
+let playbackFiles          = [];       // Gefilterte Liste fuer Projekt-Wiedergabe
 
 // Automatische Backup-Einstellungen
 let autoBackupInterval = parseInt(localStorage.getItem('hla_autoBackupInterval')) || 10; // Minuten
@@ -3593,10 +3594,15 @@ function clearProjectRowHighlight() {
     document.querySelectorAll('tr.current-project-row').forEach(r => r.classList.remove('current-project-row'));
 }
 
+// Liefert alle Dateien mit vorhandener DE-Version in aktueller Reihenfolge
+function getProjectPlaybackList() {
+    return files.filter(f => getDeFilePath(f));
+}
+
 // Spielt die aktuelle Datei im Projekt ab
 function playCurrentProjectFile() {
-    if (projectPlayIndex >= files.length) { stopProjectPlayback(); return; }
-    const file = files[projectPlayIndex];
+    if (projectPlayIndex >= playbackFiles.length) { stopProjectPlayback(); return; }
+    const file = playbackFiles[projectPlayIndex];
     // Wenn keine DE-Datei existiert, überspringen wir diese Datei
     if (!getDeFilePath(file)) {
         projectPlayIndex++;
@@ -3618,6 +3624,7 @@ function playCurrentProjectFile() {
 }
 
 function startProjectPlayback() {
+    playbackFiles = getProjectPlaybackList();
     projectPlayIndex = 0;
     projectPlayState = 'playing';
     updateProjectPlaybackButtons();
@@ -3641,6 +3648,7 @@ function resumeProjectPlayback() {
 function stopProjectPlayback() {
     projectPlayState = 'stopped';
     projectPlayIndex = 0;
+    playbackFiles = [];
     clearProjectRowHighlight();
     stopCurrentPlayback();
     updateProjectPlaybackButtons();
@@ -9885,6 +9893,9 @@ if (typeof module !== "undefined" && module.exports) {
         redownloadDubbing,
         initiateDubbing,
         downloadDe,
-        updateDubStatusForFiles
+        updateDubStatusForFiles,
+        getProjectPlaybackList,
+        __setFiles: f => { files = f; },
+        __setDeAudioCache: c => { deAudioCache = c; }
     };
 }


### PR DESCRIPTION
## Summary
- stelle sicher, dass Projekt-Playback die Datei-Reihenfolge respektiert
- neue Funktion `getProjectPlaybackList` eingeführt
- README um Hinweis auf feste Reihenfolge ergänzt
- zusätzlicher Test `projectPlaybackOrder` prüft die Abspielreihenfolge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df7bd9c788327bc0c9726af2097ae