### PR TITLE
Add Video Bookmark IPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Vollständig offline** – keine Server, keine externen Abhängigkeiten
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
 * **Eigener Video-Link:** Neben dem Spielstart kann eine beliebige URL gespeichert und per Knopfdruck geöffnet werden.
+* **Video-Bookmarks:** Speichert pro Nutzer die zuletzt gesehene Position einzelner Videos.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 
 ### 📊 Fortschritts‑Tracking

--- a/electron/ipcContracts.ts
+++ b/electron/ipcContracts.ts
@@ -58,4 +58,6 @@ export type IpcChannels =
   | 'dub-log'
   | 'save-error'
   | 'start-hla'
+  | 'load-bookmarks'
+  | 'save-bookmarks'
   | 'open-external';

--- a/electron/main.js
+++ b/electron/main.js
@@ -69,6 +69,33 @@ fs.mkdirSync(sessionDataPath, { recursive: true });
 app.setPath('sessionData', sessionDataPath);
 // =========================== USER-DATA-PFAD END =============================
 
+// =========================== VIDEO-BOOKMARKS START ==========================
+// Pfad zur Datei mit den gespeicherten Video-Bookmarks
+const dataPath = app.getPath('userData');
+const bookmarkFile = path.join(dataPath, 'videoBookmarks.json');
+
+// Liest vorhandene Bookmarks aus der JSON-Datei
+function readBookmarks() {
+  try {
+    if (fs.existsSync(bookmarkFile)) {
+      return JSON.parse(fs.readFileSync(bookmarkFile, 'utf8'));
+    }
+  } catch (err) {
+    console.error('Bookmarks konnten nicht geladen werden', err);
+  }
+  return [];
+}
+
+// Speichert eine Liste von Bookmarks in der JSON-Datei
+function saveBookmarks(list) {
+  try {
+    fs.writeFileSync(bookmarkFile, JSON.stringify(list ?? []));
+  } catch (err) {
+    console.error('Bookmarks konnten nicht gespeichert werden', err);
+  }
+}
+// =========================== VIDEO-BOOKMARKS END ============================
+
 
 // Pfade zu EN und DE relativ zur HTML-Datei
 
@@ -283,6 +310,15 @@ app.whenReady().then(() => {
   // Beliebige URL im Standardbrowser öffnen
   ipcMain.handle('open-external', async (event, url) => {
     shell.openExternal(url);
+    return true;
+  });
+
+  // Bookmarks aus dem userData-Ordner laden
+  ipcMain.handle('load-bookmarks', () => readBookmarks());
+
+  // Bookmarks im userData-Ordner speichern
+  ipcMain.handle('save-bookmarks', (event, list) => {
+    saveBookmarks(list);
     return true;
   });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -73,5 +73,11 @@ if (typeof require !== 'function') {
     startHla: (mode, lang, map) => ipcRenderer.invoke('start-hla', { mode, lang, map }),
     openExternal: (url) => ipcRenderer.invoke('open-external', url),
   });
+
+  // API für Video-Bookmarks bereitstellen
+  contextBridge.exposeInMainWorld('videoApi', {
+    loadBookmarks: () => ipcRenderer.invoke('load-bookmarks'),
+    saveBookmarks: list => ipcRenderer.invoke('save-bookmarks', list),
+  });
   console.log('[Preload] erfolgreich geladen');
 }


### PR DESCRIPTION
## Summary
- persist video bookmarks in userData folder via new helpers
- expose load/save bookmark APIs to renderer
- document new feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855b33c68e8832791c933a24279253c