### PR TITLE
Fix Videoplayer-Rückstellung

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Dynamische Größenanpassung:** Dialog, Player und Buttons passen sich automatisch an die Fenstergröße an.
 * **Behobenes Resize-Problem:** Nach einer Verkleinerung wächst der Videoplayer jetzt korrekt mit, sobald das Fenster wieder größer wird.
 * **Korrektes Skalieren nach erneutem Öffnen:** Der Player passt sich nach dem Wiedereinblenden automatisch an die aktuelle Fenstergröße an.
+* **Aktualisierung im Hintergrund:** Selbst bei geschlossenem Player wird die Größe im Hintergrund neu berechnet und beim nächsten Öffnen korrekt übernommen.
 * **Verbesserte Thumbnail-Ladefunktion:** Vorschaubilder werden über `i.ytimg.com` geladen und die gesamte Zeile ist zum Öffnen des Videos anklickbar.
 * **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
 * **Schlankerer Video-Manager:** URL-Eingabefeld unter den Buttons und eine klar beschriftete Aktions-Spalte. Der Player behält auf allen Monitoren sein 16:9-Format, ohne seitlichen Beschnitt, und die Steuerleiste bleibt sichtbar.

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -111,10 +111,13 @@ function adjustVideoDialogHeight() {
 window.adjustVideoDialogHeight = adjustVideoDialogHeight;
 
 // passt den Videoplayer dynamisch an das 16:9-Format an
-function adjustVideoPlayerSize() {
+// passt den Videoplayer dynamisch an das 16:9-Format an
+// "force" erzwingt die Berechnung auch im versteckten Zustand
+function adjustVideoPlayerSize(force = false) {
     const section = document.getElementById('videoPlayerSection');
     const frame   = document.getElementById('videoPlayerFrame');
-    if (!section || !frame || section.classList.contains('hidden')) return;
+    if (!section || !frame) return;
+    if (section.classList.contains('hidden') && !force) return;
 
     const header   = section.querySelector('.player-header');
     const controls = section.querySelector('.player-controls');
@@ -134,6 +137,8 @@ window.adjustVideoPlayerSize = adjustVideoPlayerSize;
 // auch bei Fenstergröße aktualisieren
 window.addEventListener('resize', () => {
     adjustVideoDialogHeight();
+    // Player auch im verborgenen Zustand neu skalieren
+    adjustVideoPlayerSize(true);
 });
 
 openVideoManager.onclick = async () => {

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -129,12 +129,14 @@ export function openVideoDialog(bookmark, index) {
         window.adjustVideoDialogHeight();
     }
     if (typeof window.adjustVideoPlayerSize === 'function') {
-        window.adjustVideoPlayerSize();
+        // beim Öffnen sofort skalieren
+        window.adjustVideoPlayerSize(true);
     }
     // nach dem Einblenden einen Tick warten und dann erneut skalieren
     window.requestAnimationFrame(() => {
         if (typeof window.adjustVideoPlayerSize === 'function') {
-            window.adjustVideoPlayerSize();
+            // nach dem Layout-Refresh erneut skalieren
+            window.adjustVideoPlayerSize(true);
         }
     });
 }
@@ -184,7 +186,8 @@ export async function closeVideoDialog() {
         window.adjustVideoDialogHeight();
     }
     if (typeof window.adjustVideoPlayerSize === 'function') {
-        window.adjustVideoPlayerSize();
+        // auch im geschlossenen Zustand Größe neu berechnen
+        window.adjustVideoPlayerSize(true);
     }
 }
 


### PR DESCRIPTION
## Zusammenfassung
- `adjustVideoPlayerSize` akzeptiert jetzt einen `force`-Parameter
- Videoplayer wird auch bei geschlossenem Dialog neu skaliert
- README um Hinweis zur Hintergrundaktualisierung ergänzt

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6856638c238c8327a58929c984e3a379