### PR TITLE
Video-Bookmarks mit Titeln sortiert

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.
+* **Automatische YouTube-Titel:** Beim Hinzufügen lädt das Tool den Videotitel per oEmbed und sortiert die Liste alphabetisch.
 * **Video-Manager:** Modaler Dialog mit Suchfeld, sortierbaren Spalten, Start‑, Umbenennen‑ und Lösch‑Buttons sowie einer Leiste zum Hinzufügen neuer Links.
 * **YouTube-Player:** Spielt YouTube-Videos direkt im Tool; Schließen blendet den Player aus und merkt sich die aktuelle Position.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -542,7 +542,6 @@
                 <tr>
                     <th data-asc="true">#</th>
                     <th>Titel</th>
-                    <th>URL</th>
                     <th>Letzte Zeit</th>
                     <th>•</th>
                 </tr>

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -82,8 +82,7 @@ async function refreshTable(sortKey='title', dir=true) {
         const tr = document.createElement('tr');
         tr.innerHTML = `
             <td>${i+1}</td>
-            <td title="${b.title}">${b.title.slice(0,40)}</td>
-            <td title="${b.url}">${b.url.slice(0,30)}…</td>
+            <td title="${b.url}">${b.title.slice(0,40)}</td>
             <td>${formatTime(b.time)}</td>
             <td class="video-actions">
                 <button class="start" data-idx="${i}">▶</button>
@@ -118,8 +117,9 @@ videoTableBody.onclick = async e => {
 // Sortierbare Header
 document.querySelectorAll('#videoTable thead th').forEach(th => {
     th.onclick = () => {
-        const keyMap = {0:'index',1:'title',2:'url',3:'time'};
+        const keyMap = {0:'index',1:'title',2:'time'};
         const key = keyMap[Array.from(th.parentNode.children).indexOf(th)];
+        if (!key) return; // Aktionen-Spalte ignorieren
         asc = th.dataset.asc !== 'false';
         th.dataset.asc = !asc;
         refreshTable(key, asc);


### PR DESCRIPTION
## Zusammenfassung
- Titelspalte statt URL anzeigen
- URL jetzt nur noch als Tooltip hinterlegt
- Liste der Videos nach Titel sortieren
- README mit Hinweis auf automatische Titel ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855c37ac9488327b69cc4a229ef8596