### PR TITLE
Add video bookmark button

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Live‑Statistiken:** EN‑%, DE‑%, Completion‑%, Globale Textzahlen (EN/DE/BEIDE/∑)
 * **Vollständig offline** – keine Server, keine externen Abhängigkeiten
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
-* **Eigener Video-Link:** Neben dem Spielstart kann eine beliebige URL gespeichert und per Knopfdruck geöffnet werden.
+* **Eigene Video-Links:** Über die Start-Leiste lassen sich mehrere URLs speichern und per Knopfdruck öffnen.
 * **Video-Bookmarks:** Speichert pro Nutzer die zuletzt gesehene Position einzelner Videos.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -70,6 +70,7 @@
                 </div>
                 <div class="video-launch">
                     <input type="text" id="videoUrlInput" placeholder="Video-URL..." style="width:200px">
+                    <button id="addVideoBtn" class="btn btn-secondary">Hinzufügen</button>
                     <button class="btn btn-secondary" onclick="openVideoUrl()">Öffnen</button>
                 </div>
             </div>
@@ -532,6 +533,7 @@
     <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.40.5</a>
 
     <script src="src/main.js"></script>
+    <script src="renderer.js"></script>
 </body>
 </html>
 

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -1,0 +1,25 @@
+// Elemente holen
+const urlInput = document.getElementById('videoUrlInput');
+const addBtn   = document.getElementById('addVideoBtn');
+
+// Button-Status je nach Eingabe anpassen
+function updateAddBtn() {
+    addBtn.disabled = urlInput.value.trim() === '';
+}
+
+// Initial deaktivieren, falls kein Text
+updateAddBtn();
+
+// Eingaben überwachen
+urlInput.addEventListener('input', updateAddBtn);
+
+// Klick auf "Hinzufügen"
+addBtn.addEventListener('click', async () => {
+    const url = urlInput.value.trim();
+    if (!url) return;
+    const list = await window.videoApi.loadBookmarks();
+    if (list.some(b => b.url === url)) { alert('Schon vorhanden'); return; }
+    list.push({url, time:0});
+    await window.videoApi.saveBookmarks(list);
+    alert('Gespeichert');
+});


### PR DESCRIPTION
## Summary
- allow storing multiple video URLs
- support bookmark storage via frontend button
- document video bookmark feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855b462c5c08327af2ca0645e787c32