### PR TITLE
Fix video player reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@
 * Die Content Security Policy lässt nun Bilder von `i.ytimg.com` zu, damit der YouTube-Player ohne Fehlermeldung startet.
 ## 🛠️ Patch in 1.40.27
 * Problem behoben, bei dem der YouTube-Player nach erneutem Öffnen den `videoPlayerFrame` nicht fand.
+## 🛠️ Patch in 1.40.28
+* Der YouTube-Player bleibt sichtbar, wenn man dasselbe Video erneut auswählt.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Seit Patch 1.40.39 ersetzt sie `<sb>`- und `<br>`-Tags automatisch durch Leerzei
 Seit Patch 1.40.40 entfernt der Dateiwächter beim automatischen Import persönliche Namensendungen wie `_Alex` oder `-Bob`.
 Seit Patch 1.40.41 startet die Desktop-App ohne Fehlermeldung, da `session` in `electron/main.js` korrekt eingebunden ist.
 Seit Patch 1.40.42 erlaubt die Content Security Policy nun Bilder von `i.ytimg.com`, wodurch der YouTube-Player keine CSP-Fehler mehr verursacht.
+Seit Patch 1.40.43 verschwindet der YouTube-Player nicht mehr, wenn man dasselbe Video erneut anklickt.
 
 
 Beispiel einer gültigen CSV:

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -23,17 +23,24 @@ export function openVideoDialog(bookmark, index) {
     player.dataset.index = index;
     player.querySelector('#playerDialogTitle').textContent = bookmark.title;
 
-    const iframe = document.getElementById('videoPlayerFrame');
-    if (!iframe) {
-        console.warn('videoPlayerFrame nicht gefunden');
-        return;
-    }
-    iframe.id = 'videoPlayerFrame';
-    iframe.src = `https://www.youtube.com/embed/${extractYoutubeId(bookmark.url)}?start=${Math.floor(bookmark.time)}&enablejsapi=1`;
-
+    // alten Player sauber entfernen, damit das IFrame neu erstellt werden kann
     if (window.currentYT && window.currentYT.destroy) {
         window.currentYT.destroy();
     }
+
+    // IFrame ggf. neu anlegen, falls es durch destroy() verschwunden ist
+    let iframe = document.getElementById('videoPlayerFrame');
+    if (!iframe || iframe.tagName !== 'IFRAME') {
+        if (iframe) iframe.remove();
+        const controls = player.querySelector('.player-controls');
+        iframe = document.createElement('iframe');
+        iframe.id = 'videoPlayerFrame';
+        iframe.setAttribute('allow', 'autoplay; fullscreen');
+        player.insertBefore(iframe, controls);
+    }
+
+    // neue URL setzen und Player initialisieren
+    iframe.src = `https://www.youtube.com/embed/${extractYoutubeId(bookmark.url)}?start=${Math.floor(bookmark.time)}&enablejsapi=1`;
     window.currentYT = new YT.Player('videoPlayerFrame');
 
     const slider = document.getElementById('videoSlider');


### PR DESCRIPTION
## Summary
- keep video iframe when clicking the same video again
- mention fix in README and changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856477e62e48327ba924aaaf25ffd4d