### PR TITLE
Fix path for manual dub imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
 * Dateiwächter findet nun auch Dateien mit leicht verändertem Namen und gibt bei fehlender Zuordnung eine Warnung aus.
 ## 🛠️ Patch in 1.40.18
 * Halbautomatisch heruntergeladene Dateien wandern jetzt in den dynamisch erkannten Sounds-Ordner.
+## 🛠️ Patch in 1.40.19
+* Korrigiert die Ordnerstruktur beim halbautomatischen Import: Der "sounds"-Unterordner wird nun korrekt angelegt.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Seit Patch 1.40.15 werden diese Dateien zusätzlich wie ein manueller Upload beh
 Seit Patch 1.40.16 validiert das Tool CSV-Dateien auch dann korrekt, wenn die Übersetzung Kommata enthält.
 Seit Patch 1.40.17 verknüpft der Dateiwächter heruntergeladene Dubbing-Dateien auch bei kleinen Namensabweichungen korrekt und meldet fehlende Zuordnungen im Terminal.
 Seit Patch 1.40.18 verschiebt der Dateiwächter halbautomatisch heruntergeladene Dateien nun in den dynamisch erkannten Sounds-Ordner.
+Seit Patch 1.40.19 korrigiert er zudem die Ordnerstruktur beim halbautomatischen Import, sodass der "sounds"-Unterordner erhalten bleibt.
 
 
 Beispiel einer gültigen CSV:

--- a/watcher.js
+++ b/watcher.js
@@ -80,10 +80,11 @@ function watchDownloadFolder(callback, opts = {}) {
             const job = pending[idx];
             try {
                 await warteBisFertig(file);
-                // Pfad bereinigen: führendes "sounds" entfernen
-                let rel = job.relPath.replace(/^[/\\]+/, '');
-                rel = rel.replace(/^sounds[\/]/i, '');
-                // Ziel relativ zum erkannten Sounds-Ordner aufbauen
+                // Pfad bereinigen und korrekt aufbauen
+                let rel = job.relPath.replace(/^[\/]+/, '');
+                rel = rel.replace(/^web[\/]/i, '');
+                rel = rel.replace(/^sounds[\/](?=en[\/])/i, '');
+                rel = rel.replace(/^(?:en|de)[\/]/i, '');
                 const zielRel = path.posix.join(soundsDirName, 'DE', rel.replace(/\.(mp3|wav|ogg)$/i, '.wav'));
                 const ziel = path.join(SOUNDS_BASE_PATH, 'DE', rel.replace(/\.(mp3|wav|ogg)$/i, '.wav'));
                 fs.mkdirSync(path.dirname(ziel), { recursive: true });


### PR DESCRIPTION
## Summary
- fix download watcher path handling so subfolders remain intact
- document patch 1.40.19 in README and CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ec324029c83278929a8321da5bee3