### PR TITLE
Implement Audio duplicate checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Bei einem Upload-Fehler mit Status 400 wird zusätzlich ein Ausschnitt der erzeu
 
 * **🧹 Ordnernamen bereinigen:** Korrigiert falsche Pfade automatisch
 * **🧹 Duplikate bereinigen:** Intelligente Zusammenführung ähnlicher Einträge
+* **🎵 Audio-Duplikate prüfen:** Gleiche Dateinamen mit unterschiedlichem Format zusammenführen
 * **🔄 Projekte bereinigen:** Entfernt veraltete Pfad‑Referenzen
 * **🔧 Ordner reparieren:** Aktualisiert Ordnernamen in allen Projekten
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -51,6 +51,8 @@ if (typeof require !== 'function') {
     getDebugInfo: () => ipcRenderer.invoke('get-debug-info'),
     fsReadFile: p => fs.readFileSync(p),
     fsExists: p => fs.existsSync(p),
+    getDeDuplicates: rel => ipcRenderer.invoke('get-de-duplicates', rel),
+    deleteDeFile: rel => ipcRenderer.invoke('delete-de-file', rel),
     join: (...segments) => path.join(...segments),
     translateText: text => ipcRenderer.invoke('translate-text', text),
   });

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -40,6 +40,7 @@
                     <button id="settingsButton" class="btn btn-secondary" onclick="toggleSettingsMenu()">⚙️ Einstellungen</button>
                     <div class="settings-menu" id="settingsMenu">
                         <div class="settings-item" onclick="cleanupDuplicates()">🧹 Duplikate bereinigen</div>
+                        <div class="settings-item" onclick="scanAudioDuplicates()">🎵 Audio-Duplikate</div>
                         <div class="settings-item" onclick="showBackupDialog()">💾 Backup</div>
                         <div class="settings-item" onclick="showApiDialog()">🔊 ElevenLabs API</div>
                         <div class="settings-item" onclick="resetFileDatabase()">🔄 Reset DB</div>


### PR DESCRIPTION
## Summary
- prevent MP3/WAV Doppelten im DE-Ordner
- Electron-API um Duplicate-Helper erweitern
- Audio-Duplikat-Prüfung im Frontend und neuen Menüpunkt
- README mit Hinweis auf die neue Funktion ergänzen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fb5d8e574832793ee942fdcff8cba