### PR TITLE
Update version to 1.40.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.5-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.27-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla-translation-desktop",
-  "version": "1.40.5",
+  "version": "1.40.27",
   "main": "main.js",
   "scripts": {
     "start": "electron ."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.40.5",
+  "version": "1.40.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.40.5",
+      "version": "1.40.27",
       "dependencies": {
         "chokidar": "^4.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.40.5",
+  "version": "1.40.27",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -484,7 +484,7 @@
 
     <!-- Versionsanzeige -->
     <!-- Verlinkung zur aktuellen Version -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.40.5</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.40.27</a>
 
     <script src="src/main.js"></script>
 </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -121,7 +121,7 @@ let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
 // Aktuelle Programmversion
-const APP_VERSION = '1.40.5';
+const APP_VERSION = '1.40.27';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 


### PR DESCRIPTION
## Summary
- aktualisiere Version in `APP_VERSION` auf 1.40.27
- passe Versionsanzeige in der HTML-Datei an
- aktualisiere Versionsnummern in `package.json` und `package-lock.json`
- synchronisiere Desktop-Version `electron/package.json`
- hebe neue Version im README hervor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fc546071c8327ae69b3273329b691