### PR TITLE
Entferne MP3-Encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 * Entfernt die ungenutzte Datei `web/src/watcher.js`.
 ## 🛠️ Patch in 1.40.23
 * Entfernt die Startskripte `start_tool.js` und `start_tool.bat`. `start_tool.py` bleibt als einzige Einstiegsmöglichkeit erhalten.
+## 🛠️ Patch in 1.40.24
+* MP3-Encoding entfernt: `bufferToMp3` und die Abhängigkeit `lamejs` wurden gestrichen.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ Seit Patch 1.40.25 bereinigt das Tool beim Start fehlerhafte Einträge im DE-Cac
 Seit Patch 1.40.26 wiederholt der manuelle Import das Verschieben mehrmals und wartet kurze Zeit, falls die Datei noch gesperrt ist. Dadurch verschwinden Fehler wie "resource busy or locked".
 Seit Patch 1.40.27 werden Änderungen am DE-Audio nach dem Bearbeiten sofort im Projekt gespeichert.
 Seit Patch 1.40.28 speichert applyDeEdit DE-Audios im Cache über den bereinigten Pfad und aktualisiert so konsistent die History.
-Seit Patch 1.40.29 lädt das Tool das MP3-Modul lamejs automatisch von einem CDN, falls es nicht lokal verfügbar ist.
 Seit Patch 1.40.30 nutzt das Tool cdnjs anstelle von jsDelivr, da dies durch die Content Security Policy erlaubt ist.
+Seit Patch 1.40.31 wurde das MP3-Encoding entfernt, lamejs ist nicht mehr erforderlich.
 
 
 Beispiel einer gültigen CSV:
@@ -431,7 +431,7 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 * ▶ **Hinweis:** Ordnerzugriff erneut erlauben oder Pfad prüfen. Das Tool zeigt die genaue Ursache im Toast an.
 * ▶ **Pfad prüfen:** Beim Speichern wird `sounds/DE/` nun automatisch entfernt, falls der Pfad doppelt vorkommt.
 * ▶ **Neu:** Jede Fehlermeldung beim Speichern wird nun als Toast eingeblendet.
-* ▶ **Update:** MP3-Dateien werden jetzt korrekt gespeichert.
+* ▶ **Entfernt:** MP3-Encoding ist nicht länger möglich, alle Dateien werden als WAV gespeichert.
 * ▶ **Neu:** Beim Programmstart werden vorhandene MP3-Dateien automatisch in WAV umgewandelt und im Ordner `Backups/mp3` gesichert.
 * ▶ **Fix:** Das Backup funktioniert jetzt auch über Laufwerksgrenzen hinweg, da beim Verschieben auf Kopieren mit anschließendem Löschen umgestellt wird.
 * ▶ **Neu:** Geänderte Dateiendungen werden erkannt und automatisch korrigiert.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "chokidar": "^4.0.3",
         "ffmpeg-static": "^5.2.0",
-        "lamejs": "^1.2.1",
         "progress": "^2.0.3"
       },
       "devDependencies": {
@@ -3705,15 +3704,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/lamejs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/lamejs/-/lamejs-1.2.1.tgz",
-      "integrity": "sha512-s7bxvjvYthw6oPLCm5pFxvA84wUROODB8jEO2+CE1adhKgrIvVOlmMgY8zyugxGrvRaDHNJanOiS21/emty6dQ==",
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "use-strict": "1.0.1"
-      }
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4740,12 +4730,6 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
-    },
-    "node_modules/use-strict": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/use-strict/-/use-strict-1.0.1.tgz",
-      "integrity": "sha512-IeiWvvEXfW5ltKVMkxq6FvNf2LojMKvB2OCeja6+ct24S1XOmQw2dGr2JyndwACWAGJva9B7yPHwAmeA9QCqAQ==",
-      "license": "ISC"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "chokidar": "^4.0.3",
     "ffmpeg-static": "^5.2.0",
-    "lamejs": "^1.2.1",
     "progress": "^2.0.3"
   }
 }

--- a/tests/saveFormats.test.js
+++ b/tests/saveFormats.test.js
@@ -1,14 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-jest.mock('lamejs', () => ({
-    Mp3Encoder: class { constructor(){ } encodeBuffer(){ return [1]; } flush(){ return [2]; } }
-}), { virtual: false });
-
-let bufferToMp3, bufferToWav;
+let bufferToWav;
 
 beforeAll(() => {
-    ({ bufferToMp3, bufferToWav } = require('../web/src/main.js'));
+    ({ bufferToWav } = require('../web/src/main.js'));
     jest.spyOn(console, 'log').mockImplementation(() => {});
     jest.spyOn(console, 'warn').mockImplementation(() => {});
 });
@@ -23,13 +19,6 @@ function createBuffer(samples, sampleRate = 44100) {
         getChannelData(ch) { return this._data[ch]; }
     };
 }
-
-test('bufferToMp3 erzeugt MP3-Blob', () => {
-    const buf = createBuffer([0,0,0,0]);
-    const blob = bufferToMp3(buf);
-    expect(blob.type).toBe('audio/mp3');
-    expect(blob.size).toBeGreaterThan(0);
-});
 
 test('bufferToWav erzeugt WAV-Blob', () => {
     const buf = createBuffer([0,0,0,0]);


### PR DESCRIPTION
## Summary
- entferne `bufferToMp3` und alle Verwendungen
- streiche `lamejs` aus den Abhängigkeiten
- passe Tests an
- dokumentiere die Änderung in README und CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851395e803483278701d1e65a17d21c