### PR TITLE
Fix path cleanup in applyDeEdit

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 
 **💾 Fehler beim Speichern des DE-Audios**
 * ▶ **Hinweis:** Ordnerzugriff erneut erlauben oder Pfad prüfen. Das Tool zeigt die genaue Ursache im Toast an.
+* ▶ **Pfad prüfen:** Beim Speichern wird `sounds/DE/` nun automatisch entfernt, falls der Pfad doppelt vorkommt.
 
 #### Häufige Crash-Stellen
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -8710,7 +8710,9 @@ async function applyDeEdit() {
                 delete deAudioCache[d.relPath];
             }
         }
-        await window.electronAPI.saveDeFile(relPath, new Uint8Array(buf));
+        // Pfad bereinigen, falls "sounds/DE/" bereits vorangestellt ist
+        let cleanPath = relPath.replace(/^([\\/]*sounds[\\/])?de[\\/]/i, '');
+        await window.electronAPI.saveDeFile(cleanPath, new Uint8Array(buf));
         deAudioCache[relPath] = `sounds/DE/${relPath}`;
         await updateHistoryCache(relPath);
         URL.revokeObjectURL(url);


### PR DESCRIPTION
## Summary
- sanitize relative paths before saving in `applyDeEdit`
- document the new path cleanup hint in the debug checklist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fd8eadc848327ac9a9392e73fc64e