### PR TITLE
Add URL validation for video links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.
+* **Prüfung von Video-Links:** Eingaben müssen mit `https://` beginnen und dürfen keine Leerzeichen enthalten.
 * **Duplikat-Prüfung & dauerhafte Speicherung im Nutzerordner**
 * **Automatische YouTube-Titel:** Beim Hinzufügen lädt das Tool den Videotitel per oEmbed und sortiert die Liste alphabetisch. Schlägt dies fehl, wird die eingegebene URL als Titel gespeichert.
 * **Video-Manager:** Modaler Dialog mit Suchfeld, sortierbaren Spalten (Zeit wird numerisch sortiert, "#" folgt der Originalreihenfolge), Start‑, Umbenennen‑ und Lösch‑Buttons sowie einer Leiste zum Hinzufügen neuer Links.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -6948,6 +6948,12 @@ async function scanAudioDuplicates() {
         async function openVideoUrl() {
             const url = (document.getElementById('videoUrlInput')?.value || '').trim();
             if (!url) return;
+            // URL auf Mindestformat https:// und ohne Leerzeichen prüfen
+            if (!/^https:\/\/\S+$/.test(url)) {
+                // Fehlermeldung anzeigen und nicht öffnen
+                showToast('Ungültige URL – muss mit https:// beginnen und darf keine Leerzeichen enthalten.', 'error');
+                return;
+            }
             if (window.electronAPI && window.electronAPI.openExternal) {
                 await window.electronAPI.openExternal(url);
             } else {


### PR DESCRIPTION
## Summary
- validiere Video-URLs im Video-Dialog
- dokumentiere die neue Prüfung

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855cd6644e8832798924cbac3c4b164