### PR TITLE
Use cleaned path for caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Seit Patch 1.40.24 entfernt der halbautomatische Import auch vorgestellte "EN"- 
 Seit Patch 1.40.25 bereinigt das Tool beim Start fehlerhafte Einträge im DE-Cache und erkennt Zielpfade von Dubbings nun unabhängig von der Großschreibung.
 Seit Patch 1.40.26 wiederholt der manuelle Import das Verschieben mehrmals und wartet kurze Zeit, falls die Datei noch gesperrt ist. Dadurch verschwinden Fehler wie "resource busy or locked".
 Seit Patch 1.40.27 werden Änderungen am DE-Audio nach dem Bearbeiten sofort im Projekt gespeichert.
+Seit Patch 1.40.28 speichert applyDeEdit DE-Audios im Cache über den bereinigten Pfad und aktualisiert so konsistent die History.
 
 
 Beispiel einer gültigen CSV:

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -7841,8 +7841,9 @@ async function redownloadDubbing(fileId, mode = 'beta') {
     if (window.electronAPI && window.electronAPI.saveDeFile) {
         const buffer = await dubbedBlob.arrayBuffer();
         await window.electronAPI.saveDeFile(relPath, new Uint8Array(buffer));
-        deAudioCache[relPath] = `sounds/DE/${relPath}`;
-        await updateHistoryCache(relPath);
+        // Bereinigter Pfad vermeidet doppelte Schlüssel im Cache
+        deAudioCache[cleanPath] = `sounds/DE/${relPath}`;
+        await updateHistoryCache(cleanPath);
         addDubbingLog('Datei in Desktop-Version gespeichert');
     } else {
         await speichereUebersetzungsDatei(dubbedBlob, relPath);
@@ -7872,8 +7873,9 @@ async function downloadDe(fileId) {
     if (window.electronAPI && window.electronAPI.saveDeFile) {
         const buffer = await blob.arrayBuffer();
         await window.electronAPI.saveDeFile(relPath, new Uint8Array(buffer));
-        deAudioCache[relPath] = `sounds/DE/${relPath}`;
-        await updateHistoryCache(relPath);
+        // Bereinigter Pfad vermeidet doppelte Schlüssel im Cache
+        deAudioCache[cleanPath] = `sounds/DE/${relPath}`;
+        await updateHistoryCache(cleanPath);
     } else {
         await speichereUebersetzungsDatei(blob, relPath);
     }
@@ -8681,6 +8683,8 @@ async function applyDeEdit() {
         return;
     }
     const relPath = getFullPath(currentEditFile); // Aktuellen Pfad ermitteln
+    // Pfad bereinigen, falls "sounds/DE/" bereits enthalten ist
+    const cleanPath = relPath.replace(/^([\\/]*sounds[\\/])?de[\\/]/i, '');
     try {
         // Aktuellen Status des Lautstärkeabgleichs nutzen
         if (window.electronAPI && window.electronAPI.backupDeFile) {
@@ -8710,8 +8714,7 @@ async function applyDeEdit() {
                 delete deAudioCache[d.relPath];
             }
         }
-        // Pfad bereinigen, falls "sounds/DE/" bereits vorangestellt ist
-        let cleanPath = relPath.replace(/^([\\/]*sounds[\\/])?de[\\/]/i, '');
+        // Pfadbereinigung, da manche Pfade bereits "sounds/DE/" enthalten
         try {
             await window.electronAPI.saveDeFile(cleanPath, new Uint8Array(buf));
         } catch (err) {
@@ -8721,8 +8724,9 @@ async function applyDeEdit() {
             }
             throw err;
         }
-        deAudioCache[relPath] = `sounds/DE/${relPath}`;
-        await updateHistoryCache(relPath);
+        // Bereinigter Pfad vermeidet doppelte Schlüssel im Cache
+        deAudioCache[cleanPath] = `sounds/DE/${relPath}`;
+        await updateHistoryCache(cleanPath);
         URL.revokeObjectURL(url);
     } else {
         // Backup in Browser-Version
@@ -8757,8 +8761,9 @@ async function applyDeEdit() {
         drawWaveform(document.getElementById('waveEdited'), newBuffer, { start: 0, end: newBuffer.length / newBuffer.sampleRate * 1000 });
         const blob = bufferToWav(newBuffer);
         await speichereUebersetzungsDatei(blob, relPath);
-        deAudioCache[relPath] = blob;
-        await updateHistoryCache(relPath);
+        // Bereinigter Pfad vermeidet doppelte Schlüssel im Cache
+        deAudioCache[cleanPath] = blob;
+        await updateHistoryCache(cleanPath);
     }
         currentEditFile.trimStartMs = editStartTrim;
         currentEditFile.trimEndMs = editEndTrim;


### PR DESCRIPTION
## Summary
- use `cleanPath` in `applyDeEdit`
- mention the change in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fe323df908327be7d2b1f0de970da