### PR TITLE
Sortiere Level-Stats im Browser nach Nummer

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Seit Patch 1.40.27 werden Änderungen am DE-Audio nach dem Bearbeiten sofort im 
 Seit Patch 1.40.28 speichert applyDeEdit DE-Audios im Cache über den bereinigten Pfad und aktualisiert so konsistent die History.
 Seit Patch 1.40.30 nutzt das Tool cdnjs anstelle von jsDelivr, da dies durch die Content Security Policy erlaubt ist.
 Seit Patch 1.40.31 wurde das MP3-Encoding entfernt, lamejs ist nicht mehr erforderlich.
+Seit Patch 1.40.32 sortiert das Level-Statistik-Panel die Einträge nach der Levelnummer.
 
 
 Beispiel einer gültigen CSV:

--- a/tests/levelStatsSort.test.js
+++ b/tests/levelStatsSort.test.js
@@ -1,0 +1,24 @@
+const { expect, test } = require('@jest/globals');
+
+// Beispiel-Level mit zufälliger Reihenfolge
+const map = {
+    'Gamma': { total: 1, complete: 0, parts: new Set() },
+    'Alpha': { total: 1, complete: 0, parts: new Set() },
+    'Beta':  { total: 1, complete: 0, parts: new Set() }
+};
+
+const levelOrders = { 'Alpha': 1, 'Beta': 2, 'Gamma': 3 };
+
+function getLevelOrder(name) {
+    return levelOrders[name] || 9999;
+}
+
+function sortRows(map) {
+    return Object.entries(map)
+        .sort((a, b) => getLevelOrder(a[0]) - getLevelOrder(b[0]))
+        .map(([name]) => name);
+}
+
+test('Level-Statistiken werden nach Nummer sortiert', () => {
+    expect(sortRows(map)).toEqual(['Alpha', 'Beta', 'Gamma']);
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1256,7 +1256,9 @@ function renderLevelStats() {
         });
     });
 
-    const rows = Object.entries(map);
+    const rows = Object.entries(map)
+        // Nach Level-Nummer sortieren
+        .sort((a, b) => getLevelOrder(a[0]) - getLevelOrder(b[0]));
     if (!rows.length) {
         panel.innerHTML = '<em style="color:#666;">Noch keine Level eingetragen.</em>';
         return;


### PR DESCRIPTION
## Zusammenfassung
- Level-Statistik-Panel nach Levelnummer sortieren
- Hinweis im README zu dieser Änderung
- neuer Jest-Test für die Sortierung

## Testanweisungen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851472f8ccc8327a478dacdb2e403d0