### PR TITLE
Verbesserte Größenanpassung im Video-Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Schlankerer Video-Manager:** URL-Eingabefeld unter den Buttons und eine klar beschriftete Aktions-Spalte. Der Player behält auf allen Monitoren sein 16:9-Format, ohne seitlichen Beschnitt, und die Steuerleiste bleibt sichtbar.
 * **Maximierte Listenbreite:** Die gespeicherten Videos beanspruchen nun maximal 480 px Breite. Titelspalte und Vorschaubild bleiben schlank und das Thumbnail hält stets das Seitenverhältnis 16:9.
 * **Verbesserte dynamische Dialoghöhe:** Der Video-Manager schrumpft nun auch bei kleinen Fenstern und entfernt überflüssigen Leerraum.
+* **Flexible Fenstergröße:** Liste und Player passen sich jetzt gemeinsam der tatsächlichen Höhe an.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 
 ### 📊 Fortschritts‑Tracking

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2450,6 +2450,7 @@ th:nth-child(6) {
     display: flex;
     gap: 1rem;
     overflow: hidden;
+    align-items: flex-start; /* höhenabhängige Bereiche schrumpfen nun korrekt */
 }
 .video-list-section {
     /* Linke Tabellenansicht mit flexibler Höhe */


### PR DESCRIPTION
## Zusammenfassung
- Video-Layout richtet sich nun am Inhalt aus
- README um neue Funktion zur flexiblen Fenstergröße ergänzt

## Testanweisungen
- `npm test` ausführen

------
https://chatgpt.com/codex/tasks/task_e_68565330212c83279d9481893df19b08