### PR TITLE
Automatische Übersetzungsvorschau mit Argos Translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Tab/Shift+Tab Navigation** zwischen Textfeldern und Zeilen
 * **Ctrl+Leertaste:** Audio‑Playback direkt im Textfeld
 * **Copy‑Buttons:** 📋 neben jedem Textfeld für direktes Kopieren
+* **Automatische Übersetzungsvorschau** unter jedem DE-Feld via *Argos Translate*
 * **Projekt-Playback:** ▶/⏸/⏹ spielt verfügbare DE-Dateien nacheinander ab
 * **Feste Reihenfolge:** Beim Projekt-Playback wird die Dateiliste strikt von oben nach unten abgespielt, unabhängig vom Dateityp
 * **Stabileres Audio-Playback:** Unterbrochene Wiedergabe erzeugt keine Fehlermeldungen mehr

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -51,6 +51,7 @@ if (typeof require !== 'function') {
     fsReadFile: p => fs.readFileSync(p),
     fsExists: p => fs.existsSync(p),
     join: (...segments) => path.join(...segments),
+    translateText: text => ipcRenderer.invoke('translate-text', text),
   });
   console.log('[Preload] erfolgreich geladen');
 }

--- a/translate_text.py
+++ b/translate_text.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import sys
+from argostranslate import package, translate
+
+FROM_CODE = "en"
+TO_CODE = "de"
+
+
+def ensure_package(from_code: str, to_code: str) -> None:
+    """Stellt sicher, dass das benoetigte Sprachpaket installiert ist."""
+    installed = translate.load_installed_languages()
+    have_translation = any(
+        lang.code == from_code and any(t.to_code == to_code for t in lang.translations)
+        for lang in installed
+    )
+    if have_translation:
+        return
+    package.update_package_index()
+    available = package.get_available_packages()
+    pkg = next(p for p in available if p.from_code == from_code and p.to_code == to_code)
+    package.install_from_path(pkg.download())
+
+
+def main() -> None:
+    text = sys.stdin.read()
+    if not text:
+        return
+    ensure_package(FROM_CODE, TO_CODE)
+    translated = translate.translate(text, FROM_CODE, TO_CODE)
+    print(translated)
+
+
+if __name__ == "__main__":
+    main()

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2250,6 +2250,13 @@ th:nth-child(6) {
     display: inline-block;
 }
 
+.auto-trans {
+    font-size: 11px;
+    color: #999;
+    margin-top: 2px;
+    white-space: pre-wrap;
+}
+
 @keyframes spin {
     from { transform: rotate(0deg); }
     to { transform: rotate(360deg); }


### PR DESCRIPTION
## Summary
- füge Python-Skript `translate_text.py` für Argos Translate hinzu
- integriere neue IPC `translate-text` in Electron
- biete `translateText` im Preload an
- zeige Übersetzung unter dem DE-Textfeld und speichere sie im Projekt
- erweitere Styles und README entsprechend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e92d76c64832796b0aec7aaf211f0