### PR TITLE
Fix subtitle search fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Seit Patch 1.40.31 wurde das MP3-Encoding entfernt, lamejs ist nicht mehr erford
 Seit Patch 1.40.32 sortiert das Level-Statistik-Panel die Einträge nach der Levelnummer.
 Seit Patch 1.40.33 erscheint der 🔍-Button zur Untertitel-Suche wieder korrekt in der Dateitabelle.
 Seit Patch 1.40.34 lädt die Untertitel-Suche fehlende Untertitel automatisch nach und verhindert so Fehlermeldungen beim Klick.
+Seit Patch 1.40.35 korrigiert ein Fallback das Nachladen des Untertitel-Parsers, sodass die Suche zuverlässig funktioniert.
 
 
 Beispiel einer gültigen CSV:

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -151,8 +151,10 @@ if (typeof module !== 'undefined' && module.exports) {
     });
     // Funktionen aus extensionUtils.js stehen jetzt direkt unter window bereit
     repairFileExtensions = window.repairFileExtensions;
+    // closecaptionParser als ES-Modul laden und Fallback auf window verwenden
     import('../../closecaptionParser.js').then(mod => {
-        loadClosecaptions = mod.loadClosecaptions;
+        // Bei fehlendem Export wird die Funktion trotzdem unter window angelegt
+        loadClosecaptions = mod.loadClosecaptions || window.loadClosecaptions;
     });
 }
 
@@ -2269,8 +2271,9 @@ async function openSubtitleSearch(fileId) {
     // Lade das Modul bei Bedarf dynamisch nach, wenn die Funktion noch fehlt
     if (typeof loadClosecaptions !== 'function') {
         try {
+            // Parser bei Bedarf dynamisch laden, auch wenn kein Export vorhanden ist
             const mod = await import('../../closecaptionParser.js');
-            loadClosecaptions = mod.loadClosecaptions;
+            loadClosecaptions = mod.loadClosecaptions || window.loadClosecaptions;
         } catch (e) {
             console.error('closecaptionParser konnte nicht geladen werden', e);
             alert('❌ Untertitel konnten nicht geladen werden.');


### PR DESCRIPTION
## Summary
- ensure fallback to `window.loadClosecaptions` when dynamic import has no exports
- document subtitle search fix in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68544bad3ed0832785c089ec07a65bb9