### PR TITLE
Neue Tests für YouTube-Player

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Schnellstart im Player:** YouTube-Links aus der URL-Eingabe starten direkt im eingebetteten Player; andere Links werden extern geöffnet. Beim Öffnen wird automatisch ein Bookmark angelegt.
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.
 * **Tests für Video-Bookmarks:** Überprüfen Laden, Sortierung sowie Hinzufügen und Entfernen von Einträgen.
+* **Tests für den YouTube-Player:** Prüfen Speicherung über das Intervall, Löschfunktion sowie Dialog und Slider.
 * **Prüfung von Video-Links:** Eingaben müssen mit `https://` beginnen und dürfen keine Leerzeichen enthalten.
 * **Duplikat-Prüfung & dauerhafte Speicherung im Nutzerordner**
 * **Automatische YouTube-Titel:** Beim Hinzufügen lädt das Tool den Videotitel per oEmbed und sortiert die Liste alphabetisch. Schlägt dies fehl, wird die eingegebene URL als Titel gespeichert.

--- a/tests/openVideoDialog.test.js
+++ b/tests/openVideoDialog.test.js
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// nutzt dieselbe Technik wie in anderen Tests, um die Funktionen zu laden
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+function loadModule() {
+    const code = fs.readFileSync(path.join(__dirname, '../web/ytPlayer.js'), 'utf8')
+        .replace(/export\s+(async\s+)?function/g, '$1function');
+    const sandbox = { module: { exports: {} }, window, document, setInterval, clearInterval, YT: window.YT };
+    vm.runInNewContext(code, sandbox);
+    return sandbox.module.exports;
+}
+
+describe('openVideoDialog und Slider', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        document.body.innerHTML = `
+            <dialog id="videoPlayerDialog">
+                <span id="playerDialogTitle"></span>
+                <iframe id="videoPlayerFrame"></iframe>
+                <input type="range" id="videoSlider" />
+                <span id="videoCurrent"></span>
+                <span id="videoDuration"></span>
+                <button id="videoPlay"></button>
+                <button id="videoBack"></button>
+                <button id="videoForward"></button>
+                <button id="videoReload"></button>
+                <button id="videoDelete"></button>
+                <button id="videoClose"></button>
+            </dialog>`;
+        window.videoApi = { loadBookmarks: async () => [], saveBookmarks: async () => true };
+        const dlg = document.getElementById('videoPlayerDialog');
+        dlg.showModal = jest.fn();
+        window.dialogPolyfill = null;
+        window.YT = {
+            Player: jest.fn(() => ({
+                getDuration: () => 100,
+                getCurrentTime: () => 10,
+                getPlayerState: () => 1,
+                seekTo: jest.fn()
+            })),
+            PlayerState: { PLAYING: 1, PAUSED: 2, CUED: 5 }
+        };
+    });
+
+    test('öffnet Dialog und setzt iframe-src', () => {
+        const { openVideoDialog } = loadModule();
+        const bookmark = { url: 'https://www.youtube.com/watch?v=abc', title: 't', time: 5 };
+        openVideoDialog(bookmark, 1);
+        const dlg = document.getElementById('videoPlayerDialog');
+        const iframe = document.getElementById('videoPlayerFrame');
+        expect(dlg.dataset.index).toBe('1');
+        expect(iframe.src).toContain('https://www.youtube.com/embed/abc?start=5');
+        expect(window.__ytPlayerState).not.toBeNull();
+    });
+
+    test('Slider bewegt den Player', () => {
+        const { openVideoDialog } = loadModule();
+        const bookmark = { url: 'https://youtu.be/xyz', title: 't', time: 0 };
+        openVideoDialog(bookmark, 0);
+        const slider = document.getElementById('videoSlider');
+        window.currentYT.seekTo.mockClear();
+        slider.value = '42';
+        slider.oninput();
+        expect(window.currentYT.seekTo).toHaveBeenCalledWith(42, true);
+    });
+});

--- a/tests/ytPlayerTime.test.js
+++ b/tests/ytPlayerTime.test.js
@@ -54,4 +54,56 @@ describe('YouTube-Player Zeituebernahme', () => {
         const list = await videoApi.loadBookmarks();
         expect(list[0].time).toBe(77);
     });
+
+    test('closePlayer nutzt Intervallzeit bei Fehler', async () => {
+        const fs = require('fs');
+        const vm = require('vm');
+        const path = require('path');
+        const code = fs.readFileSync(path.join(__dirname, '../web/ytPlayer.js'), 'utf8')
+            .replace(/export\s+(async\s+)?function/g, '$1function');
+        const sandbox = { module: { exports: {} }, window, document, setInterval, clearInterval };
+        vm.runInNewContext(code, sandbox);
+        const { closePlayer } = sandbox.module.exports;
+        await videoApi.saveBookmarks([{ url: 'u', title: 't', time: 0 }]);
+
+        const bookmark = { url: 'u', title: 't', time: 0 };
+        const interval = setInterval(() => {}, 1000);
+        window.currentYT = {
+            getCurrentTime: () => { throw new Error('fail'); },
+            destroy: jest.fn()
+        };
+        window.__ytPlayerState = { bookmark, index: 0, interval, get time() { return 44; } };
+
+        await closePlayer();
+
+        const list = await videoApi.loadBookmarks();
+        expect(list[0].time).toBe(44);
+    });
+
+    test('schließen nach Löschung verändert Liste nicht', async () => {
+        const fs = require('fs');
+        const vm = require('vm');
+        const path = require('path');
+        const code = fs.readFileSync(path.join(__dirname, '../web/ytPlayer.js'), 'utf8')
+            .replace(/export\s+(async\s+)?function/g, '$1function');
+        const sandbox = { module: { exports: {} }, window, document, setInterval, clearInterval, confirm: () => true };
+        vm.runInNewContext(code, sandbox);
+        const { deleteCurrentVideo, closePlayer } = sandbox.module.exports;
+        await videoApi.saveBookmarks([
+            { url: 'a', title: 'Alpha', time: 0 },
+            { url: 'b', title: 'Beta', time: 0 }
+        ]);
+
+        const interval = setInterval(() => {}, 1000);
+        const bookmark = { url: 'a', title: 'Alpha', time: 0 };
+        window.__ytPlayerState = { bookmark, index: 0, interval, get time() { return 55; } };
+        window.currentYT = { getCurrentTime: () => 66, destroy: jest.fn() };
+
+        await deleteCurrentVideo();
+
+        await closePlayer();
+
+        const list = await videoApi.loadBookmarks();
+        expect(list).toEqual([{ url: 'b', title: 'Beta', time: 0 }]);
+    });
 });


### PR DESCRIPTION
## Summary
- erweitere ytPlayerTime.test um Szenarien für Intervall-Speicherung und Löschen
- prüfe Dialogöffnung und Slider in neuer openVideoDialog.test.js
- ergänze README um Hinweis auf YouTube-Player-Tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e5526ce48327ba11e872a25636ea