### PR TITLE
Implementiere Löschfunktion im Video-Dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Video-Manager:** Modaler Dialog mit Suchfeld, sortierbaren Spalten (Zeit wird numerisch sortiert, "#" folgt der Originalreihenfolge), Start‑, Umbenennen‑ und Lösch‑Buttons sowie einer Leiste zum Hinzufügen neuer Links.
 * **Stabiles Sortieren:** Nach Filterung oder Sortierung funktionieren die Video-Buttons dank Originalindex weiterhin korrekt.
 * **YouTube-Player:** Wird jetzt dynamisch über `renderer.js` geladen und spielt Videos direkt im Tool; beim Schließen bleibt die exakte Position per `getCurrentTime()` erhalten.
-* **Video-Dialog:** Neuer Player-Dialog mit Zeitleiste, ±10 s-Steuerung, Reload und Löschfunktion sowie Tastaturkürzeln. Die aktuelle Position wird nun alle zwei Sekunden gespeichert und auch beim nativen Schließen übernommen.
+* **Video-Dialog:** Neuer Player-Dialog mit Zeitleiste, ±10 s-Steuerung, Reload und Löschfunktion sowie Tastaturkürzeln. Die aktuelle Position wird nun alle zwei Sekunden gespeichert und auch beim nativen Schließen übernommen. Der 🗑️-Button entfernt das aktuell geöffnete Video direkt aus den Bookmarks.
 * **16:9-Playerfenster:** Das eingebettete Video behält stets ein Seitenverhältnis von 16:9.
 * **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.

--- a/tests/deleteCurrentVideo.test.js
+++ b/tests/deleteCurrentVideo.test.js
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const videoApi = {
+    loadBookmarks: async () => {
+        const data = localStorage.getItem('hla_videoBookmarks');
+        try {
+            return data ? JSON.parse(data) : [];
+        } catch (e) {
+            return [];
+        }
+    },
+    saveBookmarks: async list => {
+        try {
+            localStorage.setItem('hla_videoBookmarks', JSON.stringify(list ?? []));
+        } catch (e) {}
+        return true;
+    }
+};
+
+describe('deleteCurrentVideo', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        document.body.innerHTML = '<dialog id="videoPlayerDialog"><iframe id="videoPlayerFrame"></iframe></dialog>';
+        window.videoApi = videoApi;
+        window.currentYT = null;
+    });
+
+    test('entfernt den aktuellen Bookmark', async () => {
+        const fs = require('fs');
+        const vm = require('vm');
+        const path = require('path');
+        const code = fs.readFileSync(path.join(__dirname, '../web/ytPlayer.js'), 'utf8')
+            .replace(/export\s+(async\s+)?function/g, '$1function');
+        const sandbox = { module: { exports: {} }, window, document, setInterval, clearInterval, confirm: () => true };
+        vm.runInNewContext(code, sandbox);
+        const { deleteCurrentVideo } = sandbox.module.exports;
+        await videoApi.saveBookmarks([
+            { url: 'a', title: 'Alpha', time: 0 },
+            { url: 'b', title: 'Beta', time: 0 }
+        ]);
+        const interval = setInterval(() => {}, 1000);
+        const bookmark = { url: 'a', title: 'Alpha', time: 0 };
+        window.__ytPlayerState = { bookmark, index: 0, interval, get time() { return 0; } };
+
+        await deleteCurrentVideo();
+
+        const list = await videoApi.loadBookmarks();
+        expect(list).toEqual([{ url: 'b', title: 'Beta', time: 0 }]);
+    });
+});

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -113,14 +113,8 @@ export function openVideoDialog(bookmark, index) {
     reloadBtn.onclick = () => {
         if (window.currentYT) window.currentYT.seekTo(0, true);
     };
-    deleteBtn.onclick = async () => {
-        if (!confirm('Wirklich löschen?')) return;
-        const list = await window.videoApi.loadBookmarks();
-        list.splice(index,1);
-        await window.videoApi.saveBookmarks(list);
-        closeVideoDialog();
-        if (window.refreshTable) window.refreshTable();
-    };
+    // Lösch-Button ruft nun die neue Funktion auf
+    deleteBtn.onclick = deleteCurrentVideo;
     closeBtn.onclick = closeVideoDialog;
 
     dlg.__playerKey = function(e){
@@ -181,6 +175,20 @@ export async function closeVideoDialog() {
     dlg.__closing = false;
 }
 
+// löscht das aktuell geöffnete Video aus der Bookmark-Liste
+export async function deleteCurrentVideo() {
+    if (!window.__ytPlayerState) return;
+    if (!confirm('Wirklich löschen?')) return;
+    const { index } = window.__ytPlayerState;
+    const list = await window.videoApi.loadBookmarks();
+    list.splice(index, 1);
+    await window.videoApi.saveBookmarks(list);
+    // verhindert erneutes Speichern des gelöschten Eintrags
+    window.__ytPlayerState.index = -1;
+    closeVideoDialog();
+    if (window.refreshTable) window.refreshTable();
+}
+
 // blendet den Player wieder aus
 // blendet den Player wieder aus und speichert die letzte Position
 export async function closePlayer() {
@@ -223,6 +231,7 @@ if (typeof module !== 'undefined' && module.exports) {
         closePlayer,
         extractYoutubeId,
         openVideoDialog,
-        closeVideoDialog
+        closeVideoDialog,
+        deleteCurrentVideo
     };
 }


### PR DESCRIPTION
## Summary
- neue Funktion `deleteCurrentVideo` in `ytPlayer.js`
- Verbindung des 🗑️-Buttons mit der neuen Funktion
- Bulletpoint im README für dieses Feature ergänzt
- neuen Jest-Test `deleteCurrentVideo.test.js` hinzugefügt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e2874afc832797b0be2739e8a2c7