### PR TITLE
Handle save error toast

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 **💾 Fehler beim Speichern des DE-Audios**
 * ▶ **Hinweis:** Ordnerzugriff erneut erlauben oder Pfad prüfen. Das Tool zeigt die genaue Ursache im Toast an.
 * ▶ **Pfad prüfen:** Beim Speichern wird `sounds/DE/` nun automatisch entfernt, falls der Pfad doppelt vorkommt.
+* ▶ **Neu:** Jede Fehlermeldung beim Speichern wird nun als Toast eingeblendet.
 
 #### Häufige Crash-Stellen
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -368,6 +368,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                 addDubbingLog(msg);
             });
         }
+        // Speicherfehler per Toast melden, falls API vorhanden
+        if (window.electronAPI.onSaveError) {
+            window.electronAPI.onSaveError(msg =>
+                showToast('Fehler beim Speichern: ' + msg, 'error'));
+        }
     }
 
     // 🟩 NEU: Level-Farben laden


### PR DESCRIPTION
## Summary
- show toast if saving files fails
- document save error toast in Troubleshooting section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fe41061ec832787358fd1cb5b3376