### PR TITLE
Fix Video-Player Skalierung

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Automatische Dialogbreite:** Ohne geöffneten Player richtet sich die Breite des Video-Managers nach der Liste.
 * **Flexibles Fenster für gespeicherte Videos:** Höhe passt sich jetzt automatisch an Videoplayer und Liste an.
 * **Breitenbegrenzter Player:** Die Breite richtet sich nach der verfügbaren Höhe und überschreitet nie das Format 16:9.
+* **Verbesserte Player-Anpassung:** Die Höhe des IFrames ergibt sich jetzt aus der Dialogbreite und wird auf 90 % der Fensterhöhe begrenzt. Zwei `requestAnimationFrame`-Aufrufe sorgen nach jedem Öffnen oder Resize für korrekte Maße.
 * **Fehlerfreies Skalieren nach Schließen:** Ändert man die Fenstergröße bei geschlossenem Dialog, berechnet das IFrame seine Breite beim nächsten Öffnen korrekt neu.
 * **Stabilerer ResizeObserver:** Die Dialog-Anpassung nutzt `requestAnimationFrame` und verhindert so die Fehlermeldung "ResizeObserver loop limit exceeded".
 * **Exportfunktion für Video-Bookmarks:** Gespeicherte Links lassen sich als `videoBookmarks.json` herunterladen.

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -80,6 +80,16 @@ const resizeObserver = new ResizeObserver(() => {
 });
 resizeObserver.observe(videoMgrDialog);
 
+function delayedPlayerResize() {
+    window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+            if (typeof adjustVideoPlayerSize === 'function') {
+                adjustVideoPlayerSize(true);
+            }
+        });
+    });
+}
+
 // passt Höhe und Breite des Video-Managers dynamisch an
 function adjustVideoDialogHeight() {
     // Maximale Höhe auf 90 % des Fensters begrenzen
@@ -106,6 +116,9 @@ function adjustVideoDialogHeight() {
     if (typeof adjustVideoPlayerSize === 'function') {
         adjustVideoPlayerSize();
     }
+
+    // nach dem Layout zwei Frames warten und erneut anpassen
+    delayedPlayerResize();
 }
 // Funktion global verfügbar machen
 window.adjustVideoDialogHeight = adjustVideoDialogHeight;
@@ -117,16 +130,25 @@ function adjustVideoPlayerSize(force = false) {
     const section = document.getElementById('videoPlayerSection');
     const frame   = document.getElementById('videoPlayerFrame');
     if (!section || !frame) return;
-    if (section.classList.contains('hidden') && !force) return;
 
     const header   = section.querySelector('.player-header');
     const controls = section.querySelector('.player-controls');
-    const frei = section.clientHeight
+
+    // verfügbare Breite heranziehen
+    const breite = section.clientWidth;
+    let   hoehe  = breite * 9 / 16;
+
+    // maximale Höhe: 90 % des Fensters abzüglich Header und Steuerleiste
+    const maxH = window.innerHeight * 0.9
         - (header ? header.offsetHeight : 0)
         - (controls ? controls.offsetHeight : 0);
 
-    // Breite wird per CSS auf 100 % gesetzt, hier nur die maximale Höhe anpassen
-    frame.style.maxHeight = frei + 'px';
+    if (hoehe > maxH) {
+        hoehe = maxH;
+    }
+
+    // Breite bleibt flexibel, nur die maximale Höhe wird gesetzt
+    frame.style.maxHeight = hoehe + 'px';
 }
 window.adjustVideoPlayerSize = adjustVideoPlayerSize;
 

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -132,12 +132,13 @@ export function openVideoDialog(bookmark, index) {
         // beim Öffnen sofort skalieren
         window.adjustVideoPlayerSize(true);
     }
-    // nach dem Einblenden einen Tick warten und dann erneut skalieren
+    // zwei Layout-Ticks warten und erneut anpassen
     window.requestAnimationFrame(() => {
-        if (typeof window.adjustVideoPlayerSize === 'function') {
-            // nach dem Layout-Refresh erneut skalieren
-            window.adjustVideoPlayerSize(true);
-        }
+        window.requestAnimationFrame(() => {
+            if (typeof window.adjustVideoPlayerSize === 'function') {
+                window.adjustVideoPlayerSize(true);
+            }
+        });
     });
 }
 


### PR DESCRIPTION
## Summary
- verbessere Player-Berechnung von `adjustVideoPlayerSize`
- warte nach jeder Dialoggrößenänderung zwei `requestAnimationFrame`
- passe `openVideoDialog` entsprechend an
- dokumentiere neues Verhalten

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856770a00ac8327a53188e0c985edb8