### PR TITLE
Fix zeitliche Sortierung im Video-Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.
 * **Duplikat-Prüfung & dauerhafte Speicherung im Nutzerordner**
 * **Automatische YouTube-Titel:** Beim Hinzufügen lädt das Tool den Videotitel per oEmbed und sortiert die Liste alphabetisch.
-* **Video-Manager:** Modaler Dialog mit Suchfeld, sortierbaren Spalten, Start‑, Umbenennen‑ und Lösch‑Buttons sowie einer Leiste zum Hinzufügen neuer Links.
+* **Video-Manager:** Modaler Dialog mit Suchfeld, sortierbaren Spalten (Zeit wird numerisch sortiert), Start‑, Umbenennen‑ und Lösch‑Buttons sowie einer Leiste zum Hinzufügen neuer Links.
 * **Stabiles Sortieren:** Nach Filterung oder Sortierung funktionieren die Video-Buttons dank Originalindex weiterhin korrekt.
 * **YouTube-Player:** Spielt YouTube-Videos direkt im Tool; Schließen blendet den Player aus und merkt sich die aktuelle Position.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -78,7 +78,15 @@ async function refreshTable(sortKey='title', dir=true) {
     let list = await getBookmarks();
     const q = videoFilter.value.toLowerCase();
     if (q) list = list.filter(b => b.title.toLowerCase().includes(q) || b.url.toLowerCase().includes(q));
-    list.sort((a,b)=> dir ? (''+a[sortKey]).localeCompare(b[sortKey],'de') : (''+b[sortKey]).localeCompare(a[sortKey],'de'));
+    // Zeit numerisch sortieren, sonst localeCompare nutzen
+    list.sort((a,b)=> {
+        if(sortKey === 'time'){
+            return dir ? a.time - b.time : b.time - a.time;
+        }
+        return dir
+            ? (''+a[sortKey]).localeCompare(b[sortKey],'de')
+            : (''+b[sortKey]).localeCompare(a[sortKey],'de');
+    });
     videoTableBody.innerHTML = '';
     list.forEach((b,i) => {
         const tr = document.createElement('tr');


### PR DESCRIPTION
## Zusammenfassung
- Zeitspalte im Video-Manager numerisch sortieren
- Hinweis zur numerischen Sortierung im README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855cb5d1908832792607e1a4fddbed8