### PR TITLE
Verbessertes Speichern im Video-Dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Video-Manager:** Modaler Dialog mit Suchfeld, sortierbaren Spalten (Zeit wird numerisch sortiert, "#" folgt der Originalreihenfolge), Start‑, Umbenennen‑ und Lösch‑Buttons sowie einer Leiste zum Hinzufügen neuer Links.
 * **Stabiles Sortieren:** Nach Filterung oder Sortierung funktionieren die Video-Buttons dank Originalindex weiterhin korrekt.
 * **YouTube-Player:** Wird jetzt dynamisch über `renderer.js` geladen und spielt Videos direkt im Tool; beim Schließen bleibt die exakte Position per `getCurrentTime()` erhalten.
-* **Video-Dialog:** Neuer Player-Dialog mit Zeitleiste, ±10 s-Steuerung, Reload und Löschfunktion sowie Tastaturkürzeln.
+* **Video-Dialog:** Neuer Player-Dialog mit Zeitleiste, ±10 s-Steuerung, Reload und Löschfunktion sowie Tastaturkürzeln. Die aktuelle Position wird nun alle zwei Sekunden gespeichert und auch beim nativen Schließen übernommen.
 * **16:9-Playerfenster:** Das eingebettete Video behält stets ein Seitenverhältnis von 16:9.
 * **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.


### PR DESCRIPTION
## Zusammenfassung
- Video-Dialog speichert die Abspielposition jetzt über ein eigenes 2s-Intervall
- Globale Player-State enthält zusätzlich das UI-Intervall
- Dialog schließt sicher über das `close`-Event und sichert die Zeit
- README um neue Funktionalität ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e1b00544832784e6bbf65c1f8aa7