### PR TITLE
Update closecaption import

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,13 +344,13 @@ In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über da
   * **Intelligente Zuordnung:** Dateinamen‑Spalte wird automatisch erkannt
   * **Multi‑Ordner‑Support:** Auswahl bei mehrdeutigen Dateien
   * **Database‑Matching:** Vergleich mit vorhandenen Audiodateien
-  * **Untertitel-Import:** übernimmt Texte aus `closecaption_english.txt` und `closecaption_german.txt`
+  * **Untertitel-Import:** liest `closecaption_english.txt` und `closecaption_german.txt`, verknüpft Zeilen per ID und gleicht sie automatisch ab
 
 ---
 
 ### Untertitel-Import
 
-Mit diesem Import liest das Tool die Dateien `closecaption_english.txt` und `closecaption_german.txt` aus dem Ordner `closecaption/` ein. Die IDs und Texte werden zeilenweise eingelesen und mit den vorhandenen Einträgen der Datenbank abgeglichen. Bei eindeutiger Übereinstimmung wird der deutsche Text automatisch zugeordnet. Sind mehrere Dateien möglich, erscheint eine Auswahl, um den passenden Ordner festzulegen oder den Eintrag zu überspringen.
+Mit diesem Import liest das Tool die Dateien `closecaption_english.txt` und `closecaption_german.txt` aus dem Ordner `closecaption/` ein. Eine interne Funktion `parseClosecaptionFile(path)` verarbeitet jede Zeile im Format `"ID"    "Text"`. Die Zeilen beider Dateien werden danach über ihre ID zusammengeführt und mit der Datenbank abgeglichen. Bei eindeutiger Übereinstimmung wird der deutsche Text automatisch zugeordnet. Sind mehrere Dateien möglich, erscheint eine Auswahl, um den passenden Ordner festzulegen oder den Eintrag zu überspringen.
 
 ## 📁 Ordner‑Management
 


### PR DESCRIPTION
## Summary
- read closecaption files directly from path in `importClosecaptions`
- handle reading of both language files with new helper `parseClosecaptionFile`
- update README with the new import behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68543e60cd0c83278d9a880181119101