### PR TITLE
Add automatic pip install for argostranslate

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Bei einem Upload-Fehler mit Status 400 wird zusätzlich ein Ausschnitt der erzeu
 
 ### Python-Übersetzungsskript
 
-`translate_text.py` übersetzt kurze Texte offline mit Argos Translate. Installiere zuvor die Abhängigkeiten mit `pip install -r requirements.txt`. Anschließend kann der gewünschte Text per `echo "Hello" | python translate_text.py` übersetzt werden.
+`translate_text.py` übersetzt kurze Texte offline mit Argos Translate. Fehlt das Paket, versucht das Skript automatisch, die Abhängigkeiten per `pip` zu installieren. Sollte das nicht klappen, einfach selbst `pip install -r requirements.txt` ausführen. Anschließend kann der gewünschte Text per `echo "Hello" | python translate_text.py` übersetzt werden.
 
 ### Version aktualisieren
 

--- a/translate_text.py
+++ b/translate_text.py
@@ -1,13 +1,25 @@
 #!/usr/bin/env python3
 import sys
+import subprocess
 
 try:
     from argostranslate import package, translate
-except ModuleNotFoundError as exc:
+except ModuleNotFoundError:
+    # Fehlendes Paket automatisch installieren
     sys.stderr.write(
-        "Das Paket 'argostranslate' fehlt. Bitte mit 'pip install -r requirements.txt' installieren.\n"
+        "Das Paket 'argostranslate' fehlt. Versuche automatische Installation...\n"
     )
-    raise exc
+    try:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "-r", "requirements.txt"]
+        )
+        # erneuter Import nach erfolgreicher Installation
+        from argostranslate import package, translate
+    except Exception as exc:
+        raise SystemExit(
+            "Automatische Installation von 'argostranslate' fehlgeschlagen. "
+            "Bitte 'pip install -r requirements.txt' manuell ausfuehren."
+        ) from exc
 
 FROM_CODE = "en"
 TO_CODE = "de"


### PR DESCRIPTION
## Summary
- try to install requirements automatically when argostranslate is missing
- describe auto-install behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e978cf90c8327a65e480a3b49a07f