### PR TITLE
Add subtitle search using closecaptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,13 +345,14 @@ In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über da
   * **Multi‑Ordner‑Support:** Auswahl bei mehrdeutigen Dateien
   * **Database‑Matching:** Vergleich mit vorhandenen Audiodateien
   * **Untertitel-Import:** liest `closecaption_english.txt` und `closecaption_german.txt`, verknüpft Zeilen per ID und gleicht sie automatisch ab; zeigt bei Mehrdeutigkeit die vorhandenen Datenbank-Texte an
+  * **Untertitel-Suche:** neuer 🔍-Button neben jeder Datei sucht ähnliche EN-Texte in den Untertiteln und übernimmt den passenden DE-Text
 
 ---
 
 ### Untertitel-Import
 
-Mit diesem Import liest das Tool die Dateien `closecaption_english.txt` und `closecaption_german.txt` aus dem Ordner `closecaption/` ein. Eine interne Funktion `parseClosecaptionFile(path)` verarbeitet jede Zeile im Format `"ID"    "Text"`. Die Zeilen beider Dateien werden danach über ihre ID zusammengeführt und mit der Datenbank abgeglichen. Bei eindeutiger Übereinstimmung wird der deutsche Text automatisch zugeordnet. Sind mehrere Dateien möglich, erscheint eine Auswahl, um den passenden Ordner festzulegen oder den Eintrag zu überspringen.
-Ab sofort zeigt diese Auswahl zusätzlich die vorhandenen EN- und DE-Texte des jeweiligen Ordners an, um die Zuordnung zu erleichtern.
+Mit diesem Import liest das Tool die Dateien `closecaption_english.txt` und `closecaption_german.txt` aus dem Ordner `closecaption/` ein. Eine Utility-Funktion `loadClosecaptions()` verarbeitet beide Dateien und liefert ein Array aller Zeilen. Die Einträge werden über ihre ID zusammengeführt und mit der Datenbank abgeglichen. Bei eindeutiger Übereinstimmung wird der deutsche Text automatisch zugeordnet. Sind mehrere Dateien möglich, erscheint eine Auswahl, um den passenden Ordner festzulegen oder den Eintrag zu überspringen.
+Ab sofort zeigt diese Auswahl zusätzlich die vorhandenen EN- und DE-Texte des jeweiligen Ordners an. Die gleiche Funktion wird auch für die neue Untertitel-Suche verwendet.
 
 ## 📁 Ordner‑Management
 

--- a/closecaptionParser.js
+++ b/closecaptionParser.js
@@ -1,3 +1,4 @@
+// Parst den Inhalt einer closecaption-Datei in eine Map
 function parseClosecaptionFile(content) {
     const map = new Map();
     const lines = content.split(/\r?\n/);
@@ -7,4 +8,57 @@ function parseClosecaptionFile(content) {
     }
     return map;
 }
-module.exports = { parseClosecaptionFile };
+
+// Liest beide Untertitel-Dateien ein und gibt ein Array mit EN- und DE-Text zurück
+async function loadClosecaptions(basePath) {
+    let enContent = '';
+    let deContent = '';
+
+    // Standardpfad relativ zu diesem Skript im Node-Umfeld
+    if (!basePath && typeof __dirname !== 'undefined') {
+        const path = require('path');
+        basePath = path.join(__dirname, 'closecaption');
+    }
+
+    if (typeof window !== 'undefined') {
+        // Browser oder Electron
+        const isElectron = !!window.electronAPI;
+        const join = isElectron ? window.electronAPI.join : (p, f) => `${p}/${f}`;
+        const enPath = join(basePath, 'closecaption_english.txt');
+        const dePath = join(basePath, 'closecaption_german.txt');
+
+        try {
+            if (isElectron) {
+                enContent = new TextDecoder().decode(window.electronAPI.fsReadFile(enPath));
+                deContent = new TextDecoder().decode(window.electronAPI.fsReadFile(dePath));
+            } else {
+                enContent = await (await fetch(enPath)).text();
+                deContent = await (await fetch(dePath)).text();
+            }
+        } catch {
+            return null;
+        }
+    } else {
+        // Reines Node.js
+        const fs = require('fs');
+        const path = require('path');
+        try {
+            enContent = fs.readFileSync(path.join(basePath, 'closecaption_english.txt'), 'utf8');
+            deContent = fs.readFileSync(path.join(basePath, 'closecaption_german.txt'), 'utf8');
+        } catch {
+            return null;
+        }
+    }
+
+    const enMap = parseClosecaptionFile(enContent);
+    const deMap = parseClosecaptionFile(deContent);
+
+    return Array.from(enMap.entries()).map(([id, enText]) => ({ id, enText, deText: deMap.get(id) || '' }));
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { parseClosecaptionFile, loadClosecaptions };
+} else {
+    window.parseClosecaptionFile = parseClosecaptionFile;
+    window.loadClosecaptions = loadClosecaptions;
+}

--- a/tests/closecaptionParser.test.js
+++ b/tests/closecaptionParser.test.js
@@ -1,4 +1,7 @@
-const { parseClosecaptionFile } = require('../closecaptionParser');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { parseClosecaptionFile, loadClosecaptions } = require('../closecaptionParser');
 
 describe('closecaption parser', () => {
     test('liest IDs korrekt ein', () => {
@@ -6,5 +9,13 @@ describe('closecaption parser', () => {
         const result = parseClosecaptionFile(en);
         expect(result.get('1')).toBe('Hello');
         expect(result.get('2')).toBe('World');
+    });
+
+    test('loadClosecaptions liest Dateien korrekt', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-'));
+        fs.writeFileSync(path.join(dir, 'closecaption_english.txt'), '"file"\n{\n    "1"    "Hello"\n}');
+        fs.writeFileSync(path.join(dir, 'closecaption_german.txt'), '"file"\n{\n    "1"    "Hallo"\n}');
+        const result = await loadClosecaptions(dir);
+        expect(result).toEqual([{ id: '1', enText: 'Hello', deText: 'Hallo' }]);
     });
 });

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -148,6 +148,7 @@
         <th class="sortable">Ordner</th>
         <th>EN Text</th>
         <th>DE Text</th>
+        <th width="40">UT-Suche</th>
         <th width="120" title="Pfad der EN- und DE-Datei">Pfad</th>
         <th width="60">Upload</th>
         <th width="60">Dubbing</th>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -863,6 +863,32 @@ th:nth-child(6) {
             justify-content: center;
         }
 
+        .subtitle-search-btn {
+            background: #444;
+            border: none;
+            color: #e0e0e0;
+            padding: 4px 6px;
+            border-radius: 3px;
+            cursor: pointer;
+            font-size: 11px;
+            transition: all 0.2s;
+            min-width: 24px;
+            height: 24px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .subtitle-search-btn:hover {
+            background: #ff6b1a;
+            color: white;
+            transform: scale(1.1);
+        }
+
+        .subtitle-search-btn:active {
+            transform: scale(0.95);
+        }
+
         .copy-btn:hover {
             background: #ff6b1a;
             color: white;


### PR DESCRIPTION
## Summary
- add utility `loadClosecaptions` to read subtitle files
- expose subtitle search button in table
- implement `openSubtitleSearch` dialog with similarity check
- update styles and README
- test `loadClosecaptions`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685444139ed483279ca8c7518c2ee1db