### PR TITLE
Fix Unicode output for automatic translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Ctrl+Leertaste:** Audio‑Playback direkt im Textfeld
 * **Copy‑Buttons:** 📋 neben jedem Textfeld für direktes Kopieren
 * **Automatische Übersetzungsvorschau** unter jedem DE-Feld via *Argos Translate*
+* **Umlaute korrekt anzeigen:** Die automatischen Übersetzungen nutzen nun immer UTF‑8
 * **Gespeicherte Übersetzungen:** einmal erzeugte Vorschläge werden im Projekt abgelegt und nur bei Änderungen neu berechnet
 * **Fortschrittsanzeige** beim automatischen Übersetzen aller fehlenden Texte
 * **Projekt-Playback:** ▶/⏸/⏹ spielt verfügbare DE-Dateien nacheinander ab

--- a/electron/main.js
+++ b/electron/main.js
@@ -370,12 +370,16 @@ app.whenReady().then(() => {
       const result = spawnSync(
         'python',
         [path.join(__dirname, '..', 'translate_text.py')],
-        { input: text }
+        {
+          input: text,
+          encoding: 'utf8',
+          env: { ...process.env, PYTHONIOENCODING: 'utf-8' },
+        }
       );
       if (result.status === 0) {
-        return result.stdout.toString().trim();
+        return result.stdout.trim();
       }
-      console.error('[Translate]', result.stderr.toString());
+      console.error('[Translate]', result.stderr);
     } catch (e) {
       console.error('[Translate]', e);
     }


### PR DESCRIPTION
## Summary
- call Python with UTF-8 encoding to fix garbled umlauts in auto-translations
- dokumentiere diese Änderung in der README

## Testing
- `npm test --silent`
- `npx jest --color=false`

------
https://chatgpt.com/codex/tasks/task_e_684ea579881083278bfb55393ed5c4cd