### PR TITLE
Remove direct ytPlayer import

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Automatische YouTube-Titel:** Beim Hinzufügen lädt das Tool den Videotitel per oEmbed und sortiert die Liste alphabetisch. Schlägt dies fehl, wird die eingegebene URL als Titel gespeichert.
 * **Video-Manager:** Modaler Dialog mit Suchfeld, sortierbaren Spalten (Zeit wird numerisch sortiert, "#" folgt der Originalreihenfolge), Start‑, Umbenennen‑ und Lösch‑Buttons sowie einer Leiste zum Hinzufügen neuer Links.
 * **Stabiles Sortieren:** Nach Filterung oder Sortierung funktionieren die Video-Buttons dank Originalindex weiterhin korrekt.
-* **YouTube-Player:** Spielt YouTube-Videos direkt im Tool; beim Schließen wird nun die exakte Position per `getCurrentTime()` gespeichert.
+* **YouTube-Player:** Wird jetzt dynamisch über `renderer.js` geladen und spielt Videos direkt im Tool; beim Schließen bleibt die exakte Position per `getCurrentTime()` erhalten.
 * **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -556,7 +556,6 @@
     <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.40.5</a>
 
     <script src="https://www.youtube.com/iframe_api"></script>
-    <script type="module" src="ytPlayer.js"></script>
     <script src="src/main.js"></script>
     <script src="renderer.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- remove ytPlayer module tag from HTML
- load ytPlayer only via renderer.js
- document dynamic loading in README

## Testing
- `npm test`
- `node -e "import('./web/ytPlayer.js').then(m=>console.log('ok',Object.keys(m)))"`

------
https://chatgpt.com/codex/tasks/task_e_6855d325a834832788729b3f8ecd833e