### PR TITLE
Importiere calculateProjectStats

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,6 @@ Die wichtigsten Tests befinden sich im Ordner `tests/` und prüfen die Funktione
 * **`restore-de-file(relPath)`** – stellt eine deutsche Audiodatei aus dem Backup wieder her.
 * **`saveDeHistoryBuffer(relPath, data)`** – legt einen Buffer als neue History-Version ab.
 * **`copyDubbedFile(originalPath, tempDubPath)`** – verschiebt eine heruntergeladene Dub-Datei in den deutschen Ordnerbaum.
-* **`calculateProjectStats(project)`** – ermittelt pro Projekt den Übersetzungs‑ und Audio‑Fortschritt. Diese Funktion wird auch in den Tests ausführlich geprüft.
+* **`calculateProjectStats(project)`** – ermittelt pro Projekt den Übersetzungs‑ und Audio‑Fortschritt. Die Implementierung liegt in `calculateProjectStats.js` und wird in `web/src/main.js` nur importiert. Diese Funktion wird auch in den Tests ausführlich geprüft.
 * **`ipcContracts.ts`** – definiert Typen für die IPC-Kommunikation zwischen Preload und Hauptprozess.
 * **`syncProjectData(projects, filePathDatabase, textDatabase)`** – gleicht Projekte mit der Datenbank ab, korrigiert Dateiendungen und überträgt Texte.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -132,10 +132,12 @@ const DEBUG_MODE = localStorage.getItem('hla_debug_mode') === 'true';
 // Gemeinsame Funktionen aus elevenlabs.js laden
 let createDubbing, downloadDubbingAudio, renderLanguage, pollRender;
 let repairFileExtensions;
+let calculateProjectStats;
 if (typeof module !== 'undefined' && module.exports) {
     ({ createDubbing, downloadDubbingAudio, renderLanguage, pollRender } = require('../../elevenlabs'));
     ({ repairFileExtensions } = require('../../extensionUtils'));
     lamejs = require('lamejs');
+    calculateProjectStats = require('../../calculateProjectStats');
 } else {
     import('./elevenlabs.js').then(mod => {
         createDubbing = mod.createDubbing;
@@ -146,6 +148,7 @@ if (typeof module !== 'undefined' && module.exports) {
         pollRender = mod.pollRender;
     });
     import('../../extensionUtils.js').then(mod => { repairFileExtensions = mod.repairFileExtensions; });
+    import('../../calculateProjectStats.js').then(mod => { calculateProjectStats = mod.default || mod; });
     // Versucht lamejs als ESM zu laden. Scheitert dies, wird ein Skript vom CDN nachgeladen
     import('lamejs').then(mod => { lamejs = mod; }).catch(() => {
         console.warn('lamejs konnte nicht per import geladen werden, lade von CDN');
@@ -629,34 +632,6 @@ function saveLevelColorHistory() {
 
 
 
-// Berechne Projekt-Statistiken
-function calculateProjectStats(project) {
-    const files = project.files || [];
-    const totalFiles = files.length;
-    
-    if (totalFiles === 0) {
-        return {
-            enPercent: 0,
-            dePercent: 0,
-            deAudioPercent: 0,
-            completedPercent: 0,
-            totalFiles: 0
-        };
-    }
-    
-    const filesWithEN = files.filter(f => f.enText && f.enText.trim().length > 0).length;
-    const filesWithDE = files.filter(f => f.deText && f.deText.trim().length > 0).length;
-    const filesCompleted = files.filter(isFileCompleted).length;
-    const filesWithDeAudio = files.filter(f => getDeFilePath(f)).length;
-    
-    return {
-        enPercent: Math.round((filesWithEN / totalFiles) * 100),
-        dePercent: Math.round((filesWithDE / totalFiles) * 100),
-        deAudioPercent: Math.round((filesWithDeAudio / totalFiles) * 100),
-        completedPercent: Math.round((filesCompleted / totalFiles) * 100),
-        totalFiles: totalFiles
-    };
-}
 
 // Handle Access Status Click - für den Button unten rechts
 function handleAccessStatusClick() {


### PR DESCRIPTION
## Summary
- berechne Projektstatistiken nur noch aus `calculateProjectStats.js`
- README um Hinweis auf Import ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685025ef39588327890ae90bdc710985