### PR TITLE
Extend radio effect to 200%

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Feste Reihenfolge:** Beim Projekt-Playback wird die Dateiliste strikt von oben nach unten abgespielt, unabhängig vom Dateityp
 * **Stabileres Audio-Playback:** Unterbrochene Wiedergabe erzeugt keine Fehlermeldungen mehr
 * **Automatischer History-Eintrag:** Beim Lautstärkeabgleich wird das Original gespeichert
-* **Funkgeräte-Effekt:** Stärke per Regler wählbar; DE-Audio klingt wie per Funk und bleibt dank History wiederherstellbar
+* **Funkgeräte-Effekt:** Stärke per Regler wählbar (0–200%); DE-Audio klingt wie per Funk und bleibt dank History wiederherstellbar
 
 ### 🔍 Suche & Import
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -403,7 +403,7 @@
             </div>
             <div style="margin-bottom:15px;">
                 <label>Funk-Effekt: <span id="radioStrengthDisplay"></span></label>
-                <input type="range" id="radioStrength" min="0" max="1" step="0.1">
+                <input type="range" id="radioStrength" min="0" max="2" step="0.1">
             </div>
             <div class="dialog-buttons">
                 <button class="btn btn-secondary" onclick="resetDeEdit()">Zurücksetzen</button>


### PR DESCRIPTION
## Summary
- allow stronger radio effect by clamping value to 0-2
- boost filter when strength is over 100%
- increase slider range to 200%
- document new range in the README

## Testing
- `npm test --silent -- -i`

------
https://chatgpt.com/codex/tasks/task_e_684f31f31a8c83279ba8727752b8a165