### PR TITLE
Installiere Python-Abhängigkeiten beim Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 9. `node check_environment.js` prueft Node- und npm-Version, installiert Abhaengigkeiten und startet einen kurzen Electron-Test. Mit `--tool-check` fuehrt das Skript zusaetzlich `python start_tool.py --check` aus, um die Desktop-App kurz zu testen. Ergebnisse stehen in `setup.log`.
 10. Alle Start-Skripte kontrollieren nun die installierte Node-Version und brechen bei Abweichungen ab.
 11. `reset_repo.py` setzt das Repository nun komplett zurück, installiert alle Abhängigkeiten in beiden Ordnern und startet anschließend automatisch die Desktop-App.
-12. Für das Python-Skript `translate_text.py` muss `argostranslate` installiert sein. Das Skript sucht nun selbst im eigenen Verzeichnis nach `requirements.txt` und führt bei Bedarf `pip install -r <Pfad>` aus.
+12. `start_tool.py` installiert nun zusätzlich alle Python-Abhängigkeiten aus `requirements.txt`. `translate_text.py` geht daher davon aus, dass `argostranslate` bereits vorhanden ist.
 
 ### ElevenLabs-Dubbing
 
@@ -192,7 +192,7 @@ Bei einem Upload-Fehler mit Status 400 wird zusätzlich ein Ausschnitt der erzeu
 
 ### Python-Übersetzungsskript
 
-`translate_text.py` übersetzt kurze Texte offline mit Argos Translate. Fehlt das Paket, sucht das Skript im selben Ordner nach `requirements.txt` und führt `pip install -r <Pfad>` aus. Sollte das nicht klappen, einfach selbst `pip install -r requirements.txt` ausführen. Anschließend kann der gewünschte Text per `echo "Hello" | python translate_text.py` übersetzt werden.
+`translate_text.py` übersetzt kurze Texte offline mit Argos Translate. Die benötigten Pakete werden durch `start_tool.py` automatisch installiert. Anschließend kann der gewünschte Text per `echo "Hello" | python translate_text.py` übersetzt werden.
 
 ### Version aktualisieren
 

--- a/start_tool.py
+++ b/start_tool.py
@@ -176,6 +176,21 @@ except subprocess.CalledProcessError:
     log("git clean fehlgeschlagen")
     log(str(sys.exc_info()[1]))
 
+# ----------------------- Python-Abhängigkeiten installieren -----------------
+log("Installiere Python-Abhaengigkeiten")
+req_file = os.path.join(repo_path, "requirements.txt")
+if os.path.exists(req_file):
+    try:
+        run(f"{sys.executable} -m pip install -r \"{req_file}\"")
+        log("pip install erfolgreich")
+    except subprocess.CalledProcessError as e:
+        print("pip install fehlgeschlagen. Weitere Details siehe setup.log")
+        log("pip install fehlgeschlagen")
+        log(str(e))
+        sys.exit(1)
+else:
+    log("requirements.txt nicht gefunden")
+
 # ----------------------- Haupt-Abhaengigkeiten installieren -----------------
 log("npm ci (root) starten")
 print("Abhaengigkeiten im Hauptverzeichnis werden installiert...")

--- a/translate_text.py
+++ b/translate_text.py
@@ -6,27 +6,11 @@ import os
 try:
     from argostranslate import package, translate
 except ModuleNotFoundError:
-    # Fehlendes Paket automatisch installieren (requirements.txt liegt neben dem Skript)
+    # Abhängigkeit nicht vorhanden -> Hinweis ausgeben und abbrechen
     sys.stderr.write(
-        "Das Paket 'argostranslate' fehlt. Versuche automatische Installation...\n"
+        "Das Paket 'argostranslate' fehlt. Bitte vorher 'pip install -r requirements.txt' ausfuehren.\n"
     )
-    try:
-        req_file = os.path.join(os.path.dirname(__file__), "requirements.txt")
-        subprocess.check_call([
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "-r",
-            req_file,
-        ])
-        # erneuter Import nach erfolgreicher Installation
-        from argostranslate import package, translate
-    except Exception as exc:
-        raise SystemExit(
-            "Automatische Installation von 'argostranslate' fehlgeschlagen. "
-            "Bitte 'pip install -r requirements.txt' manuell ausfuehren."
-        ) from exc
+    sys.exit(1)
 
 FROM_CODE = "en"
 TO_CODE = "de"


### PR DESCRIPTION
## Summary
- installiere `argostranslate` über `start_tool.py`
- entferne automatische Installation aus `translate_text.py`
- dokumentiere neue Vorgehensweise in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e9c0290c883278f2ed4a2dcf09d39