### PR TITLE
Fix lamejs import fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Seit Patch 1.40.25 bereinigt das Tool beim Start fehlerhafte Einträge im DE-Cac
 Seit Patch 1.40.26 wiederholt der manuelle Import das Verschieben mehrmals und wartet kurze Zeit, falls die Datei noch gesperrt ist. Dadurch verschwinden Fehler wie "resource busy or locked".
 Seit Patch 1.40.27 werden Änderungen am DE-Audio nach dem Bearbeiten sofort im Projekt gespeichert.
 Seit Patch 1.40.28 speichert applyDeEdit DE-Audios im Cache über den bereinigten Pfad und aktualisiert so konsistent die History.
+Seit Patch 1.40.29 lädt das Tool das MP3-Modul lamejs automatisch von einem CDN, falls es nicht lokal verfügbar ist.
 
 
 Beispiel einer gültigen CSV:

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -140,7 +140,14 @@ if (typeof module !== 'undefined' && module.exports) {
         renderLanguage = mod.renderLanguage;
         pollRender = mod.pollRender;
     });
-    import('lamejs').then(mod => { lamejs = mod; });
+    // Versucht lamejs als ESM zu laden. Scheitert dies, wird ein Skript vom CDN nachgeladen
+    import('lamejs').then(mod => { lamejs = mod; }).catch(() => {
+        console.warn('lamejs konnte nicht per import geladen werden, lade von CDN');
+        const script = document.createElement('script');
+        script.src = 'https://cdn.jsdelivr.net/npm/lamejs@1.2.1/lame.min.js';
+        script.onload = () => { lamejs = window.lamejs; };
+        document.head.appendChild(script);
+    });
 }
 
 // =========================== GLOBAL STATE END ===========================


### PR DESCRIPTION
## Summary
- lade lamejs über CDN, wenn der Import fehlschlägt
- Dokumentation angepasst

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fed250e2c8327b574da695f2cc54d