### PR TITLE
Fix case-insensitive dub path and cache cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Seit Patch 1.40.21 zeigt das Dubbing-Protokoll beim halbautomatischen Import, we
 Seit Patch 1.40.22 protokolliert das Tool zusätzlich den vollständigen Original- und Zielpfad der Datei.
 Seit Patch 1.40.23 benennt der Dateiwächter gefundene Dateien zunächst korrekt um und verschiebt sie erst danach.
 Seit Patch 1.40.24 entfernt der halbautomatische Import auch vorgestellte "EN"- oder "DE"-Ordnernamen, sodass keine unnötigen Unterordner mehr entstehen.
+Seit Patch 1.40.25 bereinigt das Tool beim Start fehlerhafte Einträge im DE-Cache und erkennt Zielpfade von Dubbings nun unabhängig von der Großschreibung.
 
 
 Beispiel einer gültigen CSV:

--- a/tests/markDubAsReady.test.js
+++ b/tests/markDubAsReady.test.js
@@ -1,0 +1,47 @@
+let markDubAsReady, cleanupDubCache, __setFiles, __setDeAudioCache, __setRenderFileTable, __setSaveCurrentProject;
+
+function loadMain() {
+    jest.resetModules();
+    global.document = { addEventListener: jest.fn() };
+    global.window = { addEventListener: jest.fn() };
+    global.localStorage = {
+        getItem: () => null,
+        setItem: () => {},
+        removeItem: () => {},
+        clear: () => {}
+    };
+    ({ markDubAsReady, cleanupDubCache, __setFiles, __setDeAudioCache, __setRenderFileTable, __setSaveCurrentProject } = require('../web/src/main.js'));
+    __setRenderFileTable(() => {});
+    __setSaveCurrentProject(() => {});
+}
+
+describe('markDubAsReady', () => {
+    beforeEach(loadMain);
+
+    test('entfernt Prefix unabhaengig von Grossschreibung', () => {
+        const cache = {};
+        __setFiles([{ id: 1 }]);
+        __setDeAudioCache(cache);
+        markDubAsReady(1, 'Sounds/DE/folder/test.mp3');
+        expect(cache).toEqual({ 'folder/test.mp3': 'Sounds/DE/folder/test.mp3' });
+    });
+
+    test('funktioniert auch mit kleinem sounds', () => {
+        const cache = {};
+        __setFiles([{ id: 1 }]);
+        __setDeAudioCache(cache);
+        markDubAsReady(1, 'sounds/DE/folder/test.mp3');
+        expect(cache).toEqual({ 'folder/test.mp3': 'sounds/DE/folder/test.mp3' });
+    });
+});
+
+describe('cleanupDubCache', () => {
+    beforeEach(loadMain);
+
+    test('bereinigt alte Eintraege', () => {
+        const cache = { 'Sounds/DE/test.mp3': 'Sounds/DE/test.mp3', 'ok.mp3': 'ok' };
+        __setDeAudioCache(cache);
+        cleanupDubCache();
+        expect(cache).toEqual({ 'ok.mp3': 'ok', 'test.mp3': 'Sounds/DE/test.mp3' });
+    });
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -132,6 +132,19 @@ if (typeof module !== 'undefined' && module.exports) {
 
 // =========================== GLOBAL STATE END ===========================
 
+// Entfernt versehentlich falsch gespeicherte Einträge aus dem DE-Cache
+function cleanupDubCache() {
+    for (const key of Object.keys(deAudioCache)) {
+        if (key.match(/^sounds\/DE\//i)) {
+            const neu = key.replace(/^sounds\/DE\//i, '');
+            if (!deAudioCache[neu]) {
+                deAudioCache[neu] = deAudioCache[key];
+            }
+            delete deAudioCache[key];
+        }
+    }
+}
+
 
 // =========================== DEBUG LOG START ===========================
 // Schreibt Meldungen in die Browser-Konsole und die Debug-Anzeige
@@ -247,6 +260,8 @@ function stopCurrentPlayback() {
 // =========================== DOM READY INITIALISIERUNG ===========================
 document.addEventListener('DOMContentLoaded', async () => {
     updateProjectPlaybackButtons();
+    // Beim Start alte, falsch gespeicherte Cache-Einträge entfernen
+    cleanupDubCache();
     // DevTools-Knopf wird immer eingeblendet
 
 
@@ -9896,10 +9911,12 @@ function showChapterCustomization(chapterName, ev) {
         }
 
         // Markiert eine Datei als bereit und aktualisiert die Anzeige
+        // Markiert eine Datei als bereit und aktualisiert die Anzeige
+        // Das Präfix "sounds/DE/" wird nun Groß-/Kleinschreibungs-unabhängig entfernt
         function markDubAsReady(id, dest) {
             const file = files.find(f => f.id === id);
             if (!file) return;
-            const rel = dest.replace(/^sounds\/DE\//, '');
+            const rel = dest.replace(/^sounds\/DE\//i, '');
             deAudioCache[rel] = dest;
             file.dubReady = true;
             file.waitingForManual = false;
@@ -10043,8 +10060,12 @@ if (typeof module !== "undefined" && module.exports) {
         initiateDubbing,
         downloadDe,
         updateDubStatusForFiles,
+        markDubAsReady,
+        cleanupDubCache,
         getProjectPlaybackList,
         __setFiles: f => { files = f; },
-        __setDeAudioCache: c => { deAudioCache = c; }
+        __setDeAudioCache: c => { deAudioCache = c; },
+        __setRenderFileTable: fn => { renderFileTable = fn; },
+        __setSaveCurrentProject: fn => { saveCurrentProject = fn; }
     };
 }


### PR DESCRIPTION
## Summary
- handle 'sounds/DE' prefix case-insensitive in `markDubAsReady`
- clean incorrect cache entries on startup
- export helpers for tests
- add tests for `markDubAsReady` and cache cleanup
- document behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ee33e2284832780aa10c92005b8f1