### PR TITLE
Fix move-file cross-drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 * Importierte Dateien erzeugen sofort einen History-Eintrag und gelten als fertig.
 ## 🛠️ Patch in 1.40.16
 * `validateCsv` erhält nun Anführungszeichen, sodass Kommata in Übersetzungen keinen Fehler mehr auslösen.
+## 🛠️ Patch in 1.40.17
+* `move-file` verschiebt Dateien nun auch über Laufwerksgrenzen hinweg.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Seit Patch 1.40.13 springt die Projekt-Wiedergabe nach einer Datei automatisch z
 Seit Patch 1.40.14 werden halbautomatisch importierte Dateien korrekt nach `web/sounds/DE` verschoben, auch wenn der gespeicherte Pfad mit `sounds` beginnt.
 Seit Patch 1.40.15 werden diese Dateien zusätzlich wie ein manueller Upload behandelt: Ein History-Eintrag entsteht und der Status springt sofort auf *fertig*.
 Seit Patch 1.40.16 validiert das Tool CSV-Dateien auch dann korrekt, wenn die Übersetzung Kommata enthält.
+Seit Patch 1.40.17 verschiebt der halbautomatische Import Dateien auch über Laufwerksgrenzen hinweg.
 
 
 Beispiel einer gültigen CSV:

--- a/electron/main.js
+++ b/electron/main.js
@@ -343,7 +343,18 @@ app.whenReady().then(() => {
     // Zielpfad absolut bestimmen
     const target = path.resolve(projectRoot, dest);
     fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.renameSync(src, target);
+    try {
+      // Direkt verschieben
+      fs.renameSync(src, target);
+    } catch (err) {
+      // Bei unterschiedlichen Laufwerken schlagen rename-Operationen fehl
+      if (err.code === 'EXDEV') {
+        fs.copyFileSync(src, target);
+        fs.unlinkSync(src);
+      } else {
+        throw err;
+      }
+    }
     // Sicherheitshalber alten Pfad löschen
     if (fs.existsSync(src)) fs.unlinkSync(src);
     return target;


### PR DESCRIPTION
## Summary
- allow moving files across drives in `move-file` handler
- note new patch in CHANGELOG and README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eb3f493608327a559916ca16264eb