### PR TITLE
Fix video table layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **`openPlayer`/`closePlayer` veraltet:** Diese Funktionen leiten jetzt intern auf `openVideoDialog` bzw. `closeVideoDialog` um.
 * **16:9-Playerfenster:** Das eingebettete Video behält stets ein Seitenverhältnis von 16:9.
 * **Fehlerbehebung:** Der integrierte Player lässt sich mehrfach starten, ohne dass der `videoPlayerFrame` fehlt.
+* **Korrekte Spaltenbreite im Video-Manager:** Kopfzeile und Tabelle sind jetzt bündig, komplette Videotitel erscheinen als Tooltip.
 * **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -99,7 +99,7 @@ async function refreshTable(sortKey='title', dir=true) {
         const tr = document.createElement('tr');
         tr.innerHTML = `
             <td>${i+1}</td>
-            <td title="${b.url}">${b.title.slice(0,40)}</td>
+            <td title="${b.title}">${b.title}</td>
             <td>${formatTime(b.time)}</td>
             <td class="video-actions">
                 <button class="start" data-idx="${b.origIndex}" title="Video starten">▶️</button>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2476,6 +2476,11 @@ th:nth-child(6) {
     width: 100%;
     border-collapse: collapse;
 }
+#videoTable thead {
+    display: table;
+    width: 100%;
+    table-layout: fixed;
+}
 #videoTable thead th {
     cursor: pointer;
     border-bottom: 1px solid #555;
@@ -2495,6 +2500,11 @@ th:nth-child(6) {
 }
 #videoTable tbody tr:hover { background: #222; }
 #videoTable td, #videoTable th { padding: 0.3rem 0.6rem; }
+#videoTable td {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 .video-actions button { margin: 0 2px; }
 .video-actions button:hover { background:#444; }
 


### PR DESCRIPTION
## Summary
- show full video titles in saved list rows
- align table header with saved video entries
- clip long titles nicely
- document fix in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856441ba5248327a95c79ba8c40ef77