### PR TITLE
Add IPC type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 * Korrigiert die Ordnerstruktur beim halbautomatischen Import: Der "sounds"-Unterordner wird nun korrekt angelegt.
 ## 🛠️ Patch in 1.40.20
 * Neuer Button setzt die Funk-Effektparameter auf Standardwerte zurück.
+## 🛠️ Patch in 1.40.21
+* Typdefinitionen für die IPC-Kommunikation ergänzen `ipcContracts.ts`.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -508,3 +508,4 @@ Die wichtigsten Tests befinden sich im Ordner `tests/` und prüfen die Funktione
 * **`saveDeHistoryBuffer(relPath, data)`** – legt einen Buffer als neue History-Version ab.
 * **`copyDubbedFile(originalPath, tempDubPath)`** – verschiebt eine heruntergeladene Dub-Datei in den deutschen Ordnerbaum.
 * **`calculateProjectStats(project)`** – ermittelt pro Projekt den Übersetzungs‑ und Audio‑Fortschritt. Diese Funktion wird auch in den Tests ausführlich geprüft.
+* **`ipcContracts.ts`** – definiert Typen für die IPC-Kommunikation zwischen Preload und Hauptprozess.

--- a/electron/ipcContracts.ts
+++ b/electron/ipcContracts.ts
@@ -1,0 +1,55 @@
+export interface SaveDeFileArgs {
+  relPath: string;
+  data: Uint8Array;
+}
+
+export interface SaveFileArgs {
+  data: Uint8Array;
+  defaultPath: string;
+}
+
+export interface MoveFileArgs {
+  src: string;
+  dest: string;
+}
+
+export interface RestoreDeHistoryArgs {
+  relPath: string;
+  name: string;
+}
+
+export interface SaveDeHistoryBufferArgs {
+  relPath: string;
+  data: Uint8Array;
+}
+
+export type IpcChannels =
+  | 'scan-folders'
+  | 'open-folder-dialog'
+  | 'save-file'
+  | 'list-backups'
+  | 'save-backup'
+  | 'read-backup'
+  | 'delete-backup'
+  | 'open-backup-folder'
+  | 'get-download-path'
+  | 'get-debug-info'
+  | 'backup-de-file'
+  | 'delete-de-backup-file'
+  | 'restore-de-file'
+  | 'save-de-file'
+  | 'move-file'
+  | 'list-de-history'
+  | 'restore-de-history'
+  | 'save-de-history-buffer'
+  | 'get-de-duplicates'
+  | 'delete-de-file'
+  | 'translate-text'
+  | 'toggle-devtools'
+  | 'dub-start'
+  | 'manual-file'
+  | 'dub-done'
+  | 'dub-error'
+  | 'dub-status'
+  | 'dub-log'
+  | 'save-error';

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,3 +1,12 @@
+// @ts-check
+/**
+ * Typdefinitionen für die IPC-Kommunikation importieren
+ * @typedef {import('./ipcContracts').SaveDeFileArgs} SaveDeFileArgs
+ * @typedef {import('./ipcContracts').SaveFileArgs} SaveFileArgs
+ * @typedef {import('./ipcContracts').MoveFileArgs} MoveFileArgs
+ * @typedef {import('./ipcContracts').RestoreDeHistoryArgs} RestoreDeHistoryArgs
+ * @typedef {import('./ipcContracts').SaveDeHistoryBufferArgs} SaveDeHistoryBufferArgs
+ */
 const { app, BrowserWindow, ipcMain, globalShortcut, dialog, shell } = require('electron');
 // 'node:path' nutzen, damit das integrierte Modul auch nach dem Packen gefunden wird
 const path = require('node:path'); // Pfadmodul einbinden
@@ -137,7 +146,7 @@ app.whenReady().then(() => {
   });
 
   // Speichert eine Datei über einen Dialog auf der Festplatte
