### PR TITLE
Bugfix: Übersetzungs-Paketprüfung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 * Kapitel-Auswahllisten sind jetzt nach der Kapitelnummer sortiert.
 ## 🛠️ Patch in 1.40.12
 * Level-Auswahlliste in den Projekt-Einstellungen folgt nun der Level-Nummer.
+## 🛠️ Patch in 1.40.13
+* Offline-Übersetzung erkennt installierte Sprachpakete jetzt korrekt.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Bei einem Upload-Fehler mit Status 400 wird zusätzlich ein Ausschnitt der erzeu
 
 ### Python-Übersetzungsskript
 
-`translate_text.py` übersetzt kurze Texte offline mit Argos Translate. Die benötigten Pakete werden durch `start_tool.py` automatisch installiert. Fehlende Sprachpakete lädt das Skript beim ersten Aufruf automatisch herunter. Anschließend kann der gewünschte Text per `echo "Hello" | python translate_text.py` übersetzt werden.
+`translate_text.py` übersetzt kurze Texte offline mit Argos Translate. Die benötigten Pakete werden durch `start_tool.py` automatisch installiert. Fehlende Sprachpakete lädt das Skript beim ersten Aufruf automatisch herunter. Seit Version 1.40.13 wird dabei korrekt erkannt, ob ein Paket bereits vorhanden ist. Anschließend kann der gewünschte Text per `echo "Hello" | python translate_text.py` übersetzt werden.
 
 ### Version aktualisieren
 

--- a/translate_text.py
+++ b/translate_text.py
@@ -23,7 +23,7 @@ def ensure_package(from_code: str, to_code: str) -> None:
     have_translation = any(
         lang.code == from_code
         and any(
-            t.to_code == to_code
+            t.to_lang.code == to_code
             for t in getattr(lang, "translations_from", [])
         )
         for lang in installed


### PR DESCRIPTION
## Summary
- erkennen, ob ein Argos-Paket bereits installiert ist
- Hinweis im README zu dieser Fehlerbehebung
- changelog um Patch 1.40.13 ergänzen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e9f8cf50c8327b480932f66e5ca0a