### PR TITLE
Zentrale YouTube-ID Funktion

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Video-Manager:** Modaler Dialog mit Suchfeld, sortierbaren Spalten (Zeit wird numerisch sortiert, "#" folgt der Originalreihenfolge), Start‑, Umbenennen‑ und Lösch‑Buttons sowie einer Leiste zum Hinzufügen neuer Links.
 * **Stabiles Sortieren:** Nach Filterung oder Sortierung funktionieren die Video-Buttons dank Originalindex weiterhin korrekt.
 * **YouTube-Player:** Spielt YouTube-Videos direkt im Tool; Schließen blendet den Player aus und merkt sich die aktuelle Position.
+* **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 
 ### 📊 Fortschritts‑Tracking

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -8,10 +8,11 @@ const videoTableBody   = document.querySelector('#videoTable tbody');
 const videoFilter      = document.getElementById('videoFilter');
 const closeVideoDlg    = document.getElementById('closeVideoDlg');
 
-let openPlayer, closePlayer;
+let openPlayer, closePlayer, extractYoutubeId;
 import('./ytPlayer.js').then(m => {
-    openPlayer  = m.openPlayer;
-    closePlayer = m.closePlayer;
+    openPlayer       = m.openPlayer;
+    closePlayer      = m.closePlayer;
+    extractYoutubeId = m.extractYoutubeId;
 });
 
 // Fallback auf LocalStorage, falls die Electron-API fehlt
@@ -156,11 +157,6 @@ function formatTime(sec){
     return m+':'+('0'+s).slice(-2);
 }
 
-// extrahiert die Video-ID aus einer YouTube-URL
-function getYoutubeId(u){
-    const m = u.match(/[?&]v=([^&]+)/) || u.match(/youtu\.be\/([^?]+)/);
-    return m ? m[1] : '';
-}
 
 // Add-Button Status
 function updateAddBtn(){ addBtn.disabled = urlInput.value.trim() === ''; }

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -1,7 +1,7 @@
 // Steuert den eingebetteten YouTube-Player
 
 // extrahiert die Video-ID aus einer YouTube-URL
-function extractId(url) {
+export function extractYoutubeId(url) {
     const m = url.match(/[?&]v=([^&]+)/) || url.match(/youtu\.be\/([^?]+)/);
     return m ? m[1] : '';
 }
@@ -13,7 +13,7 @@ export function openPlayer(bookmark, index) {
     if (!div) return;
     div.style.display = 'block';
     div.innerHTML = `<iframe id="ytIframe" width="100%" height="100%"
-        src="https://www.youtube.com/embed/${extractId(bookmark.url)}?start=${Math.floor(bookmark.time)}&enablejsapi=1"
+        src="https://www.youtube.com/embed/${extractYoutubeId(bookmark.url)}?start=${Math.floor(bookmark.time)}&enablejsapi=1"
         allow="autoplay; fullscreen" frameborder="0"></iframe>`;
     if (window.currentYT && window.currentYT.destroy) {
         window.currentYT.destroy();
@@ -54,4 +54,9 @@ export async function closePlayer() {
         await window.videoApi.saveBookmarks(list);
         window.__ytPlayerState = null;
     }
+}
+
+// Node-kompatibler Export für Tests
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { openPlayer, closePlayer, extractYoutubeId };
 }


### PR DESCRIPTION
## Summary
- exportiere `extractYoutubeId` in `ytPlayer.js`
- entferne alte `getYoutubeId` Funktion aus `renderer.js`
- importiere neue Funktion überall
- README um Hinweis auf neue Funktion erweitert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855d019cd2c832788f835963be76e0e