### PR TITLE
Starte Half-Life Alyx per Steam-URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Automatische Prüfung geänderter Endungen** passt Datenbank und Projekte an
 * **Live‑Statistiken:** EN‑%, DE‑%, Completion‑%, Globale Textzahlen (EN/DE/BEIDE/∑)
 * **Vollständig offline** – keine Server, keine externen Abhängigkeiten
-* **Direkter Spielstart:** Half-Life: Alyx lässt sich über das Steam-URL-Protokoll starten (Normal oder Workshop, Deutsch/Englisch)
+* **Direkter Spielstart:** Half-Life: Alyx lässt sich über das Steam-URL-Protokoll starten (Normal oder Workshop, Deutsch/Englisch). Die Buttons oben rechts sind dadurch unabhängig vom Installationspfad.
 
 ### 📊 Fortschritts‑Tracking
 
@@ -273,7 +273,7 @@ In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über da
 | **Projekt sortieren**     | Drag & Drop der Projekt‑Kacheln                   |
 | **Kapitel anpassen**      | ⚙️ neben Kapitel‑Titel → Name, Farbe, Löschen |
 | **Level‑Name kopieren**   | ⧉‑Button in Meta‑Leiste                           |
-| **Half-Life: Alyx starten** | Buttons "HLA DE/EN" und "Tools DE/EN" in der Toolbar |
+| **Half-Life: Alyx starten** | Buttons "HLA DE/EN" und "Tools DE/EN" in der Toolbar (starten per Steam-URL) |
 
 ### Datei‑Management
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -24,8 +24,7 @@ const { isDubReady } = require('../elevenlabs.js');
 // Fortschrittsbalken und FFmpeg für MP3->WAV-Konvertierung
 const ProgressBar = require('progress');
 const ffmpeg = require('ffmpeg-static');
-// Standardpfad zur Steam-Installation (nur Windows)
-const steamPath = 'C:\\Program Files (x86)\\Steam\\steam.exe';
+// Spielstart erfolgt nun über eine Steam-URL, daher kein fester Steam-Pfad mehr
 const pendingDubs = [];
 let mainWindow;
 if (!fs.existsSync(DL_WATCH_PATH)) fs.mkdirSync(DL_WATCH_PATH);
@@ -532,11 +531,16 @@ app.whenReady().then(() => {
   // =========================== START-HLA START ==============================
   // Startet Half-Life: Alyx mit optionalen Parametern
   ipcMain.handle('start-hla', async (event, { mode, lang }) => {
-    const args = ['-applaunch', '546560'];
-    if (mode === 'tools') args.push('-tools');
-    if (lang) args.push('-language', lang);
+    // Steam-URL mit allen Parametern aufbauen
+    const params = [];
+    if (mode === 'tools') params.push('-tools');
+    if (lang) params.push('-language', lang);
+    const encoded = encodeURIComponent(params.join(' '));
+    const url = params.length
+      ? `steam://rungameid/546560/${encoded}`
+      : 'steam://rungameid/546560';
     try {
-      spawn(steamPath, args, { detached: true, stdio: 'ignore' }).unref();
+      await shell.openExternal(url);
       return true;
     } catch (e) {
       console.error('HL-Alyx Start fehlgeschlagen', e);


### PR DESCRIPTION
## Summary
- nutze `shell.openExternal` zum Starten von Half-Life Alyx
- entferne festen Steam-Pfad und passe Import an
- README um Hinweis auf Steam-URL erweitert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68511c9840848327bdfaae9924532d6f