### PR TITLE
Improve video player resize handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Fehlerbehebung:** Der integrierte Player lässt sich mehrfach starten, ohne dass der `videoPlayerFrame` fehlt.
 * **Korrekte Spaltenbreite im Video-Manager:** Kopfzeile und Tabelle sind jetzt bündig, komplette Videotitel erscheinen als Tooltip.
 * **Dynamische Größenanpassung:** Dialog, Player und Buttons passen sich automatisch an die Fenstergröße an.
-* **Behobenes Resize-Problem:** Nach dem Verkleinern passt sich der Videoplayer nun auch wieder an, wenn das Fenster vergrößert wird.
+* **Behobenes Resize-Problem:** Nach einer Verkleinerung wächst der Videoplayer jetzt korrekt mit, sobald das Fenster wieder größer wird.
 * **Verbesserte Thumbnail-Ladefunktion:** Vorschaubilder werden über `i.ytimg.com` geladen und die gesamte Zeile ist zum Öffnen des Videos anklickbar.
 * **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
 * **Schlankerer Video-Manager:** URL-Eingabefeld unter den Buttons und eine klar beschriftete Aktions-Spalte. Der Player behält auf allen Monitoren sein 16:9-Format, ohne seitlichen Beschnitt, und die Steuerleiste bleibt sichtbar.

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -82,22 +82,30 @@ resizeObserver.observe(videoMgrDialog);
 
 // passt Höhe und Breite des Video-Managers dynamisch an
 function adjustVideoDialogHeight() {
-    // Zuerst den Player aktualisieren, damit scrollWidth korrekt berechnet wird
-    if (typeof adjustVideoPlayerSize === 'function') {
-        adjustVideoPlayerSize();
-    }
-
-    // Maximale Höhe: 90 % des Fensters
+    // Maximale Höhe auf 90 % des Fensters begrenzen
     const maxH = window.innerHeight * 0.9;
     videoMgrDialog.style.height = 'auto';
     const benoetigtH = videoMgrDialog.scrollHeight;
     videoMgrDialog.style.height = Math.min(benoetigtH, maxH) + 'px';
 
-    // Breite orientiert sich an Inhalt bzw. max. 90 % des Fensters
+    // Dialog vorübergehend auf Maximalbreite setzen
     const maxW = window.innerWidth * 0.9;
+    videoMgrDialog.style.width = maxW + 'px';
+
+    // Player anhand dieser Breite skalieren
+    if (typeof adjustVideoPlayerSize === 'function') {
+        adjustVideoPlayerSize();
+    }
+
+    // Benötigte Breite ermitteln und endgültig setzen
     videoMgrDialog.style.width = 'auto';
     const benoetigtW = videoMgrDialog.scrollWidth;
     videoMgrDialog.style.width = Math.min(benoetigtW, maxW) + 'px';
+
+    // Player erneut anpassen, falls sich die Breite geändert hat
+    if (typeof adjustVideoPlayerSize === 'function') {
+        adjustVideoPlayerSize();
+    }
 }
 // Funktion global verfügbar machen
 window.adjustVideoDialogHeight = adjustVideoDialogHeight;


### PR DESCRIPTION
## Summary
- fix resize logic in `adjustVideoDialogHeight` so the player grows again when the window expands
- update README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68565fbbd5f48327b9bcdd64eebb514b