### PR TITLE
Add immediate save after DE edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Seit Patch 1.40.23 benennt der Dateiwächter gefundene Dateien zunächst korrekt
 Seit Patch 1.40.24 entfernt der halbautomatische Import auch vorgestellte "EN"- oder "DE"-Ordnernamen, sodass keine unnötigen Unterordner mehr entstehen.
 Seit Patch 1.40.25 bereinigt das Tool beim Start fehlerhafte Einträge im DE-Cache und erkennt Zielpfade von Dubbings nun unabhängig von der Großschreibung.
 Seit Patch 1.40.26 wiederholt der manuelle Import das Verschieben mehrmals und wartet kurze Zeit, falls die Datei noch gesperrt ist. Dadurch verschwinden Fehler wie "resource busy or locked".
+Seit Patch 1.40.27 werden Änderungen am DE-Audio nach dem Bearbeiten sofort im Projekt gespeichert.
 
 
 Beispiel einer gültigen CSV:

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -8753,6 +8753,8 @@ async function applyDeEdit() {
         renderFileTable();
         closeDeEdit();
         updateStatus('DE-Audio bearbeitet und gespeichert');
+        // Sofort speichern, damit die Bearbeitung gesichert ist
+        saveCurrentProject();
     } catch (err) {
         console.error('Fehler beim Speichern', err);
         updateStatus('Fehler beim Speichern');


### PR DESCRIPTION
## Summary
- save DE edits directly to project
- document new behaviour in patch notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fc1436c7c8327bad662a285da855c