### PR TITLE
Fix Subtitle Search similarity scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 * Entfernt die Startskripte `start_tool.js` und `start_tool.bat`. `start_tool.py` bleibt als einzige Einstiegsmöglichkeit erhalten.
 ## 🛠️ Patch in 1.40.24
 * MP3-Encoding entfernt: `bufferToMp3` und die Abhängigkeit `lamejs` wurden gestrichen.
+## 🛠️ Patch in 1.40.25
+* Die Untertitel-Suche bewertet nur noch ganze Wörter, wodurch keine falschen 100-%-Treffer mehr erscheinen.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Seit Patch 1.40.34 lädt die Untertitel-Suche fehlende Untertitel automatisch na
 Seit Patch 1.40.35 korrigiert ein Fallback das Nachladen des Untertitel-Parsers, sodass die Suche zuverlässig funktioniert.
 Seit Patch 1.40.36 blendet die Untertitel-Suche Farbcodes wie `<clr:255,190,255>` aus, berücksichtigt sie nicht bei der Ähnlichkeitsberechnung und zeigt den gesuchten EN-Text im Dialog an.
 Seit Patch 1.40.37 entfernt die Untertitel-Suche zusätzlich Tags wie `<HEADSET>` oder `<cr>` automatisch aus den übernommenen Texten.
+Seit Patch 1.40.38 berechnet die Untertitel-Suche die Ähnlichkeit präziser und ignoriert kurze Wortfragmente.
 
 
 Beispiel einer gültigen CSV:

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2388,9 +2388,9 @@ function calculateTextSimilarity(text1, text2) {
     const allWords = new Set([...words1, ...words2]);
     
     words1.forEach(word1 => {
-        if (words2.some(word2 => 
-            word1.includes(word2) || 
-            word2.includes(word1) || 
+        if (words2.some(word2 =>
+            // Exakte oder nahezu exakte Wortuebereinstimmung pruefen
+            word1 === word2 ||
             levenshteinDistance(word1, word2) <= Math.max(1, Math.min(word1.length, word2.length) * 0.3)
         )) {
             commonWords++;


### PR DESCRIPTION
## Summary
- refine `calculateTextSimilarity` to ignore partial word matches
- document subtitle search improvements in README and CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685459f040748327b19b74e4f5471248