### PR TITLE
Zeilennummer per Klick ändern

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Keyboard‑Navigation:** Pfeiltasten, Tab, Leertaste für Audio, Enter für Texteingabe
 * **Context‑Menu** (Rechtsklick): Audio, Kopieren, Einfügen, Ordner öffnen, Löschen
 * **Drag & Drop:** Projekte und Dateien sortieren
-* **Doppelklick:** Zeilennummer ändern, Projekt umbenennen
+* **Klick auf Zeilennummer:** Position anpassen
+* **Doppelklick:** Projekt umbenennen
 
 ---
 
@@ -280,7 +281,7 @@ In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über da
 | **Dateien hinzufügen**    | Direct‑Input, Suchresultat‑Klick, Browser         |
 | **Datei als fertig**      | ✓ Completion‑Checkbox                             |
 | **Datei ignorieren**      | 🚫 Ignorieren‑Button (im Ordner‑Browser)          |
-| **Position ändern**       | Doppelklick auf Zeilennummer (#)                  |
+| **Position ändern**       | Klick auf Zeilennummer (#)                  |
 | **Sortierung ändern**     | Klick auf Spalten‑Header                          |
 | **Datei löschen**         | × am Zeilenende oder Context‑Menu                 |
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2098,7 +2098,7 @@ async function renderFileTableWithOrder(sortedFiles) {
 return `
     <tr data-id="${file.id}" ${isFileCompleted(file) ? 'class="completed"' : ''}>
         <td class="drag-handle" draggable="true">↕</td>
-        <td class="row-number" data-file-id="${file.id}" ondblclick="changeRowNumber(${file.id}, ${originalIndex + 1})" title="Doppelklick um Position zu ändern">${originalIndex + 1}</td>
+        <td class="row-number" data-file-id="${file.id}" onclick="changeRowNumber(${file.id}, ${originalIndex + 1})" title="Klick um Position zu ändern">${originalIndex + 1}</td>
         <td class="filename-cell clickable" onclick="checkFilename(${file.id})">${file.filename}</td>
         <td>
             <span class="folder-badge clickable"
@@ -3497,7 +3497,8 @@ function deleteFile(fileId) {
     updateProgressStats();
 }
 
-        // Row number manipulation
+        // Aufgerufen durch Klick auf die Zeilennummer, 
+        // ermöglicht das direkte Ändern der Position
         function changeRowNumber(fileId, currentPosition) {
             const file = files.find(f => f.id === fileId);
             if (!file) return;


### PR DESCRIPTION
## Summary
- Zeilennummern lassen sich nun per einfachem Klick anpassen
- Hinweise in der README aktualisiert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685052b248988327ab737fb245a2861b