### PR TITLE
Handle personal suffixes in watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ So können Sie das Ergebnis später erneut herunterladen oder neu generieren.
 Beim erneuten Download fragt das Tool nun ebenfalls, ob die Beta-API oder der halbautomatische Modus genutzt werden soll.
 
 Ein Watcher überwacht automatisch den Ordner `web/Download` bzw. `web/Downloads` im Projekt. Taucht dort eine fertig gerenderte Datei auf, meldet das Tool „Datei gefunden“ und verschiebt sie nach `web/sounds/DE`. Seit Version 1.40.5 klappt das auch nach einem Neustart: Legen Sie die Datei einfach in den Ordner, sie wird anhand der Dubbing‑ID automatisch der richtigen Zeile zugeordnet. Der Status springt anschließend auf *fertig*. Alle 15 Sekunden erfolgt zusätzlich eine Status-Abfrage der offenen Jobs, allerdings nur im Beta-Modus. Beta-Jobs werden nun automatisch aus dieser Liste entfernt, sobald sie fertig sind. Der halbautomatische Modus verzichtet auf diese Abfrage. Der Download-Ordner wird zu Beginn jedes neuen Dubbings und nach dem Import automatisch geleert. Seit Version 1.40.17 findet der Watcher auch Dateien mit leicht verändertem Namen und warnt bei fehlender Zuordnung im Terminal.
+Persönliche Zusätze wie `_Alex` oder `-Bob` entfernt er dabei automatisch.
 Seit Patch 1.40.7 merkt sich das Tool außerdem den fertigen Status dauerhaft. Auch nach einem erneuten Download bleibt der grüne Haken erhalten.
 Seit Patch 1.40.8 werden Dateien auch dann korrekt verschoben, wenn sich Download- und Projektordner auf unterschiedlichen Laufwerken befinden.
 Seit Patch 1.40.9 merkt sich der Level-Dialog die zuletzt genutzten fünf Farben und bietet eine Schnellwahl unter dem Farbpicker.
@@ -218,6 +219,7 @@ Seit Patch 1.40.36 blendet die Untertitel-Suche Farbcodes wie `<clr:255,190,255>
 Seit Patch 1.40.37 entfernt die Untertitel-Suche zusätzlich Tags wie `<HEADSET>` oder `<cr>` automatisch aus den übernommenen Texten.
 Seit Patch 1.40.38 berechnet die Untertitel-Suche die Ähnlichkeit präziser und ignoriert kurze Wortfragmente.
 Seit Patch 1.40.39 ersetzt sie `<sb>`- und `<br>`-Tags automatisch durch Leerzeichen und fügt fehlende Leerzeichen nach Satzzeichen ein.
+Seit Patch 1.40.40 entfernt der Dateiwächter beim automatischen Import persönliche Namensendungen wie `_Alex` oder `-Bob`.
 
 
 Beispiel einer gültigen CSV:

--- a/tests/watcher.test.js
+++ b/tests/watcher.test.js
@@ -72,4 +72,14 @@ describe('watchDownloadFolder', () => {
     expect(pruefeAudiodatei(tmp)).toBe(false);
     fs.unlinkSync(tmp);
   });
+
+  test('matchPendingJob entfernt Namenszusätze korrekt', () => {
+    jest.resetModules();
+    const { matchPendingJob } = require('../watcher.js');
+    const pending = [{ id: 'abc', relPath: 'x/abc.wav' }];
+
+    const result = matchPendingJob('abc-Max', pending);
+
+    expect(result.idx).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- erweitere `watcher.js` um Erkennung und Entfernung von Suffixen wie `_Alex` oder `-Bob`
- exportiere neue Hilfsfunktion `matchPendingJob`
- passe die Tests an und ergänze einen neuen Test für die Suffixbehandlung
- dokumentiere die automatische Entfernung persönlicher Endungen in der README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854715eab54832793a6d7e0a3bcd706