### PR TITLE
Support 'Downloads' folder for manual dubbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ if (await isDubReady(job.dubbing_id, 'de', apiKey)) {
 Ein Klick auf **Dubbing** öffnet zunächst ein Einstellungsfenster. Danach fragt das Tool,
 ob die **Beta-API** genutzt oder der **halbautomatische Modus** verwendet werden soll.
 Im halbautomatischen Modus werden Audiodatei und Texte lediglich an ElevenLabs gesendet.
-Anschließend erscheint ein Hinweis, die fertig gerenderte Datei in den projektspezifischen Ordner `web/Download` zu legen.
+Anschließend erscheint ein Hinweis, die fertig gerenderte Datei in den projektspezifischen Ordner `web/Download` (oder `web/Downloads`) zu legen.
 Sobald dort eine passende Datei auftaucht, zeigt das Tool „Datei gefunden" mit Namen an und
 wartet auf eine Bestätigung.
 Im Einstellungsfenster lassen sich folgende Parameter anpassen:
@@ -170,7 +170,7 @@ Nach erfolgreichem Download merkt sich das Projekt die zugehörige **Dubbing-ID*
 So können Sie das Ergebnis später erneut herunterladen oder neu generieren.
 Beim erneuten Download fragt das Tool nun ebenfalls, ob die Beta-API oder der halbautomatische Modus genutzt werden soll.
 
-Ein Watcher überwacht automatisch den Ordner `web/Download` im Projekt. Taucht dort eine fertig gerenderte Datei auf, meldet das Tool „Datei gefunden“ und verschiebt sie nach `web/sounds/DE`. Seit Version 1.40.5 klappt das auch nach einem Neustart: Legen Sie die Datei einfach in den Ordner, sie wird anhand der Dubbing‑ID automatisch der richtigen Zeile zugeordnet. Der Status springt anschließend auf *fertig*. Alle 15 Sekunden erfolgt zusätzlich eine Status-Abfrage der offenen Jobs, allerdings nur im Beta-Modus. Beta-Jobs werden nun automatisch aus dieser Liste entfernt, sobald sie fertig sind. Der halbautomatische Modus verzichtet auf diese Abfrage. Der Download-Ordner wird zu Beginn jedes neuen Dubbings und nach dem Import automatisch geleert.
+Ein Watcher überwacht automatisch den Ordner `web/Download` bzw. `web/Downloads` im Projekt. Taucht dort eine fertig gerenderte Datei auf, meldet das Tool „Datei gefunden“ und verschiebt sie nach `web/sounds/DE`. Seit Version 1.40.5 klappt das auch nach einem Neustart: Legen Sie die Datei einfach in den Ordner, sie wird anhand der Dubbing‑ID automatisch der richtigen Zeile zugeordnet. Der Status springt anschließend auf *fertig*. Alle 15 Sekunden erfolgt zusätzlich eine Status-Abfrage der offenen Jobs, allerdings nur im Beta-Modus. Beta-Jobs werden nun automatisch aus dieser Liste entfernt, sobald sie fertig sind. Der halbautomatische Modus verzichtet auf diese Abfrage. Der Download-Ordner wird zu Beginn jedes neuen Dubbings und nach dem Import automatisch geleert.
 Seit Patch 1.40.7 merkt sich das Tool außerdem den fertigen Status dauerhaft. Auch nach einem erneuten Download bleibt der grüne Haken erhalten.
 Seit Patch 1.40.8 werden Dateien auch dann korrekt verschoben, wenn sich Download- und Projektordner auf unterschiedlichen Laufwerken befinden.
 Seit Patch 1.40.9 merkt sich der Level-Dialog die zuletzt genutzten fünf Farben und bietet eine Schnellwahl unter dem Farbpicker.

--- a/web/src/config.js
+++ b/web/src/config.js
@@ -8,11 +8,14 @@ const projectRoot = path.resolve(__dirname, '..');
 const soundsDirName = chooseExisting(projectRoot, ['Sounds', 'sounds']);
 // Absoluter Pfad zum Sounds-Ordner
 const SOUNDS_BASE_PATH = path.resolve(projectRoot, soundsDirName);
+// Name des Download-Ordners automatisch ermitteln
+// Unterstuetzt sowohl "Download" als auch "Downloads"
+const downloadDirName = chooseExisting(projectRoot, ['Download', 'Downloads']);
 // Pfad zum Download-Ordner relativ zur Projektwurzel
-const DL_WATCH_PATH = path.resolve(projectRoot, 'Download');
+const DL_WATCH_PATH = path.resolve(projectRoot, downloadDirName);
 
 // Ordner beim Programmstart sicherstellen
 if (!fs.existsSync(DL_WATCH_PATH)) fs.mkdirSync(DL_WATCH_PATH);
 
 // Export für andere Module
-module.exports = { DL_WATCH_PATH, projectRoot, SOUNDS_BASE_PATH, soundsDirName };
+module.exports = { DL_WATCH_PATH, projectRoot, SOUNDS_BASE_PATH, soundsDirName, downloadDirName };


### PR DESCRIPTION
## Summary
- allow both `Download` and `Downloads` folder names
- mention optional folder name in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eab2668fc8327b397f0f741c0a3c3