### PR TITLE
Add persistent video URL opener

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Live‑Statistiken:** EN‑%, DE‑%, Completion‑%, Globale Textzahlen (EN/DE/BEIDE/∑)
 * **Vollständig offline** – keine Server, keine externen Abhängigkeiten
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
+* **Eigener Video-Link:** Neben dem Spielstart kann eine beliebige URL gespeichert und per Knopfdruck geöffnet werden.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 
 ### 📊 Fortschritts‑Tracking

--- a/electron/ipcContracts.ts
+++ b/electron/ipcContracts.ts
@@ -54,4 +54,5 @@ export type IpcChannels =
   | 'dub-status'
   | 'dub-log'
   | 'save-error'
-  | 'start-hla';
+  | 'start-hla'
+  | 'open-external';

--- a/electron/main.js
+++ b/electron/main.js
@@ -261,6 +261,12 @@ app.whenReady().then(() => {
     return true;
   });
 
+  // Beliebige URL im Standardbrowser öffnen
+  ipcMain.handle('open-external', async (event, url) => {
+    shell.openExternal(url);
+    return true;
+  });
+
   // Pfad des projektinternen Download-Ordners liefern
   ipcMain.handle('get-download-path', () => {
     // Der Download-Ordner liegt im Web-Verzeichnis des Projekts

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -68,6 +68,7 @@ if (typeof require !== 'function') {
     onTranslateFinished: cb => ipcRenderer.on('translate-finished', (e, data) => cb(data)),
     // Half-Life: Alyx starten (Modus und Sprache wählbar, optional Map)
     startHla: (mode, lang, map) => ipcRenderer.invoke('start-hla', { mode, lang, map }),
+    openExternal: (url) => ipcRenderer.invoke('open-external', url),
   });
   console.log('[Preload] erfolgreich geladen');
 }

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -68,6 +68,10 @@
                     <input type="text" id="mapSelect" placeholder="Level" style="width:140px">
                     <button id="startButton" class="btn btn-secondary" onclick="startHla()">Starten</button>
                 </div>
+                <div class="video-launch">
+                    <input type="text" id="videoUrlInput" placeholder="Video-URL..." style="width:200px">
+                    <button class="btn btn-secondary" onclick="openVideoUrl()">Öffnen</button>
+                </div>
             </div>
 			
 <!-- =========================== PROJECT META BAR START =========================== -->

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -119,6 +119,9 @@ let radioSaturation    = parseFloat(localStorage.getItem('hla_radioSaturation') 
 let radioNoise         = parseFloat(localStorage.getItem('hla_radioNoise') || '-26');
 let radioCrackle       = parseFloat(localStorage.getItem('hla_radioCrackle') || '0.1');
 
+// Gespeicherte URL für das Dubbing-Video
+let savedVideoUrl      = localStorage.getItem('hla_videoUrl') || '';
+
 // === Stacks für Undo/Redo ===
 let undoStack          = [];
 let redoStack          = [];
@@ -447,6 +450,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     loadProjects();
 
     initializeEventListeners();
+
+    const urlInput = document.getElementById('videoUrlInput');
+    if (urlInput) {
+        urlInput.value = savedVideoUrl;
+        urlInput.addEventListener('change', saveVideoUrl);
+    }
 
     // 📁 Ordner-Anpassungen laden
     const savedCustomizations = localStorage.getItem('hla_folderCustomizations');
@@ -6885,6 +6894,28 @@ async function scanAudioDuplicates() {
             }
         }
         window.startHla = startHla;
+
+        // Speichert die URL des Videos dauerhaft
+        function saveVideoUrl() {
+            const inp = document.getElementById('videoUrlInput');
+            if (inp) {
+                const url = inp.value.trim();
+                localStorage.setItem('hla_videoUrl', url);
+                savedVideoUrl = url;
+            }
+        }
+
+        // Öffnet die gespeicherte URL in einem neuen Fenster
+        async function openVideoUrl() {
+            const url = (document.getElementById('videoUrlInput')?.value || '').trim();
+            if (!url) return;
+            if (window.electronAPI && window.electronAPI.openExternal) {
+                await window.electronAPI.openExternal(url);
+            } else {
+                window.open(url, '_blank');
+            }
+        }
+        window.openVideoUrl = openVideoUrl;
 
         // Öffnet ein Fenster mit detaillierten Debug-Informationen
         async function openDebugInfo() {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -435,6 +435,13 @@ th:nth-child(6) {
             align-items: center;
         }
 
+        .video-launch {
+            margin-left: auto;
+            display: flex;
+            gap: 5px;
+            align-items: center;
+        }
+
         .hla-launch select,
         .hla-launch input[type="text"] {
             padding: 4px 6px;


### PR DESCRIPTION
## Summary
- allow storing and opening an arbitrary URL in the start bar
- show URL field next to game launcher
- style new `video-launch` container
- implement openExternal IPC handler for Electron
- document new feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854883557d88327a95d966153c88f55