### PR TITLE
Workshop-Startoption für Half-Life: Alyx

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über da
 | **Projekt sortieren**     | Drag & Drop der Projekt‑Kacheln                   |
 | **Kapitel anpassen**      | ⚙️ neben Kapitel‑Titel → Name, Farbe, Löschen |
 | **Level‑Name kopieren**   | ⧉‑Button in Meta‑Leiste                           |
-| **Half-Life: Alyx starten** | Buttons "HLA DE/EN" und "Tools DE/EN" in der Toolbar (starten per Steam-URL) |
+| **Half-Life: Alyx starten** | Buttons "HLA DE/EN" und "Workshop DE/EN" in der Toolbar (starten per Steam-URL) |
 
 ### Datei‑Management
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -533,7 +533,7 @@ app.whenReady().then(() => {
   ipcMain.handle('start-hla', async (event, { mode, lang }) => {
     // Steam-URL mit allen Parametern aufbauen
     const params = [];
-    if (mode === 'tools') params.push('-tools');
+    if (mode === 'workshop') params.push('-hlvr_workshop');
     if (lang) params.push('-language', lang);
     const encoded = encodeURIComponent(params.join(' '));
     const url = params.length

--- a/launch_hla.py
+++ b/launch_hla.py
@@ -3,19 +3,19 @@ from urllib.parse import quote
 
 
 def start_hla(mode: str = "normal", lang: str = "english") -> None:
-    """Starte Half-Life: Alyx über das Steam-URL-Protokoll.
+    """Startet Half-Life: Alyx über das Steam-Protokoll.
 
     Args:
-        mode: "normal" oder "tools". Bei "tools" wird -tools angehängt.
-        lang: Sprache wie "german" oder "english". Wird als -language Parameter verwendet.
+        mode: "normal" oder "workshop". Bei "workshop" wird -hlvr_workshop angehängt.
+        lang: "german" oder "english". Wird als -language Parameter verwendet.
     """
-    # Basis-URL mit der App-ID von Half-Life: Alyx
+    # Basis-URL mit der App-ID des Spiels
     base_url = "steam://rungameid/546560"
     args = []
 
-    # Optionalen Modus anfügen
-    if mode == "tools":
-        args.append("-tools")
+    # Workshop-Modus aktivieren
+    if mode == "workshop":
+        args.append("-hlvr_workshop")
 
     # Sprachparameter immer anfügen
     if lang:

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -53,8 +53,8 @@
                 <div class="hla-launch">
                     <button class="btn btn-secondary" onclick="startHla('normal','german')">HLA DE</button>
                     <button class="btn btn-secondary" onclick="startHla('normal','english')">HLA EN</button>
-                    <button class="btn btn-secondary" onclick="startHla('tools','german')">Tools DE</button>
-                    <button class="btn btn-secondary" onclick="startHla('tools','english')">Tools EN</button>
+                    <button class="btn btn-secondary" onclick="startHla('workshop','german')">Workshop DE</button>
+                    <button class="btn btn-secondary" onclick="startHla('workshop','english')">Workshop EN</button>
                 </div>
             </div>
 			


### PR DESCRIPTION
## Summary
- HLA direkt aus Python und Electron im Workshop-Modus starten
- Knöpfe im Interface entsprechend angepasst
- Dokumentation aktualisiert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685120bfcb588327b676bbd54a0af2d0