### PR TITLE
Bugfix: korrekte Pfade beim manuellen Dubbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Seit Patch 1.40.10 sortiert sich die Kapitel-Liste in der Projekt-Ansicht sofort
 Seit Patch 1.40.11 sind die Kapitel-Auswahllisten in den Projekt- und Level-Dialogen ebenfalls nach der Nummer sortiert.
 Seit Patch 1.40.12 ist auch die Level-Auswahl im Projekt-Dialog nach der Level-Nummer sortiert.
 Seit Patch 1.40.13 springt die Projekt-Wiedergabe nach einer Datei automatisch zur nächsten.
+Seit Patch 1.40.14 werden halbautomatisch importierte Dateien korrekt nach `web/sounds/DE` verschoben, auch wenn der gespeicherte Pfad mit `sounds` beginnt.
 
 
 Beispiel einer gültigen CSV:

--- a/watcher.js
+++ b/watcher.js
@@ -67,7 +67,10 @@ function watchDownloadFolder(callback, opts = {}) {
             const job = pending[idx];
             try {
                 await warteBisFertig(file);
-                const zielRel = path.posix.join('sounds', 'DE', job.relPath.replace(/\.(mp3|wav|ogg)$/i, '.wav'));
+                // Pfad bereinigen: führendes "sounds" entfernen
+                let rel = job.relPath.replace(/^[/\\]+/, '');
+                rel = rel.replace(/^sounds[\/]/i, '');
+                const zielRel = path.posix.join('sounds', 'DE', rel.replace(/\.(mp3|wav|ogg)$/i, '.wav'));
                 const ziel = path.join(projectRoot, zielRel);
                 fs.mkdirSync(path.dirname(ziel), { recursive: true });
                 try {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -282,9 +282,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
                 const rel = getFullPath(ziel).replace(/\.(mp3|wav|ogg)$/i, '');
                 const ext = file.substring(file.lastIndexOf('.'));
-                const dest = `sounds/DE/${rel}${ext}`;
+                // Pfad bereinigen, falls er bereits mit "sounds" beginnt
+                const cleanedRel = rel.replace(/^sounds[\/]/i, '');
+                const dest = `sounds/DE/${cleanedRel}${ext}`;
                 await window.electronAPI.moveFile(file, dest);
-                deAudioCache[`${rel}${ext}`] = dest;
+                deAudioCache[`${cleanedRel}${ext}`] = dest;
                 ziel.dubReady = true;
                 ziel.waitingForManual = false;
                 renderFileTable();


### PR DESCRIPTION
## Zusammenfassung
- bereinige Pfad in `watcher.js`, damit beim Kopieren aus dem Download-Ordner kein doppeltes `sounds` entsteht
- bereinige Pfad auch in `web/src/main.js`, wenn eine Datei manuell importiert wird
- README mit Hinweis auf neuen Patch 1.40.14 aktualisiert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ea88e0dc48327aaced5fd70b87b5f