### PR TITLE
Fix UT-Suche button crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Seit Patch 1.40.30 nutzt das Tool cdnjs anstelle von jsDelivr, da dies durch die
 Seit Patch 1.40.31 wurde das MP3-Encoding entfernt, lamejs ist nicht mehr erforderlich.
 Seit Patch 1.40.32 sortiert das Level-Statistik-Panel die Einträge nach der Levelnummer.
 Seit Patch 1.40.33 erscheint der 🔍-Button zur Untertitel-Suche wieder korrekt in der Dateitabelle.
+Seit Patch 1.40.34 lädt die Untertitel-Suche fehlende Untertitel automatisch nach und verhindert so Fehlermeldungen beim Klick.
 
 
 Beispiel einer gültigen CSV:

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2266,6 +2266,18 @@ async function openSubtitleSearch(fileId) {
     const file = files.find(f => f.id === fileId);
     if (!file || !file.enText) return;
 
+    // Lade das Modul bei Bedarf dynamisch nach, wenn die Funktion noch fehlt
+    if (typeof loadClosecaptions !== 'function') {
+        try {
+            const mod = await import('../../closecaptionParser.js');
+            loadClosecaptions = mod.loadClosecaptions;
+        } catch (e) {
+            console.error('closecaptionParser konnte nicht geladen werden', e);
+            alert('❌ Untertitel konnten nicht geladen werden.');
+            return;
+        }
+    }
+
     if (!subtitleData) {
         const base = isElectron ? window.electronAPI.join('..', 'closecaption') : '../closecaption';
         subtitleData = await loadClosecaptions(base);


### PR DESCRIPTION
## Summary
- load subtitle module on demand when using the UT-Suche-Button
- document the bug fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68544a8bebac8327a26ebb8be20f1fda