### PR TITLE
Fix CSP violation for lamejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Seit Patch 1.40.26 wiederholt der manuelle Import das Verschieben mehrmals und w
 Seit Patch 1.40.27 werden Änderungen am DE-Audio nach dem Bearbeiten sofort im Projekt gespeichert.
 Seit Patch 1.40.28 speichert applyDeEdit DE-Audios im Cache über den bereinigten Pfad und aktualisiert so konsistent die History.
 Seit Patch 1.40.29 lädt das Tool das MP3-Modul lamejs automatisch von einem CDN, falls es nicht lokal verfügbar ist.
+Seit Patch 1.40.30 nutzt das Tool cdnjs anstelle von jsDelivr, da dies durch die Content Security Policy erlaubt ist.
 
 
 Beispiel einer gültigen CSV:

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -144,7 +144,8 @@ if (typeof module !== 'undefined' && module.exports) {
     import('lamejs').then(mod => { lamejs = mod; }).catch(() => {
         console.warn('lamejs konnte nicht per import geladen werden, lade von CDN');
         const script = document.createElement('script');
-        script.src = 'https://cdn.jsdelivr.net/npm/lamejs@1.2.1/lame.min.js';
+        // Lade lamejs von cdnjs, da dieser Host durch die CSP erlaubt ist
+        script.src = 'https://cdnjs.cloudflare.com/ajax/libs/lamejs/1.2.1/lame.min.js';
         script.onload = () => { lamejs = window.lamejs; };
         document.head.appendChild(script);
     });


### PR DESCRIPTION
## Summary
- load lamejs from cdnjs instead of jsDelivr (allowed by CSP)
- document this change in README

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684feec9d284832793fc7998239ae538