### PR TITLE
Implement video dialog keyboard controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Video-Manager:** Modaler Dialog mit Suchfeld, sortierbaren Spalten (Zeit wird numerisch sortiert, "#" folgt der Originalreihenfolge), Start‑, Umbenennen‑ und Lösch‑Buttons sowie einer Leiste zum Hinzufügen neuer Links.
 * **Stabiles Sortieren:** Nach Filterung oder Sortierung funktionieren die Video-Buttons dank Originalindex weiterhin korrekt.
 * **YouTube-Player:** Wird jetzt dynamisch über `renderer.js` geladen und spielt Videos direkt im Tool; beim Schließen bleibt die exakte Position per `getCurrentTime()` erhalten.
-* **Video-Dialog:** Neuer Player-Dialog mit Zeitleiste, ±10 s-Steuerung, Reload und Löschfunktion sowie Tastaturkürzeln. Die aktuelle Position wird nun alle zwei Sekunden gespeichert und auch beim nativen Schließen übernommen. Der 🗑️-Button entfernt das aktuell geöffnete Video direkt aus den Bookmarks.
+* **Video-Dialog:** Neuer Player-Dialog mit Zeitleiste, ±10 s-Steuerung, Reload und Löschfunktion. Per **Escape** wird er geschlossen, **Leertaste** startet oder pausiert die Wiedergabe und die **Pfeiltasten** springen jeweils 10 s. Die aktuelle Position wird nun alle zwei Sekunden gespeichert und auch beim nativen Schließen übernommen. Der 🗑️-Button entfernt das aktuell geöffnete Video direkt aus den Bookmarks.
 * **16:9-Playerfenster:** Das eingebettete Video behält stets ein Seitenverhältnis von 16:9.
 * **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
@@ -360,6 +360,13 @@ In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über da
 | **`Ctrl + Leertaste`**    | Audio abspielen (im Textfeld)                     |
 | **`Tab`**                 | Nächstes Textfeld                                 |
 | **`Shift + Tab`**         | Vorheriges Textfeld                               |
+### Video-Dialog
+
+|  Taste             |  Funktion |
+| ------------------ | ----------------------------- |
+| **`Escape`**       | Player schließen |
+| **`Leertaste`**    | Wiedergabe starten/pausieren |
+| **`←` / `→`**      | 10 s zurück/vor |
 
 ---
 

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -117,14 +117,7 @@ export function openVideoDialog(bookmark, index) {
     deleteBtn.onclick = deleteCurrentVideo;
     closeBtn.onclick = closeVideoDialog;
 
-    dlg.__playerKey = function(e){
-        if (!dlg.open) return;
-        if (e.key === 'Escape') { e.preventDefault(); closeVideoDialog(); }
-        if (e.key === ' ') { e.preventDefault(); playBtn.click(); }
-        if (e.key === 'ArrowLeft') { e.preventDefault(); backBtn.click(); }
-        if (e.key === 'ArrowRight') { e.preventDefault(); fwdBtn.click(); }
-    };
-    document.addEventListener('keydown', dlg.__playerKey);
+
 
     // speichert auch bei nativen Dialog-Schließen
     dlg.addEventListener('close', () => {
@@ -150,7 +143,6 @@ export async function closeVideoDialog() {
     if (dlg.__closing) return;
     dlg.__closing = true;
     if (dlg.open) dlg.close();
-    if (dlg.__playerKey) { document.removeEventListener('keydown', dlg.__playerKey); dlg.__playerKey = null; }
     document.getElementById('videoPlayerFrame').src = '';
 
     let exactTime;
@@ -223,6 +215,31 @@ export async function closePlayer() {
         window.__ytPlayerState = null;
     }
 }
+
+// globaler Keydown-Listener für den Video-Dialog
+document.addEventListener('keydown', e => {
+    const dlg = document.getElementById('videoPlayerDialog');
+    if (!dlg || !dlg.open) return;
+    const playBtn = document.getElementById('videoPlay');
+    const backBtn = document.getElementById('videoBack');
+    const fwdBtn  = document.getElementById('videoForward');
+    if (e.key === 'Escape') {
+        e.preventDefault();
+        closeVideoDialog();
+    }
+    if (e.key === ' ') {
+        e.preventDefault();
+        if (playBtn) playBtn.click();
+    }
+    if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        if (backBtn) backBtn.click();
+    }
+    if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        if (fwdBtn) fwdBtn.click();
+    }
+});
 
 // Node-kompatibler Export für Tests
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
## Summary
- add a global keydown handler in `ytPlayer.js` to control the video dialog via Escape, Space and arrow keys
- document the new controls and update README shortcuts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e3ab857c83278eb345f351d7a374