### PR TITLE
Add dynamische Größenanpassung für Video-Player

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Maximierte Listenbreite:** Die gespeicherten Videos beanspruchen nun maximal 480 px Breite. Titelspalte und Vorschaubild bleiben schlank und das Thumbnail hält stets das Seitenverhältnis 16:9.
 * **Verbesserte dynamische Dialoghöhe:** Der Video-Manager schrumpft nun auch bei kleinen Fenstern und entfernt überflüssigen Leerraum.
 * **Flexibles Fenster für gespeicherte Videos:** Höhe passt sich jetzt automatisch an Videoplayer und Liste an.
+* **Breitenbegrenzter Player:** Die Breite richtet sich nach der verfügbaren Höhe und überschreitet nie das Format 16:9.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 
 ### 📊 Fortschritts‑Tracking

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -66,28 +66,59 @@ ensureDialogSupport(videoMgrDialog);
 function adjustVideoDialogHeight() {
     const max = window.innerHeight * 0.9;
     videoMgrDialog.style.height = 'auto';
-    const benötigt = videoMgrDialog.scrollHeight;
-    videoMgrDialog.style.height = Math.min(benötigt, max) + 'px';
+    const benoetigt = videoMgrDialog.scrollHeight;
+    videoMgrDialog.style.height = Math.min(benoetigt, max) + 'px';
+    // danach den Player anpassen
+    if (typeof adjustVideoPlayerSize === 'function') {
+        adjustVideoPlayerSize();
+    }
 }
 // Funktion global verfügbar machen
 window.adjustVideoDialogHeight = adjustVideoDialogHeight;
 
+// passt den Videoplayer dynamisch an das 16:9-Format an
+function adjustVideoPlayerSize() {
+    const section = document.getElementById('videoPlayerSection');
+    const frame   = document.getElementById('videoPlayerFrame');
+    if (!section || !frame || section.classList.contains('hidden')) return;
+
+    const header   = section.querySelector('.player-header');
+    const controls = section.querySelector('.player-controls');
+    const frei = section.clientHeight
+        - (header ? header.offsetHeight : 0)
+        - (controls ? controls.offsetHeight : 0);
+    const maxBreite = frei * 16 / 9;
+    const bereichBreite = section.clientWidth;
+    const nutzBreite = Math.min(bereichBreite, maxBreite);
+    const nutzHoehe = nutzBreite * 9 / 16;
+
+    frame.style.width  = nutzBreite + 'px';
+    frame.style.height = nutzHoehe + 'px';
+}
+window.adjustVideoPlayerSize = adjustVideoPlayerSize;
+
 // auch bei Fenstergröße aktualisieren
-window.addEventListener('resize', adjustVideoDialogHeight);
+window.addEventListener('resize', () => {
+    adjustVideoDialogHeight();
+    adjustVideoPlayerSize();
+});
 
 openVideoManager.onclick = async () => {
     await refreshTable();
     videoMgrDialog.showModal();
     adjustVideoDialogHeight();
+    adjustVideoPlayerSize();
 };
 closeVideoDlg.onclick = () => {
     videoMgrDialog.close();
     if (typeof closeVideoDialog === 'function') closeVideoDialog();
     adjustVideoDialogHeight();
+    adjustVideoPlayerSize();
 };
 videoMgrDialog.addEventListener('cancel', () => {
     if (typeof closeVideoDialog === 'function') closeVideoDialog();
     adjustVideoDialogHeight();
+    adjustVideoPlayerSize();
 });
 document.addEventListener('keydown', e => {
     if (e.key === 'Escape' && videoMgrDialog.open) {

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -128,6 +128,9 @@ export function openVideoDialog(bookmark, index) {
     if (typeof window.adjustVideoDialogHeight === 'function') {
         window.adjustVideoDialogHeight();
     }
+    if (typeof window.adjustVideoPlayerSize === 'function') {
+        window.adjustVideoPlayerSize();
+    }
 }
 
 // schließt den Video-Dialog und speichert die Zeit
@@ -173,6 +176,9 @@ export async function closeVideoDialog() {
 
     if (typeof window.adjustVideoDialogHeight === 'function') {
         window.adjustVideoDialogHeight();
+    }
+    if (typeof window.adjustVideoPlayerSize === 'function') {
+        window.adjustVideoPlayerSize();
     }
 }
 


### PR DESCRIPTION
## Summary
- passe Player-Breite dynamisch an die verfügbare Höhe an
- sorge dafür, dass der Videoplayer nie breiter als 16:9 wird
- aktualisiere Dokumentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856567879dc8327ab61b7308bb1a36f