### PR TITLE
Fix session import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Seit Patch 1.40.37 entfernt die Untertitel-Suche zusätzlich Tags wie `<HEADSET>
 Seit Patch 1.40.38 berechnet die Untertitel-Suche die Ähnlichkeit präziser und ignoriert kurze Wortfragmente.
 Seit Patch 1.40.39 ersetzt sie `<sb>`- und `<br>`-Tags automatisch durch Leerzeichen und fügt fehlende Leerzeichen nach Satzzeichen ein.
 Seit Patch 1.40.40 entfernt der Dateiwächter beim automatischen Import persönliche Namensendungen wie `_Alex` oder `-Bob`.
+Seit Patch 1.40.41 startet die Desktop-App ohne Fehlermeldung, da `session` in `electron/main.js` korrekt eingebunden ist.
 
 
 Beispiel einer gültigen CSV:

--- a/electron/main.js
+++ b/electron/main.js
@@ -7,7 +7,7 @@
  * @typedef {import('./ipcContracts').RestoreDeHistoryArgs} RestoreDeHistoryArgs
  * @typedef {import('./ipcContracts').SaveDeHistoryBufferArgs} SaveDeHistoryBufferArgs
  */
-const { app, BrowserWindow, ipcMain, globalShortcut, dialog, shell } = require('electron');
+const { app, BrowserWindow, ipcMain, globalShortcut, dialog, shell, session } = require('electron'); // session wird für Header-Manipulation benötigt
 // 'node:path' nutzen, damit das integrierte Modul auch nach dem Packen gefunden wird
 const path = require('node:path'); // Pfadmodul einbinden
 const fs = require('fs');


### PR DESCRIPTION
## Summary
- import `session` in the Electron main process
- document the fix in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855dcfc6f3c832793f64cde04a7ca7d