### PR TITLE
Add reset option for radio effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 * Halbautomatisch heruntergeladene Dateien wandern jetzt in den dynamisch erkannten Sounds-Ordner.
 ## 🛠️ Patch in 1.40.19
 * Korrigiert die Ordnerstruktur beim halbautomatischen Import: Der "sounds"-Unterordner wird nun korrekt angelegt.
+## 🛠️ Patch in 1.40.20
+* Neuer Button setzt die Funk-Effektparameter auf Standardwerte zurück.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Feste Reihenfolge:** Beim Projekt-Playback wird die Dateiliste strikt von oben nach unten abgespielt, unabhängig vom Dateityp
 * **Stabileres Audio-Playback:** Unterbrochene Wiedergabe erzeugt keine Fehlermeldungen mehr
 * **Automatischer History-Eintrag:** Beim Lautstärkeabgleich wird das Original gespeichert
-* **Funkgeräte-Effekt:** Alle Parameter (Bandpass, Sättigung, Rauschen, Knackser, Wet) lassen sich bequem per Regler einstellen und werden dauerhaft gespeichert
+* **Funkgeräte-Effekt:** Alle Parameter (Bandpass, Sättigung, Rauschen, Knackser, Wet) lassen sich bequem per Regler einstellen und werden dauerhaft gespeichert. Über einen neuen Button stellen Sie die Standardwerte wieder her.
 
 ### 🔍 Suche & Import
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -425,6 +425,7 @@
                 <button class="btn btn-secondary" onclick="resetDeEdit()">Zurücksetzen</button>
                 <button id="volumeMatchBtn" class="btn btn-secondary" onclick="applyVolumeMatch()">Lautstärke angleichen</button>
                 <button id="radioEffectBtn" class="btn btn-secondary" onclick="applyRadioEffect()">Funkgerät-Effekt</button>
+                <button class="btn btn-secondary" onclick="resetRadioSettings()">Standardwerte</button>
                 <button class="btn btn-secondary" onclick="applyDeEdit()">Speichern</button>
                 <button class="btn btn-secondary" onclick="closeDeEdit()">Abbrechen</button>
             </div>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -8239,6 +8239,56 @@ async function applyRadioEffect() {
 // =========================== APPLYRADIOEFFECT END ==========================
 // =========================== APPLYVOLUMEMATCH END =========================
 
+// =========================== RESETRADIOSETTINGS START =====================
+// Setzt alle Funk-Effektwerte auf Standard zurück
+function resetRadioSettings() {
+    // Globale Standardwerte setzen
+    radioEffectStrength = 0.85;
+    radioHighpass = 300;
+    radioLowpass = 3200;
+    radioSaturation = 0.2;
+    radioNoise = -26;
+    radioCrackle = 0.1;
+
+    // Werte im LocalStorage aktualisieren
+    localStorage.setItem('hla_radioEffectStrength', radioEffectStrength);
+    localStorage.setItem('hla_radioHighpass', radioHighpass);
+    localStorage.setItem('hla_radioLowpass', radioLowpass);
+    localStorage.setItem('hla_radioSaturation', radioSaturation);
+    localStorage.setItem('hla_radioNoise', radioNoise);
+    localStorage.setItem('hla_radioCrackle', radioCrackle);
+
+    // Regler im Dialog zurücksetzen
+    const rStrength = document.getElementById('radioStrength');
+    const rStrengthDisp = document.getElementById('radioStrengthDisplay');
+    if (rStrength && rStrengthDisp) {
+        rStrength.value = radioEffectStrength;
+        rStrengthDisp.textContent = Math.round(radioEffectStrength * 100) + '%';
+    }
+    const rHigh = document.getElementById('radioHighpass');
+    if (rHigh) rHigh.value = radioHighpass;
+    const rLow = document.getElementById('radioLowpass');
+    if (rLow) rLow.value = radioLowpass;
+    const rSat = document.getElementById('radioSaturation');
+    const rSatDisp = document.getElementById('radioSaturationDisplay');
+    if (rSat && rSatDisp) {
+        rSat.value = radioSaturation;
+        rSatDisp.textContent = Math.round(radioSaturation * 100) + '%';
+    }
+    const rNoise = document.getElementById('radioNoise');
+    if (rNoise) rNoise.value = radioNoise;
+    const rCrackle = document.getElementById('radioCrackle');
+    const rCrackleDisp = document.getElementById('radioCrackleDisplay');
+    if (rCrackle && rCrackleDisp) {
+        rCrackle.value = radioCrackle;
+        rCrackleDisp.textContent = Math.round(radioCrackle * 100) + '%';
+    }
+
+    // Effekte neu berechnen, falls aktiv
+    if (isRadioEffect) recomputeEditBuffer();
+}
+// =========================== RESETRADIOSETTINGS END =======================
+
 // =========================== UPDATEDEEDITWAVEFORMS START ==================
 function updateDeEditWaveforms(progressOrig = null, progressDe = null) {
     // Cursor aktualisieren, falls neue Positionen mitgegeben werden


### PR DESCRIPTION
## Summary
- add `resetRadioSettings` to restore default radio effect parameters
- provide a new `Standardwerte` button in the DE edit dialog
- document the reset button in README and CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f38b2826c8327b26e4f20ff769b31