### PR TITLE
Fix Textfeldgrößen bei Projektstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über da
 | **Audio im Textfeld**     | `Ctrl + Leertaste` |
 | **Text kopieren**         | 📋 Button neben Textfeld |
 | **Zwischen Feldern**      | `Tab` / `Shift + Tab` |
-| **Auto-Resize verbessert** | Textfelder passen sich sauber an und schneiden keine Zeilen mehr ab |
+| **Auto-Resize verbessert** | Textfelder passen sich sauber an und schneiden keine Zeilen mehr ab; beim Projektstart wird die korrekte Höhe jetzt sofort gesetzt |
 * Beim Speichern eines DE-Audios verhindert das Tool nun ungültige Schnittbereiche und zeigt einen Fehler an.
 ---
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1170,10 +1170,8 @@ function selectProject(id){
 
     renderFileTable();
 
-    // Nach dem Laden des Projekts alle Textfelder dynamisch anpassen
-    setTimeout(() => {
-        autoResizeAllInputs();
-    }, 100);
+    // Nach dem Laden des Projekts Textfelder korrekt anpassen
+    resizeTextFields();
     updateDubStatusForFiles();
     updateStatus();
     updateFileAccessStatus();
@@ -2160,9 +2158,9 @@ return `
     updateCounts();
     updateDubButtons();
 
-    // Auto-resize all text inputs after rendering
+    // Nach dem Rendern Textfelder und Übersetzungsanzeige anpassen
     setTimeout(() => {
-        autoResizeAllInputs();
+        resizeTextFields();
         sortedFiles.forEach(f => updateTranslationDisplay(f.id));
     }, 50);
 }
@@ -3410,7 +3408,7 @@ function toggleFileCompletion(fileId) {
         }
 
         // Auto-resize all text inputs in table
-        function autoResizeAllInputs() {
+function autoResizeAllInputs() {
             // Process all rows to sync heights
             document.querySelectorAll('#fileTableBody tr').forEach(row => {
                 const enInput = row.querySelector('td:nth-child(7) .text-input');
@@ -3471,6 +3469,16 @@ function toggleCompletionAll() {
     const count = Array.from(completionCheckboxes).filter(cb => cb.checked).length;
     updateStatus(`Status für ${count} Dateien aktualisiert`);
 }
+
+        // Textfelder nach dem Laden und nach fertigem Font anpassen
+        function resizeTextFields() {
+            setTimeout(() => {
+                autoResizeAllInputs();
+                if (document.fonts && document.fonts.ready) {
+                    document.fonts.ready.then(() => autoResizeAllInputs());
+                }
+            }, 100);
+        }
 
         // Selection
         function toggleFileSelection(fileId) {
@@ -10717,9 +10725,7 @@ function showChapterCustomization(chapterName, ev) {
 
         // Window resize handling for text inputs
         window.addEventListener('resize', () => {
-            setTimeout(() => {
-                autoResizeAllInputs();
-            }, 100);
+            resizeTextFields();
         });
 
         // Initialize app


### PR DESCRIPTION
## Zusammenfassung
- stelle Textfelder auf korrekte Höhe ein, sobald ein Projekt geladen wird
- führe Funktion `resizeTextFields` ein und rufe sie nach dem Rendern auf
- passe README-Eintrag zum Auto‑Resize an

## Testanweisungen
- `npm test` ausführen

------
https://chatgpt.com/codex/tasks/task_e_6851493adf1083278ab9938fb9655164