### PR TITLE
Fix manual dubbing import

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Seit Patch 1.40.11 sind die Kapitel-Auswahllisten in den Projekt- und Level-Dial
 Seit Patch 1.40.12 ist auch die Level-Auswahl im Projekt-Dialog nach der Level-Nummer sortiert.
 Seit Patch 1.40.13 springt die Projekt-Wiedergabe nach einer Datei automatisch zur nächsten.
 Seit Patch 1.40.14 werden halbautomatisch importierte Dateien korrekt nach `web/sounds/DE` verschoben, auch wenn der gespeicherte Pfad mit `sounds` beginnt.
+Seit Patch 1.40.15 meldet das Tool erkannte Dateien nur noch – das Verschieben übernimmt vollständig der Watcher.
 
 
 Beispiel einer gültigen CSV:

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -266,33 +266,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         // Meldung bei neuen Dateien aus dem Download-Ordner
         if (window.electronAPI.onManualFile) {
-            window.electronAPI.onManualFile(async file => {
-                // Zuerst nach aktivem Dubbing-Item suchen
-                let ziel = getActiveDubItem();
-
-                if (!ziel) {
-                    // Kein aktives Item -> per Dateinamen oder Dubbing-ID suchen
-                    const basis = file.substring(file.lastIndexOf('/') + 1)
-                                      .replace(/\.(mp3|wav|ogg)$/i, '');
-                    ziel = files.find(f => f.dubbingId === basis ||
-                        f.filename.replace(/\.(mp3|wav|ogg)$/i, '') === basis);
-                }
-
-                if (!ziel) return; // Keine Zuordnung möglich
-
-                const rel = getFullPath(ziel).replace(/\.(mp3|wav|ogg)$/i, '');
-                const ext = file.substring(file.lastIndexOf('.'));
-                // Pfad bereinigen, falls er bereits mit "sounds" beginnt
-                const cleanedRel = rel.replace(/^sounds[\/]/i, '');
-                const dest = `sounds/DE/${cleanedRel}${ext}`;
-                await window.electronAPI.moveFile(file, dest);
-                deAudioCache[`${cleanedRel}${ext}`] = dest;
-                ziel.dubReady = true;
-                ziel.waitingForManual = false;
-                renderFileTable();
-                saveCurrentProject();
-                const name = dest.split('/').pop();
-                showToast(`${name} importiert.`);
+            window.electronAPI.onManualFile(file => {
+                const name = file.substring(file.lastIndexOf('/') + 1);
+                showToast(`${name} erkannt.`);
                 updateDownloadWaitDialog(name);
             });
         }


### PR DESCRIPTION
## Summary
- ignore manual download file in UI so watcher can handle move
- document patch 1.40.15 in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eaec7f418832789fa6b8e9e5fca22