### PR TITLE
Update Electron start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ### Desktop-Version (Electron)
 1. Im Hauptverzeichnis `npm ci` ausführen, damit benötigte Pakete wie `chokidar` vorhanden sind
 2. In das Verzeichnis `electron/` wechseln und `npm ci` ausführen. Fehlt npm (z.B. bei Node 22), `npm install -g npm` oder `corepack enable` nutzen
-3. Mit `npm start` startet die Desktop-App ohne Browserdialog
+3. Im Ordner `electron/` `npm start` ausführen, um die Desktop-App ohne Browserdialog zu starten
+
+   ```bash
+   cd electron
+   npm start
+   ```
 4. Das Projekt lässt sich plattformübergreifend mit `python start_tool.py` starten. Fehlt das Repository, wird es automatisch geklont; andernfalls werden die neuesten Änderungen geladen und die Desktop-App gestartet. `start_tool.py` erkennt dabei automatisch, ob es im Repository oder davor gestartet wurde.
 5. Beim Start werden die Ordner `web/sounds/EN` und `web/sounds/DE` automatisch erstellt und eingelesen. Liegen die Ordner außerhalb des `web`-Verzeichnisses, erkennt das Tool sie nun ebenfalls.
 6. Kopieren Sie Ihre Originaldateien in `web/sounds/EN` (oder den gefundenen Ordner) und legen Sie Übersetzungen in `web/sounds/DE` ab
@@ -543,6 +548,7 @@ Die wichtigsten Tests befinden sich im Ordner `tests/` und prüfen die Funktione
 
 1. **Entwicklungsserver starten**
    ```bash
+   cd electron
    npm start
    ```
 2. **Audiodatei hochladen** – im geöff­neten Tool eine WAV‑ oder MP3‑Datei auswählen.


### PR DESCRIPTION
## Summary
- clarify that `npm start` is run within `electron/`
- update the test section accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855d51e46348327886a98e4e4e17e2f