### PR TITLE
Fix requirements path in translate_text

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 9. `node check_environment.js` prueft Node- und npm-Version, installiert Abhaengigkeiten und startet einen kurzen Electron-Test. Mit `--tool-check` fuehrt das Skript zusaetzlich `python start_tool.py --check` aus, um die Desktop-App kurz zu testen. Ergebnisse stehen in `setup.log`.
 10. Alle Start-Skripte kontrollieren nun die installierte Node-Version und brechen bei Abweichungen ab.
 11. `reset_repo.py` setzt das Repository nun komplett zurück, installiert alle Abhängigkeiten in beiden Ordnern und startet anschließend automatisch die Desktop-App.
-12. Für das Python-Skript `translate_text.py` muss `argostranslate` installiert sein. Dies erledigt `pip install -r requirements.txt`.
+12. Für das Python-Skript `translate_text.py` muss `argostranslate` installiert sein. Das Skript sucht nun selbst im eigenen Verzeichnis nach `requirements.txt` und führt bei Bedarf `pip install -r <Pfad>` aus.
 
 ### ElevenLabs-Dubbing
 
@@ -192,7 +192,7 @@ Bei einem Upload-Fehler mit Status 400 wird zusätzlich ein Ausschnitt der erzeu
 
 ### Python-Übersetzungsskript
 
-`translate_text.py` übersetzt kurze Texte offline mit Argos Translate. Fehlt das Paket, versucht das Skript automatisch, die Abhängigkeiten per `pip` zu installieren. Sollte das nicht klappen, einfach selbst `pip install -r requirements.txt` ausführen. Anschließend kann der gewünschte Text per `echo "Hello" | python translate_text.py` übersetzt werden.
+`translate_text.py` übersetzt kurze Texte offline mit Argos Translate. Fehlt das Paket, sucht das Skript im selben Ordner nach `requirements.txt` und führt `pip install -r <Pfad>` aus. Sollte das nicht klappen, einfach selbst `pip install -r requirements.txt` ausführen. Anschließend kann der gewünschte Text per `echo "Hello" | python translate_text.py` übersetzt werden.
 
 ### Version aktualisieren
 

--- a/translate_text.py
+++ b/translate_text.py
@@ -1,18 +1,25 @@
 #!/usr/bin/env python3
 import sys
 import subprocess
+import os
 
 try:
     from argostranslate import package, translate
 except ModuleNotFoundError:
-    # Fehlendes Paket automatisch installieren
+    # Fehlendes Paket automatisch installieren (requirements.txt liegt neben dem Skript)
     sys.stderr.write(
         "Das Paket 'argostranslate' fehlt. Versuche automatische Installation...\n"
     )
     try:
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "-r", "requirements.txt"]
-        )
+        req_file = os.path.join(os.path.dirname(__file__), "requirements.txt")
+        subprocess.check_call([
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            req_file,
+        ])
         # erneuter Import nach erfolgreicher Installation
         from argostranslate import package, translate
     except Exception as exc:


### PR DESCRIPTION
## Summary
- import `os` in `translate_text.py`
- install dependencies via `requirements.txt` relativ zum Skript
- erwähne automatische Installation im README

## Testing
- `npm test`
- `python translate_text.py` from different directories (aborted due to heavy downloads)

------
https://chatgpt.com/codex/tasks/task_e_684e9a097d548327847df61e1160654c