### PR TITLE
Improve dubbing log

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Seit Patch 1.40.18 verschiebt der Dateiwächter halbautomatisch heruntergeladene
 Seit Patch 1.40.19 korrigiert er zudem die Ordnerstruktur beim halbautomatischen Import, sodass der "sounds"-Unterordner erhalten bleibt.
 Seit Patch 1.40.20 prüft der Dateiwächter im halbautomatischen Modus die Audiodatei vor dem Verschieben auf Gültigkeit.
 Seit Patch 1.40.21 zeigt das Dubbing-Protokoll beim halbautomatischen Import, welche Datei gefunden wurde, wohin sie kopiert wurde und ob die Prüfung vor und nach dem Kopieren erfolgreich war.
+Seit Patch 1.40.22 protokolliert das Tool zusätzlich den vollständigen Original- und Zielpfad der Datei.
 
 
 Beispiel einer gültigen CSV:

--- a/watcher.js
+++ b/watcher.js
@@ -134,7 +134,10 @@ function watchDownloadFolder(callback, opts = {}) {
                     dest: zielRel,
                     source: path.relative(watchPath, file),
                     srcValid,
-                    destValid
+                    destValid,
+                    // Neuer Eintrag: absolute Pfade fuer detailliertes Logging
+                    sourcePath: file,
+                    destPath: ziel
                 });
                 // Nach erfolgreichem Verschieben den Download-Ordner leeren
                 leereOrdner(watchPath);

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -304,8 +304,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Automatischer Import abgeschlossen
         if (window.electronAPI.onDubDone) {
             window.electronAPI.onDubDone(info => {
-                if (info.source) addDubbingLog('Gefunden: ' + info.source);
-                if (info.dest) addDubbingLog('Kopiert nach: ' + info.dest);
+                // Pfade der Original- und Zieldatei im Log ausgeben
+                if (info.sourcePath) addDubbingLog('Originalpfad: ' + info.sourcePath);
+                if (info.destPath)   addDubbingLog('Zielpfad: ' + info.destPath);
                 if (info.srcValid !== undefined) {
                     addDubbingLog('Prüfung Download-Datei: ' + (info.srcValid ? 'OK' : 'FEHLER'));
                 }


### PR DESCRIPTION
## Summary
- extend the watcher's `onDone` info with absolute source and destination paths
- log these new paths in the renderer
- document new patch in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ec9c16760832786192a70ecb4ea31