### PR TITLE
Prüfung des Schnittbereichs

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Bei einem Upload-Fehler mit Status 400 wird zusätzlich ein Ausschnitt der erzeu
 | **Text kopieren**         | 📋 Button neben Textfeld |
 | **Zwischen Feldern**      | `Tab` / `Shift + Tab` |
 | **Auto-Resize aktiviert** | Textfelder passen sich automatisch an |
+* Beim Speichern eines DE-Audios verhindert das Tool nun ungültige Schnittbereiche und zeigt einen Fehler an.
 ---
 
 ## ⌨️ Keyboard Shortcuts

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -8674,6 +8674,12 @@ async function resetDeEdit() {
 // Speichert die bearbeitete DE-Datei und legt ein Backup an
 async function applyDeEdit() {
     if (!currentEditFile || !originalEditBuffer) return;
+    // Restlänge berechnen und ungültigen Schnitt verhindern
+    const restlaenge = editDurationMs - editStartTrim - editEndTrim;
+    if (restlaenge <= 0) {
+        showToast('Ungültiger Schnittbereich – Datei wurde nicht gespeichert', 'error');
+        return;
+    }
     const relPath = getFullPath(currentEditFile); // Aktuellen Pfad ermitteln
     try {
         // Aktuellen Status des Lautstärkeabgleichs nutzen


### PR DESCRIPTION
## Zusammenfassung
- validiere Restlänge beim Speichern von DE-Schnitten
- Hinweis zum Verhalten im README ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fd6fccd28832788943ea1777295a3