-  ipcMain.handle('save-file', async (event, { data, defaultPath }) => {
+  ipcMain.handle('save-file', async (event, /** @type {SaveFileArgs} */{ data, defaultPath }) => {
     const { canceled, filePath } = await dialog.showSaveDialog({
       defaultPath,
     });
@@ -326,7 +335,7 @@ app.whenReady().then(() => {
 
   // =========================== SAVE-DE-FILE START ===========================
   // Speichert eine hochgeladene DE-Datei im richtigen Unterordner
-  ipcMain.handle('save-de-file', async (event, { relPath, data }) => {
+  ipcMain.handle('save-de-file', async (event, /** @type {SaveDeFileArgs} */{ relPath, data }) => {
     try {
       // Absoluten Zielpfad aufbauen
       const target = path.resolve(dePath, relPath);
@@ -345,7 +354,7 @@ app.whenReady().then(() => {
   });
 
   // Verschiebt eine Datei innerhalb des Projekts
-  ipcMain.handle('move-file', async (event, { src, dest }) => {
+  ipcMain.handle('move-file', async (event, /** @type {MoveFileArgs} */{ src, dest }) => {
     // Zielpfad absolut bestimmen
     const target = path.resolve(projectRoot, dest);
     fs.mkdirSync(path.dirname(target), { recursive: true });
@@ -387,12 +396,12 @@ app.whenReady().then(() => {
   });
 
   // Stellt eine gewählte History-Version wieder her und tauscht sie mit der aktuellen
-  ipcMain.handle('restore-de-history', async (event, { relPath, name }) => {
+  ipcMain.handle('restore-de-history', async (event, /** @type {RestoreDeHistoryArgs} */{ relPath, name }) => {
     return historyUtils.switchVersion(deHistoryPath, relPath, name, dePath);
   });
 
   // Speichert einen übergebenen Buffer als neue History-Version
-  ipcMain.handle('save-de-history-buffer', async (event, { relPath, data }) => {
+  ipcMain.handle('save-de-history-buffer', async (event, /** @type {SaveDeHistoryBufferArgs} */{ relPath, data }) => {
     return historyUtils.saveBufferVersion(deHistoryPath, relPath, Buffer.from(data));
   });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,3 +1,12 @@
+// @ts-check
+/**
+ * Typdefinitionen für die IPC-Kommunikation importieren
+ * @typedef {import('./ipcContracts').SaveDeFileArgs} SaveDeFileArgs
+ * @typedef {import('./ipcContracts').SaveFileArgs} SaveFileArgs
+ * @typedef {import('./ipcContracts').MoveFileArgs} MoveFileArgs
+ * @typedef {import('./ipcContracts').RestoreDeHistoryArgs} RestoreDeHistoryArgs
+ * @typedef {import('./ipcContracts').SaveDeHistoryBufferArgs} SaveDeHistoryBufferArgs
+ */
 console.log('[PRELOAD] start', __filename);
 process.on('uncaughtException',  e => console.error('[PRELOAD] uncaught', e));
 process.on('unhandledRejection', e => console.error('[PRELOAD] rejected', e));
@@ -24,22 +33,22 @@ if (typeof require !== 'function') {
     // Befehl an Hauptprozess senden, um DevTools umzuschalten
     toggleDevTools: () => ipcRenderer.send('toggle-devtools'),
     // Datei speichern (z.B. Backup)
-    saveFile: (data, defaultPath) => ipcRenderer.invoke('save-file', { data, defaultPath }),
+    saveFile: (data, defaultPath) => ipcRenderer.invoke('save-file', /** @type {SaveFileArgs} */({ data, defaultPath })),
     // DE-Datei im Projektordner speichern
-    saveDeFile: (relPath, data) => ipcRenderer.invoke('save-de-file', { relPath, data }),
+    saveDeFile: (relPath, data) => ipcRenderer.invoke('save-de-file', /** @type {SaveDeFileArgs} */({ relPath, data })),
     backupDeFile: (relPath) => ipcRenderer.invoke('backup-de-file', relPath),
     restoreDeFile: (relPath) => ipcRenderer.invoke('restore-de-file', relPath),
     deleteDeBackupFile: (relPath) => ipcRenderer.invoke('delete-de-backup-file', relPath),
     listDeHistory: (relPath) => ipcRenderer.invoke('list-de-history', relPath),
-    restoreDeHistory: (relPath, name) => ipcRenderer.invoke('restore-de-history', { relPath, name }),
-    saveDeHistoryBuffer: (relPath, data) => ipcRenderer.invoke('save-de-history-buffer', { relPath, data }),
+    restoreDeHistory: (relPath, name) => ipcRenderer.invoke('restore-de-history', /** @type {RestoreDeHistoryArgs} */({ relPath, name })),
+    saveDeHistoryBuffer: (relPath, data) => ipcRenderer.invoke('save-de-history-buffer', /** @type {SaveDeHistoryBufferArgs} */({ relPath, data })),
     // Backup-Funktionen
     listBackups: () => ipcRenderer.invoke('list-backups'),
     saveBackup: (data) => ipcRenderer.invoke('save-backup', data),
     readBackup: (name) => ipcRenderer.invoke('read-backup', name),
     deleteBackup: (name) => ipcRenderer.invoke('delete-backup', name),
     openBackupFolder: () => ipcRenderer.invoke('open-backup-folder'),
-    moveFile: (src, dest) => ipcRenderer.invoke('move-file', { src, dest }),
+    moveFile: (src, dest) => ipcRenderer.invoke('move-file', /** @type {MoveFileArgs} */({ src, dest })),
     onManualFile: (cb) => ipcRenderer.on('manual-file', (e, file) => cb(file)),
     onDubDone: cb => ipcRenderer.on('dub-done', (e, info) => cb(info)),
     onDubError: cb => ipcRenderer.on('dub-error', (e, info) => cb(info)),


### PR DESCRIPTION
## Summary
- add `ipcContracts.ts` with IPC argument interfaces and channel union
- use these types in `main.js` and `preload.cjs`
- document `ipcContracts.ts` in the README
- note change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fdc01bb94832792871a944f600555