### PR TITLE
Fix video scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Thumbnail-Ansicht:** Die Tabelle zeigt Vorschaubilder statt Nummern. Ein Klick auf Bild oder Titel startet sofort das Video – der separate Play-Button entfällt.
 * **YouTube-Player:** Läuft innerhalb des Managers. Beim Schließen des Players bleibt die exakte Position per `getCurrentTime()` erhalten. **Escape** schließt den Player, **Leertaste** startet oder pausiert und die **Pfeiltasten** springen 10 s.
 * **`openPlayer`/`closePlayer` veraltet:** Diese Funktionen leiten jetzt intern auf `openVideoDialog` bzw. `closeVideoDialog` um.
-* **16:9-Playerfenster:** Das eingebettete Video behält stets ein Seitenverhältnis von 16:9.
+* **16:9-Playerfenster:** Das eingebettete Video behält stets ein Seitenverhältnis von 16:9 und passt sich jeder Fenstergröße an.
 * **Fehlerbehebung:** Der integrierte Player lässt sich mehrfach starten, ohne dass der `videoPlayerFrame` fehlt.
 * **Korrekte Spaltenbreite im Video-Manager:** Kopfzeile und Tabelle sind jetzt bündig, komplette Videotitel erscheinen als Tooltip.
 * **Dynamische Größenanpassung:** Dialog, Player und Buttons passen sich automatisch an die Fenstergröße an.
 * **Verbesserte Thumbnail-Ladefunktion:** Vorschaubilder werden über `i.ytimg.com` geladen und die gesamte Zeile ist zum Öffnen des Videos anklickbar.
 * **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
-* **Schlankerer Video-Manager:** URL-Eingabefeld unter den Buttons und eine klar beschriftete Aktions-Spalte. Der Player behält auf 21:9‑Monitoren sein 16:9-Format und die Steuerleiste bleibt sichtbar.
+* **Schlankerer Video-Manager:** URL-Eingabefeld unter den Buttons und eine klar beschriftete Aktions-Spalte. Der Player behält auf allen Monitoren sein 16:9-Format, ohne seitlichen Beschnitt, und die Steuerleiste bleibt sichtbar.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 
 ### 📊 Fortschritts‑Tracking

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2477,13 +2477,15 @@ th:nth-child(6) {
     box-shadow: 0 2px 4px rgba(0,0,0,0.5);
 }
 .video-player-section iframe {
+    /* Video skaliert flexibel, behält stets 16:9 und wird nie abgeschnitten */
     align-self: center;
-    width: auto;
-    height: calc(100% - 6rem);
+    width: 100%;
+    height: auto;
     max-height: calc(100% - 6rem);
     aspect-ratio: 16 / 9;
     border: none;
     display: block;
+    margin: 0 auto;
 }
 .video-player-section .player-controls {
     display: flex;


### PR DESCRIPTION
## Summary
- fix 16:9 player scaling so video isn't clipped
- update README docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68564b9188c0832783c5e013a989917c