### PR TITLE
Fix textarea resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ### 🖋️ Texteingabe & Navigation
 
-* **Auto‑Resize‑Textfelder** (EN & DE bleiben höhengleich)
+* **Verbessertes Auto‑Resize** – Textfelder schneiden keine Zeilen mehr ab und bleiben zwischen EN & DE höhengleich
 * **Automatische Anpassung beim Laden** der Textfelder beim Projektstart
 * **Sofort‑Speicherung** nach 1 s Inaktivität
 * **Tab/Shift+Tab Navigation** zwischen Textfeldern und Zeilen
@@ -299,7 +299,7 @@ In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über da
 | **Audio im Textfeld**     | `Ctrl + Leertaste` |
 | **Text kopieren**         | 📋 Button neben Textfeld |
 | **Zwischen Feldern**      | `Tab` / `Shift + Tab` |
-| **Auto-Resize aktiviert** | Textfelder passen sich automatisch an |
+| **Auto-Resize verbessert** | Textfelder passen sich sauber an und schneiden keine Zeilen mehr ab |
 * Beim Speichern eines DE-Audios verhindert das Tool nun ungültige Schnittbereiche und zeigt einen Fehler an.
 ---
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1613,7 +1613,8 @@ function addFiles() {
             const fileInput = document.getElementById('fileInput');
             fileInput.addEventListener('input', function() {
                 this.style.height = 'auto';
-                this.style.height = this.scrollHeight + 'px';
+                const fudge = 2; // kleiner Puffer gegen abschneiden
+                this.style.height = (this.scrollHeight + fudge) + 'px';
             });
             
             // Keyboard navigation
@@ -3363,21 +3364,22 @@ function toggleFileCompletion(fileId) {
             updateGlobalProjectProgress();
         }
 
-        // Auto-resize text inputs based on content (HEIGHT not width)
+        // Automatisches Anpassen der Höhe von Texteingaben (nur vertikal)
         function autoResizeInput(input) {
             if (!input) return;
-            
-            // Reset height to auto to get the correct scroll height
+
+            // Höhe zur Ermittlung korrekt zurücksetzen
             input.style.height = 'auto';
-            
-            // Calculate needed height
-            const minHeight = 36; // Minimum height in pixels
-            const newHeight = Math.max(minHeight, input.scrollHeight);
-            
-            // Set the new height
+
+            // Benötigte Höhe berechnen
+            const minHeight = 36; // Mindesthöhe in Pixel
+            const fudge = 2;      // kleiner Puffer gegen abgeschnittene Zeilen
+            const newHeight = Math.max(minHeight, input.scrollHeight + fudge);
+
+            // Neue Höhe setzen
             input.style.height = newHeight + 'px';
-            
-            // Sync height with partner input in the same row
+
+            // Partnerfeld in der gleichen Zeile angleichen
             syncRowHeights(input);
         }
 
@@ -3395,8 +3397,9 @@ function toggleFileCompletion(fileId) {
             enInput.style.height = 'auto';
             deInput.style.height = 'auto';
             
-            const enHeight = Math.max(36, enInput.scrollHeight);
-            const deHeight = Math.max(36, deInput.scrollHeight);
+            const fudge = 2; // Puffer gegen abgeschnittene Zeilen
+            const enHeight = Math.max(36, enInput.scrollHeight + fudge);
+            const deHeight = Math.max(36, deInput.scrollHeight + fudge);
             const maxHeight = Math.max(enHeight, deHeight);
             
             // Set both inputs to the same height
@@ -3417,8 +3420,9 @@ function toggleFileCompletion(fileId) {
                     deInput.style.height = 'auto';
                     
                     // Calculate max height needed
-                    const enHeight = Math.max(36, enInput.scrollHeight);
-                    const deHeight = Math.max(36, deInput.scrollHeight);
+                    const fudge = 2; // Puffer gegen abgeschnittene Zeilen
+                    const enHeight = Math.max(36, enInput.scrollHeight + fudge);
+                    const deHeight = Math.max(36, deInput.scrollHeight + fudge);
                     const maxHeight = Math.max(enHeight, deHeight);
                     
                     // Set both to same height


### PR DESCRIPTION
## Summary
- ensure textarea resize does not cut off the last line
- document improved auto-resize behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685145f7a4f483278d598408b6fc091f