### PR TITLE
Verbesserte Untertitel-Suche

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Seit Patch 1.40.33 erscheint der 🔍-Button zur Untertitel-Suche wieder korrekt
 Seit Patch 1.40.34 lädt die Untertitel-Suche fehlende Untertitel automatisch nach und verhindert so Fehlermeldungen beim Klick.
 Seit Patch 1.40.35 korrigiert ein Fallback das Nachladen des Untertitel-Parsers, sodass die Suche zuverlässig funktioniert.
 Seit Patch 1.40.36 blendet die Untertitel-Suche Farbcodes wie `<clr:255,190,255>` aus, berücksichtigt sie nicht bei der Ähnlichkeitsberechnung und zeigt den gesuchten EN-Text im Dialog an.
+Seit Patch 1.40.37 entfernt die Untertitel-Suche zusätzlich Tags wie `<HEADSET>` oder `<cr>` automatisch aus den übernommenen Texten.
 
 
 Beispiel einer gültigen CSV:
@@ -349,7 +350,7 @@ In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über da
   * **Multi‑Ordner‑Support:** Auswahl bei mehrdeutigen Dateien
   * **Database‑Matching:** Vergleich mit vorhandenen Audiodateien
   * **Untertitel-Import:** liest `closecaption_english.txt` und `closecaption_german.txt`, verknüpft Zeilen per ID und gleicht sie automatisch ab; zeigt bei Mehrdeutigkeit die vorhandenen Datenbank-Texte an
-  * **Untertitel-Suche:** neuer 🔍-Button neben jeder Datei sucht ähnliche EN-Texte in den Untertiteln und übernimmt den passenden DE-Text; zeigt dabei den gesuchten EN-Text an und ignoriert `<clr:...>`-Farbcodes
+  * **Untertitel-Suche:** neuer 🔍-Button neben jeder Datei sucht ähnliche EN-Texte in den Untertiteln und übernimmt den passenden DE-Text; der gesuchte EN-Text wird angezeigt, `<clr:...>`-Farbcodes sowie Hinweise wie `<HEADSET>` oder `<cr>` werden entfernt
 
 ---
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2264,9 +2264,9 @@ function searchSimilarEntriesInDatabase(currentFile) {
 // =========================== SEARCH SIMILAR ENTRIES END ===========================
 
 // =========================== SUBTITLE SEARCH START ===========================
-// Entfernt Farbcodes wie "<clr:255,190,255>" aus einem Untertitel-Text
+// Entfernt Untertitel-Tags wie "<clr:255,190,255>" oder "<HEADSET>"
 function stripColorCodes(text) {
-    return text.replace(/<clr:[^>]+>/gi, '');
+    return text.replace(/<[^>]+>/gi, '');
 }
 
 async function openSubtitleSearch(fileId) {


### PR DESCRIPTION
## Zusammenfassung
- Untertitel-Tags wie `<HEADSET>` und `<cr>` werden nun entfernt
- Dokumentation zur Untertitel-Suche aktualisiert

## Testanweisungen
- `npm test` ausführen und sicherstellen, dass alle Tests erfolgreich sind

------
https://chatgpt.com/codex/tasks/task_e_6854543d74b88327998ac2ecaf7a3bca