### PR TITLE
Begrenzte Videolistenbreite

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Verbesserte Thumbnail-Ladefunktion:** Vorschaubilder werden über `i.ytimg.com` geladen und die gesamte Zeile ist zum Öffnen des Videos anklickbar.
 * **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
 * **Schlankerer Video-Manager:** URL-Eingabefeld unter den Buttons und eine klar beschriftete Aktions-Spalte. Der Player behält auf allen Monitoren sein 16:9-Format, ohne seitlichen Beschnitt, und die Steuerleiste bleibt sichtbar.
+* **Maximierte Listenbreite:** Die gespeicherten Videos beanspruchen nun maximal 480 px Breite. Titelspalte und Vorschaubild bleiben schlank und das Thumbnail hält stets das Seitenverhältnis 16:9.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 
 ### 📊 Fortschritts‑Tracking

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2448,6 +2448,7 @@ th:nth-child(6) {
 .video-list-section {
     /* Linke Tabellenansicht mit flexibler Höhe */
     width: 35%;
+    max-width: 480px; /* damit die Liste bei großen Fenstern nicht zu breit wird */
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -2559,7 +2560,10 @@ th:nth-child(6) {
     object-fit: cover;
     cursor: pointer;
 }
-.video-title { cursor: pointer; }
+.video-title {
+    cursor: pointer;
+    max-width: 26ch; /* reduziert die Breite der Titelspalte */
+}
 .video-actions button {
     margin: 0 2px;
     font-size: clamp(14px, 2.2vh, 20px);


### PR DESCRIPTION
## Zusammenfassung
- beschränke Breite der gespeicherten Video-Liste auf 480 px
- reduziere verfügbare Breite der Titelspalte
- erwähne die Änderung im README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68564caa5bd0832788a2a816f429d0c4