### PR TITLE
Verbessertes Schließen des YouTube-Players

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Automatische YouTube-Titel:** Beim Hinzufügen lädt das Tool den Videotitel per oEmbed und sortiert die Liste alphabetisch. Schlägt dies fehl, wird die eingegebene URL als Titel gespeichert.
 * **Video-Manager:** Modaler Dialog mit Suchfeld, sortierbaren Spalten (Zeit wird numerisch sortiert, "#" folgt der Originalreihenfolge), Start‑, Umbenennen‑ und Lösch‑Buttons sowie einer Leiste zum Hinzufügen neuer Links.
 * **Stabiles Sortieren:** Nach Filterung oder Sortierung funktionieren die Video-Buttons dank Originalindex weiterhin korrekt.
-* **YouTube-Player:** Spielt YouTube-Videos direkt im Tool; Schließen blendet den Player aus und merkt sich die aktuelle Position.
+* **YouTube-Player:** Spielt YouTube-Videos direkt im Tool; beim Schließen wird nun die exakte Position per `getCurrentTime()` gespeichert.
 * **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 

--- a/tests/ytPlayerTime.test.js
+++ b/tests/ytPlayerTime.test.js
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+
+
+// simulierte Video-API fuer das Speichern der Bookmarks
+const videoApi = {
+    loadBookmarks: async () => {
+        const data = localStorage.getItem('hla_videoBookmarks');
+        try {
+            return data ? JSON.parse(data) : [];
+        } catch (e) {
+            return [];
+        }
+    },
+    saveBookmarks: async list => {
+        try {
+            localStorage.setItem('hla_videoBookmarks', JSON.stringify(list ?? []));
+        } catch (e) {
+            // ignorieren
+        }
+        return true;
+    }
+};
+
+describe('YouTube-Player Zeituebernahme', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        document.body.innerHTML = '<div id="ytPlayerBox"></div>';
+        window.videoApi = videoApi;
+    });
+
+    test('closePlayer speichert exakte Zeit', async () => {
+        const fs = require('fs');
+        const vm = require('vm');
+        const path = require('path');
+        const code = fs.readFileSync(path.join(__dirname, '../web/ytPlayer.js'), 'utf8')
+            .replace(/export\s+(async\s+)?function/g, '$1function');
+        const sandbox = { module: { exports: {} }, window, document, setInterval, clearInterval };
+        vm.runInNewContext(code, sandbox);
+        const { closePlayer } = sandbox.module.exports;
+        await videoApi.saveBookmarks([{ url: 'u', title: 't', time: 0 }]);
+
+        const bookmark = { url: 'u', title: 't', time: 0 };
+        const interval = setInterval(() => {}, 1000);
+        window.currentYT = {
+            getCurrentTime: () => 77,
+            destroy: jest.fn()
+        };
+        window.__ytPlayerState = { bookmark, index: 0, interval, get time() { return 33; } };
+
+        await closePlayer();
+
+        const list = await videoApi.loadBookmarks();
+        expect(list[0].time).toBe(77);
+    });
+});

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -40,6 +40,16 @@ export async function closePlayer() {
     if (!div) return;
     div.style.display = 'none';
     div.innerHTML = '';
+    // vor dem Zerstören die exakte Abspielzeit sichern, falls möglich
+    let exactTime;
+    if (window.currentYT && typeof window.currentYT.getCurrentTime === 'function') {
+        try {
+            exactTime = window.currentYT.getCurrentTime();
+        } catch (e) {
+            // ignorieren und später auf time zurückfallen
+        }
+    }
+
     if (window.currentYT && window.currentYT.destroy) {
         window.currentYT.destroy();
     }
@@ -48,7 +58,8 @@ export async function closePlayer() {
     if (window.__ytPlayerState) {
         clearInterval(window.__ytPlayerState.interval);
         const { bookmark, index, time } = window.__ytPlayerState;
-        bookmark.time = time;
+        // falls vorhanden, verwende die exakte Zeit des Players
+        bookmark.time = (typeof exactTime === 'number') ? exactTime : time;
         const list = await window.videoApi.loadBookmarks();
         list[index] = bookmark;
         await window.videoApi.saveBookmarks(list);


### PR DESCRIPTION
## Summary
- hole vor dem Zerstören des Players die aktuelle Zeit
- sichere sie nur, wenn `getCurrentTime` existiert
- ergänze einen Test für die Zeitübernahme beim Schließen
- dokumentiere die neue Funktion im README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855d1d7647c83278d264f2544d3c8fb