### PR TITLE
Add IPC channel for bookmark deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Schnellstart im Player:** YouTube-Links aus der URL-Eingabe starten direkt im eingebetteten Player; andere Links werden extern geöffnet. Beim Öffnen wird automatisch ein Bookmark angelegt.
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.
+* **Löschen per Desktop-API:** Einzelne Bookmarks lassen sich nun über einen zusätzlichen IPC-Kanal entfernen.
 * **Tests für Video-Bookmarks:** Überprüfen Laden, Sortierung sowie Hinzufügen und Entfernen von Einträgen.
 * **Tests für den YouTube-Player:** Prüfen Speicherung über das Intervall, Löschfunktion sowie Dialog und Slider.
 * **Prüfung von Video-Links:** Eingaben müssen mit `https://` beginnen und dürfen keine Leerzeichen enthalten.

--- a/electron/ipcContracts.ts
+++ b/electron/ipcContracts.ts
@@ -60,4 +60,5 @@ export type IpcChannels =
   | 'start-hla'
   | 'load-bookmarks'
   | 'save-bookmarks'
+  | 'delete-bookmark'
   | 'open-external';

--- a/electron/main.js
+++ b/electron/main.js
@@ -332,6 +332,16 @@ app.whenReady().then(() => {
     return true;
   });
 
+  // einzelnen Bookmark anhand des Index entfernen
+  ipcMain.handle('delete-bookmark', (event, idx) => {
+    const list = readBookmarks();
+    if (typeof idx === 'number' && idx >= 0 && idx < list.length) {
+      list.splice(idx, 1);
+      saveBookmarks(list);
+    }
+    return true;
+  });
+
   // Pfad des projektinternen Download-Ordners liefern
   ipcMain.handle('get-download-path', () => {
     // Der Download-Ordner liegt im Web-Verzeichnis des Projekts

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -78,6 +78,8 @@ if (typeof require !== 'function') {
   contextBridge.exposeInMainWorld('videoApi', {
     loadBookmarks: () => ipcRenderer.invoke('load-bookmarks'),
     saveBookmarks: list => ipcRenderer.invoke('save-bookmarks', list),
+    // einzelnen Bookmark per Index löschen
+    deleteBookmark: idx => ipcRenderer.invoke('delete-bookmark', idx),
   });
   console.log('[Preload] erfolgreich geladen');
 }


### PR DESCRIPTION
## Summary
- support removing bookmarks via desktop IPC
- update electron contract and handlers accordingly
- document new deletion capability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e67067388327a2e541be496b43e8