### PR TITLE
Verbesserte Video-Dialog-Dynamik

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **16:9-Playerfenster:** Das eingebettete Video behält stets ein Seitenverhältnis von 16:9.
 * **Fehlerbehebung:** Der integrierte Player lässt sich mehrfach starten, ohne dass der `videoPlayerFrame` fehlt.
 * **Korrekte Spaltenbreite im Video-Manager:** Kopfzeile und Tabelle sind jetzt bündig, komplette Videotitel erscheinen als Tooltip.
+* **Dynamische Größenanpassung:** Dialog, Player und Buttons passen sich automatisch an die Fenstergröße an.
 * **Verbesserte Thumbnail-Ladefunktion:** Vorschaubilder werden über `i.ytimg.com` geladen und die gesamte Zeile ist zum Öffnen des Videos anklickbar.
 * **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -539,17 +539,19 @@
                         <button id="openVideoBtn" class="btn btn-blue" onclick="openVideoUrl()">🔗 Öffnen</button>
                     </div>
                 </div>
-                <table id="videoTable">
-                    <thead>
-                        <tr>
-                            <th data-asc="true">Bild</th>
-                            <th>Titel</th>
-                            <th>Letzte Zeit</th>
-                            <th>•</th>
-                        </tr>
-                    </thead>
-                    <tbody></tbody>
-                </table>
+                <div id="videoTableWrapper">
+                    <table id="videoTable">
+                        <thead>
+                            <tr>
+                                <th data-asc="true">Bild</th>
+                                <th>Titel</th>
+                                <th>Letzte Zeit</th>
+                                <th>•</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
                 <button id="closeVideoDlg" class="btn btn-danger">❌ Schließen</button>
             </div>
             <div id="videoPlayerSection" class="video-player-section hidden">

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2400,12 +2400,15 @@ th:nth-child(6) {
 }
 
 .video-dialog {
-    /* Großer dunkler Dialog für den Video-Manager */
-    width: 80vw;
-    max-height: 80vh;
+    /* Großer dunkler Dialog für den Video-Manager
+       füllt dynamisch 90% des Fensters */
+    width: 90vw;
+    height: 90vh;
     background: #1a1a1a;
     color: #e0e0e0;
     padding: 1rem;
+    display: flex;
+    flex-direction: column;
 }
 
 /* Werkzeugleiste mit Suchfeld und Buttons */
@@ -2423,10 +2426,23 @@ th:nth-child(6) {
     border-radius: 4px;
 }
 
-/* Flex-Layout für Liste und Player */
-.video-layout { display: flex; gap: 1rem; }
-.video-list-section { width: 35%; max-height: 70vh; overflow-y: auto; }
-.video-player-section { flex: 1; display: flex; flex-direction: column; }
+/* Flex-Layout für Liste und Player,
+   verteilt den verfügbaren Platz dynamisch */
+.video-layout { display: flex; gap: 1rem; flex: 1; overflow: hidden; }
+.video-list-section {
+    /* Linke Tabellenansicht mit flexibler Höhe */
+    width: 35%;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+.video-player-section {
+    /* Rechter Bereich mit Player, passt sich der Dialoghöhe an */
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
 .video-player-section.hidden { display: none; }
 
 /* YouTube-Player Box im festen 16:9-Format */
@@ -2467,9 +2483,16 @@ th:nth-child(6) {
     padding: 4px 6px;
     border-radius: 4px;
     cursor: pointer;
+    font-size: clamp(16px, 2.5vh, 24px);
 }
 .video-player-section .player-controls button:hover {
     background: #444;
+}
+
+#videoTableWrapper {
+    /* Container für die Tabelle mit dynamischer Höhe */
+    flex: 1;
+    overflow-y: auto;
 }
 
 #videoTable {
@@ -2489,7 +2512,7 @@ th:nth-child(6) {
 #videoTable thead th[data-asc="false"]::after { content: ' ▼'; }
 #videoTable tbody {
     display: block;
-    max-height: 60vh;
+    height: 100%;
     overflow-y: auto;
 }
 #videoTable tbody tr {
@@ -2509,13 +2532,16 @@ th:nth-child(6) {
     white-space: nowrap;
 }
 .video-thumb {
-    width: 80px;
-    height: 45px;
+    width: clamp(60px, 8vw, 120px);
+    aspect-ratio: 16 / 9;
     object-fit: cover;
     cursor: pointer;
 }
 .video-title { cursor: pointer; }
-.video-actions button { margin: 0 2px; }
+.video-actions button {
+    margin: 0 2px;
+    font-size: clamp(14px, 2.2vh, 20px);
+}
 .video-actions button:hover { background:#444; }
 
 .accordion-content {


### PR DESCRIPTION
## Summary
- Video-Liste in ein Wrapper-Div gelegt
- Video-Dialog füllt nun 90% des Fensters und nutzt Flexbox
- Tabellenelemente, Vorschaubilder und Buttons passen sich dynamisch an
- neue deutsche Kommentare im CSS
- README um Hinweis zur dynamischen Größenanpassung erweitert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685648d6d860832786641534ad53842b