### PR TITLE
Add thumbnails to video manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Video-Manager mit integriertem Player:** Ein einziges Fenster zeigt links die gespeicherten Links und rechts den YouTube‑Player. Suchfeld, sortierbare Spalten sowie Hinzufügen‑, Umbenennen‑ und Lösch‑Buttons bleiben erhalten.
 * **Überarbeitete Video-Manager-Oberfläche:** Neue Farbakzente, Suchfeld und deutlichere Aktions-Icons erleichtern die Bedienung.
 * **Stabiles Sortieren:** Nach Filterung oder Sortierung funktionieren die Video-Buttons dank Originalindex weiterhin korrekt.
+* **Thumbnail-Ansicht:** Die Tabelle zeigt Vorschaubilder statt Nummern. Ein Klick auf Bild oder Titel startet sofort das Video – der separate Play-Button entfällt.
 * **YouTube-Player:** Läuft innerhalb des Managers. Beim Schließen des Players bleibt die exakte Position per `getCurrentTime()` erhalten. **Escape** schließt den Player, **Leertaste** startet oder pausiert und die **Pfeiltasten** springen 10 s.
 * **`openPlayer`/`closePlayer` veraltet:** Diese Funktionen leiten jetzt intern auf `openVideoDialog` bzw. `closeVideoDialog` um.
 * **16:9-Playerfenster:** Das eingebettete Video behält stets ein Seitenverhältnis von 16:9.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -542,7 +542,7 @@
                 <table id="videoTable">
                     <thead>
                         <tr>
-                            <th data-asc="true">#</th>
+                            <th data-asc="true">Bild</th>
                             <th>Titel</th>
                             <th>Letzte Zeit</th>
                             <th>•</th>

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -97,12 +97,12 @@ async function refreshTable(sortKey='title', dir=true) {
     videoTableBody.innerHTML = '';
     list.forEach((b,i) => {
         const tr = document.createElement('tr');
+        const thumbUrl = `https://img.youtube.com/vi/${extractYoutubeId(b.url)}/default.jpg`;
         tr.innerHTML = `
-            <td>${i+1}</td>
-            <td title="${b.title}">${b.title}</td>
+            <td><img src="${thumbUrl}" data-idx="${b.origIndex}" class="video-thumb"></td>
+            <td class="video-title" data-idx="${b.origIndex}" title="${b.title}">${b.title}</td>
             <td>${formatTime(b.time)}</td>
             <td class="video-actions">
-                <button class="start" data-idx="${b.origIndex}" title="Video starten">▶️</button>
                 <button class="delete" data-idx="${b.origIndex}" title="Video löschen">🗑️</button>
                 <button class="rename" data-idx="${b.origIndex}" title="Titel bearbeiten">✏️</button>
             </td>`;
@@ -113,29 +113,33 @@ async function refreshTable(sortKey='title', dir=true) {
 // Delegierte Button-Events
 videoTableBody.onclick = async e => {
     const btn = e.target.closest('button');
-    if (!btn) return;
-    const origIdx = Number(btn.dataset.idx);
-    let list = await window.videoApi.loadBookmarks();
-    const bm = list[origIdx];
-    switch(btn.className){
-        case 'start':
-            openVideoDialog(bm, origIdx);
-            break;
-        case 'rename':
-            const t = prompt('Neuer Titel', bm.title);
-            if (t && t.trim()) {
-                bm.title = t.trim();
-                await window.videoApi.saveBookmarks(list);
-                refreshTable();
-            }
-            break;
-        case 'delete':
-            if (confirm('Wirklich löschen?')) {
-                list.splice(origIdx,1);
-                await window.videoApi.saveBookmarks(list);
-                refreshTable();
-            }
-            break;
+    const thumb = e.target.closest('.video-thumb, .video-title');
+    if (btn) {
+        const origIdx = Number(btn.dataset.idx);
+        let list = await window.videoApi.loadBookmarks();
+        const bm = list[origIdx];
+        switch(btn.className){
+            case 'rename':
+                const t = prompt('Neuer Titel', bm.title);
+                if (t && t.trim()) {
+                    bm.title = t.trim();
+                    await window.videoApi.saveBookmarks(list);
+                    refreshTable();
+                }
+                break;
+            case 'delete':
+                if (confirm('Wirklich löschen?')) {
+                    list.splice(origIdx,1);
+                    await window.videoApi.saveBookmarks(list);
+                    refreshTable();
+                }
+                break;
+        }
+    } else if (thumb) {
+        const origIdx = Number(thumb.dataset.idx);
+        let list = await window.videoApi.loadBookmarks();
+        const bm = list[origIdx];
+        openVideoDialog(bm, origIdx);
     }
 };
 

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2505,6 +2505,13 @@ th:nth-child(6) {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+.video-thumb {
+    width: 80px;
+    height: 45px;
+    object-fit: cover;
+    cursor: pointer;
+}
+.video-title { cursor: pointer; }
 .video-actions button { margin: 0 2px; }
 .video-actions button:hover { background:#444; }
 


### PR DESCRIPTION
## Summary
- show thumbnails instead of numbers in the video manager
- remove play button and start video when thumbnail or title is clicked
- update CSS for thumbnails
- document the new thumbnail view in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68564532a1808327ae75b81ef99bece8