### PR TITLE
Fix: Layout und Speichern im Audio-Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Feste Reihenfolge:** Beim Projekt-Playback wird die Dateiliste strikt von oben nach unten abgespielt, unabhängig vom Dateityp
 * **Stabileres Audio-Playback:** Unterbrochene Wiedergabe erzeugt keine Fehlermeldungen mehr
 * **Automatischer History-Eintrag:** Beim Lautstärkeabgleich wird das Original gespeichert
-* **Funkgeräte-Effekt:** Alle Parameter (Bandpass, Sättigung, Rauschen, Knackser, Wet) lassen sich bequem per Regler einstellen und werden dauerhaft gespeichert. Über einen kleinen Button oben rechts stellen Sie die Standardwerte wieder her.
-* **Schneller Zugriff:** Die Funktionen Lautstärke angleichen – ⚡ und Funkgerät-Effekt – 📻 besitzen nun eigene Buttons mit Symbolen.
+* **Funkgeräte-Effekt:** Alle Parameter (Bandpass, Sättigung, Rauschen, Knackser, Wet) lassen sich bequem per Regler einstellen und werden dauerhaft gespeichert.
+* **Schneller Zugriff:** Die Funktionen Lautstärke angleichen – ⚡ und Funkgerät-Effekt – 📻 besitzen nun eigene Buttons mit Symbolen. Der Button **⟳ Standardwerte** befindet sich direkt daneben.
+* **Verbessertes Speichern:** Nach dem Anwenden von Lautstärke angleichen oder Funkgerät‑Effekt bleiben die Änderungen nun zuverlässig erhalten.
 
 ### 🔍 Suche & Import
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -421,11 +421,11 @@
                 <label title="Häufigkeit der Knackser">Knackser: <span id="radioCrackleDisplay"></span>
                     <input type="range" id="radioCrackle" min="0" max="1" step="0.05">
                 </label>
-                <button class="btn-reset-settings" onclick="resetRadioSettings()">⟳ Standardwerte</button>
             </div>
             <div class="effect-buttons" style="margin-bottom:15px; display:flex; gap:10px;">
                 <button id="volumeMatchBtn" class="effect-btn" onclick="applyVolumeMatch()">🔊 Lautstärke angleichen</button>
                 <button id="radioEffectBtn" class="effect-btn" onclick="applyRadioEffect()">📻 Funkgerät-Effekt</button>
+                <button class="btn-reset-settings" onclick="resetRadioSettings()">⟳ Standardwerte</button>
             </div>
             <div class="dialog-buttons">
                 <button class="btn btn-secondary" onclick="resetDeEdit()">Zurücksetzen</button>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -8181,7 +8181,9 @@ async function openDeEdit(fileId) {
     if (!deSrc) return;
     // Zuerst versuchen wir, die aktuelle DE-Datei zu laden
     try {
-        originalEditBuffer = await loadAudioBuffer(deSrc);
+        // Cache-Buster anhängen, damit nach Änderungen die aktuelle Datei geladen wird
+        const src = typeof deSrc === 'string' ? `${deSrc}?v=${Date.now()}` : deSrc;
+        originalEditBuffer = await loadAudioBuffer(src);
     } catch {
         // Falls das fehlschlägt, greifen wir auf das Backup zurück
         const backupSrc = `sounds/DE-Backup/${rel}`;

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -849,9 +849,6 @@ th:nth-child(6) {
 
 /* Kleiner Button für Standardwerte rechts oben */
 .btn-reset-settings {
-    position: absolute;
-    top: 0;
-    right: 0;
     background: #333;
     border: 1px solid #555;
     color: #ccc;


### PR DESCRIPTION
## Zusammenfassung
- Button **⟳ Standardwerte** direkt neben Lautstärke angleichen und Funkgerät-Effekt platziert
- Layout-Anpassung des Buttons in der CSS-Datei
- Cache-Buster beim Laden der DE-Datei, damit geänderte Audios korrekt geladen werden
- Dokumentation angepasst: neuer Button-Standort und Hinweis auf zuverlässiges Speichern

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fbca6f5c88327b063491d29b59f90