### PR TITLE
Add project sync function

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,3 +520,4 @@ Die wichtigsten Tests befinden sich im Ordner `tests/` und prüfen die Funktione
 * **`copyDubbedFile(originalPath, tempDubPath)`** – verschiebt eine heruntergeladene Dub-Datei in den deutschen Ordnerbaum.
 * **`calculateProjectStats(project)`** – ermittelt pro Projekt den Übersetzungs‑ und Audio‑Fortschritt. Diese Funktion wird auch in den Tests ausführlich geprüft.
 * **`ipcContracts.ts`** – definiert Typen für die IPC-Kommunikation zwischen Preload und Hauptprozess.
+* **`syncProjectData(projects, filePathDatabase, textDatabase)`** – gleicht Projekte mit der Datenbank ab, korrigiert Dateiendungen und überträgt Texte.

--- a/extensionUtils.js
+++ b/extensionUtils.js
@@ -46,4 +46,76 @@ function repairFileExtensions(projects, filePathDatabase, textDatabase) {
     return updated;
 }
 
-module.exports = { repairFileExtensions };
+/**
+ * Synchronisiert Projektdateien mit der Datenbank und uebertraegt Texte.
+ * Wird genutzt, wenn Dateiendungen gewechselt haben und Texte erhalten
+ * bleiben sollen.
+ * @param {Array} projects Liste aller Projekte
+ * @param {Object} filePathDatabase Mapping Dateiname -> Pfadinformationen
+ * @param {Object} textDatabase Mapping "Ordner/Dateiname" -> Texte
+ * @returns {number} Anzahl geaenderter Dateien
+ */
+function syncProjectData(projects, filePathDatabase, textDatabase) {
+    let updated = 0;
+    const extList = ['.wav', '.ogg', '.mp3'];
+
+    for (const project of projects) {
+        if (!project.files) continue;
+        for (const file of project.files) {
+            const base = file.filename.replace(/\.(mp3|wav|ogg)$/i, '');
+            let targetName = file.filename;
+            let bestPath = null;
+
+            if (filePathDatabase[file.filename]) {
+                const paths = filePathDatabase[file.filename];
+                bestPath = paths.find(p => p.folder === file.folder) || paths[0];
+            } else {
+                for (const ext of extList) {
+                    const cand = base + ext;
+                    if (!filePathDatabase[cand]) continue;
+                    const paths = filePathDatabase[cand];
+                    bestPath = paths.find(p => p.folder === file.folder) || paths[0];
+                    if (bestPath) {
+                        targetName = cand;
+                        break;
+                    }
+                }
+            }
+
+            if (!bestPath) continue;
+
+            const oldKey = `${file.folder}/${file.filename}`;
+            const newKey = `${bestPath.folder}/${targetName}`;
+
+            const merged = { en: '', de: '' };
+            if (textDatabase[oldKey]) {
+                if (textDatabase[oldKey].en) merged.en = textDatabase[oldKey].en;
+                if (textDatabase[oldKey].de) merged.de = textDatabase[oldKey].de;
+                delete textDatabase[oldKey];
+            }
+            if (textDatabase[newKey]) {
+                merged.en = merged.en || textDatabase[newKey].en;
+                merged.de = merged.de || textDatabase[newKey].de;
+            }
+            if (file.enText && !merged.en) merged.en = file.enText;
+            if (file.deText && !merged.de) merged.de = file.deText;
+            if (merged.en || merged.de) {
+                textDatabase[newKey] = {
+                    en: merged.en || '',
+                    de: merged.de || ''
+                };
+            }
+
+            if (file.filename !== targetName || file.folder !== bestPath.folder) {
+                file.filename = targetName;
+                file.folder = bestPath.folder;
+                file.fullPath = bestPath.fullPath;
+                updated++;
+            }
+        }
+    }
+
+    return updated;
+}
+
+module.exports = { repairFileExtensions, syncProjectData };

--- a/tests/syncProjectData.test.js
+++ b/tests/syncProjectData.test.js
@@ -1,0 +1,23 @@
+const { syncProjectData } = require('../extensionUtils');
+
+describe('syncProjectData', () => {
+    test('uebertraegt Texte und passt Endungen an', () => {
+        const projects = [{ files: [{ filename: 'test.mp3', folder: 'a', fullPath: 'a/test.mp3', enText: 'hi', deText: 'hallo' }] }];
+        const filePathDatabase = { 'test.wav': [{ folder: 'a', fullPath: 'a/test.wav' }] };
+        const textDatabase = { 'a/test.mp3': { en: 'hi' } };
+        const count = syncProjectData(projects, filePathDatabase, textDatabase);
+        expect(count).toBe(1);
+        expect(projects[0].files[0].filename).toBe('test.wav');
+        expect(textDatabase['a/test.wav']).toEqual({ en: 'hi', de: 'hallo' });
+        expect(textDatabase['a/test.mp3']).toBeUndefined();
+    });
+
+    test('fuellt fehlende Texte in bestehendem Eintrag', () => {
+        const projects = [{ files: [{ filename: 'ok.wav', folder: 'b', fullPath: 'b/ok.wav', deText: 'gut' }] }];
+        const filePathDatabase = { 'ok.wav': [{ folder: 'b', fullPath: 'b/ok.wav' }] };
+        const textDatabase = { 'b/ok.wav': { en: 'fine' } };
+        const count = syncProjectData(projects, filePathDatabase, textDatabase);
+        expect(count).toBe(0);
+        expect(textDatabase['b/ok.wav']).toEqual({ en: 'fine', de: 'gut' });
+    });
+});


### PR DESCRIPTION
## Summary
- implement `syncProjectData` to merge project texts with database and update changed extensions
- cover new helper with tests
- document `syncProjectData` in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ff962045483278a692d9e9c608666