### PR TITLE
Verbesserte Dialoghöhe bei Video-Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
 * **Schlankerer Video-Manager:** URL-Eingabefeld unter den Buttons und eine klar beschriftete Aktions-Spalte. Der Player behält auf allen Monitoren sein 16:9-Format, ohne seitlichen Beschnitt, und die Steuerleiste bleibt sichtbar.
 * **Maximierte Listenbreite:** Die gespeicherten Videos beanspruchen nun maximal 480 px Breite. Titelspalte und Vorschaubild bleiben schlank und das Thumbnail hält stets das Seitenverhältnis 16:9.
-* **Dynamische Dialoghöhe:** Der Video-Manager schrumpft bei kurzen Listen und nutzt nur so viel Platz wie nötig.
+* **Verbesserte dynamische Dialoghöhe:** Der Video-Manager schrumpft nun auch bei kleinen Fenstern und entfernt überflüssigen Leerraum.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 
 ### 📊 Fortschritts‑Tracking

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2445,7 +2445,12 @@ th:nth-child(6) {
 
 /* Flex-Layout für Liste und Player,
    verteilt den verfügbaren Platz dynamisch */
-.video-layout { display: flex; gap: 1rem; flex: 1; overflow: hidden; }
+.video-layout {
+    /* Liste und Player nebeneinander ohne feste Höhe */
+    display: flex;
+    gap: 1rem;
+    overflow: hidden;
+}
 .video-list-section {
     /* Linke Tabellenansicht mit flexibler Höhe */
     width: 35%;
@@ -2456,10 +2461,9 @@ th:nth-child(6) {
 }
 .video-player-section {
     /* Rechter Bereich mit Player, passt sich der Dialoghöhe an */
-    flex: 1;
+    flex: 1 1 auto;
     display: flex;
     flex-direction: column;
-    height: 100%;
     overflow: hidden;
 }
 .video-player-section.hidden { display: none; }
@@ -2514,9 +2518,9 @@ th:nth-child(6) {
 }
 
 #videoTableWrapper {
-    /* Container für die Tabelle mit dynamischer Höhe */
-    flex: 1;
+    /* Container für die Tabelle: wächst bei Bedarf, sonst passt er sich an */
     overflow-y: auto;
+    max-height: 60vh;
 }
 
 #videoTable {
@@ -2536,7 +2540,6 @@ th:nth-child(6) {
 #videoTable thead th[data-asc="false"]::after { content: ' ▼'; }
 #videoTable tbody {
     display: block;
-    height: 100%;
     overflow-y: auto;
 }
 #videoTable tbody tr {


### PR DESCRIPTION
## Summary
- stelle Liste und Player ohne starre Höhe dar
- begrenze die Höhe der gespeicherten Videos
- entferne die 100%-Höhe der Tabelle
- erweitere README um die neue dynamische Dialoghöhe

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68565226e1a88327ba8b0cec0a0faefa