### PR TITLE
Fix duplicate comment in ytPlayer

### DIFF
--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -7,7 +7,6 @@ export function extractYoutubeId(url) {
 }
 
 // öffnet den Player für ein Bookmark
-// öffnet den Player für ein Bookmark
 export function openPlayer(bookmark, index) {
     const div = document.getElementById('ytPlayerBox');
     if (!div) return;


### PR DESCRIPTION
## Summary
- entferne die überflüssige Kommentarzeile in `web/ytPlayer.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855d47170dc8327a2ccb7867c900225