### PR TITLE
Add Steam URL launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Automatische Prüfung geänderter Endungen** passt Datenbank und Projekte an
 * **Live‑Statistiken:** EN‑%, DE‑%, Completion‑%, Globale Textzahlen (EN/DE/BEIDE/∑)
 * **Vollständig offline** – keine Server, keine externen Abhängigkeiten
-* **Direkter Spielstart:** Half-Life: Alyx lässt sich aus der Toolbar starten (Normal oder Workshop, Deutsch/Englisch)
+* **Direkter Spielstart:** Half-Life: Alyx lässt sich über das Steam-URL-Protokoll starten (Normal oder Workshop, Deutsch/Englisch)
 
 ### 📊 Fortschritts‑Tracking
 

--- a/launch_hla.py
+++ b/launch_hla.py
@@ -1,0 +1,44 @@
+import os
+from urllib.parse import quote
+
+
+def start_hla(mode: str = "normal", lang: str = "english") -> None:
+    """Starte Half-Life: Alyx über das Steam-URL-Protokoll.
+
+    Args:
+        mode: "normal" oder "tools". Bei "tools" wird -tools angehängt.
+        lang: Sprache wie "german" oder "english". Wird als -language Parameter verwendet.
+    """
+    # Basis-URL mit der App-ID von Half-Life: Alyx
+    base_url = "steam://rungameid/546560"
+    args = []
+
+    # Optionalen Modus anfügen
+    if mode == "tools":
+        args.append("-tools")
+
+    # Sprachparameter immer anfügen
+    if lang:
+        args.extend(["-language", lang])
+
+    # Argumente zu einem String verbinden und korrekt escapen
+    url = base_url
+    if args:
+        encoded = quote(" ".join(args))
+        url = f"{base_url}/{encoded}"
+
+    # Unter Windows die URL per os.startfile öffnen
+    if os.name == "nt":
+        os.startfile(url)
+    else:
+        # Auf anderen Systemen versuchen wir es mit xdg-open oder open
+        opener = "xdg-open" if os.name == "posix" else "open"
+        try:
+            os.spawnlp(os.P_NOWAIT, opener, opener, url)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    # Kleiner Selbsttest: Start im Normalmodus
+    start_hla()


### PR DESCRIPTION
## Summary
- add a Python helper to start Half-Life: Alyx via steam:// URL
- document the new method in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68511b33b8a08327b9e103bb6fa1f186