### PR TITLE
Implement video bookmark storage in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Live‑Statistiken:** EN‑%, DE‑%, Completion‑%, Globale Textzahlen (EN/DE/BEIDE/∑)
 * **Vollständig offline** – keine Server, keine externen Abhängigkeiten
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
-* **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen.
+* **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Video-Bookmarks:** Merkt pro Link die zuletzt gesehene Zeit und setzt sie beim nächsten Start fort.
 * **Video-Manager:** Modaler Dialog mit Suchfeld, sortierbaren Spalten, Start‑, Umbenennen‑ und Lösch‑Buttons sowie einer Leiste zum Hinzufügen neuer Links.
 * **YouTube-Player:** Startet Videos direkt im Tool und speichert beim Schließen die aktuelle Position.

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -14,6 +14,30 @@ import('./ytPlayer.js').then(m => {
     closePlayer = m.closePlayer;
 });
 
+// Fallback auf LocalStorage, falls die Electron-API fehlt
+if (!window.videoApi) {
+    console.log('Video-API fehlt, verwende LocalStorage');
+    window.videoApi = {
+        loadBookmarks: async () => {
+            const data = localStorage.getItem('hla_videoBookmarks');
+            try {
+                return data ? JSON.parse(data) : [];
+            } catch (e) {
+                console.warn('Lese LocalStorage fehlgeschlagen', e);
+                return [];
+            }
+        },
+        saveBookmarks: async list => {
+            try {
+                localStorage.setItem('hla_videoBookmarks', JSON.stringify(list ?? []));
+            } catch (e) {
+                console.error('Speichern im LocalStorage fehlgeschlagen', e);
+            }
+            return true;
+        }
+    };
+}
+
 // Dialog-Unterstützung sicherstellen
 function ensureDialogSupport(d) {
     if (typeof d.showModal !== 'function') {


### PR DESCRIPTION
## Summary
- save Video-Manager Links im LocalStorage, falls die Electron-API fehlt
- dokumentiere die lokale Speicherung im README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855bfd2eda08327b78f438c0fcc0b1d