### PR TITLE
Verbesserte Video-Steuerleiste

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Responsiver Video-Manager:** Fester Dialog-Abstand, flexible Toolbar mit Min-Buttons und kompaktem ❌-Icon bei schmaler Breite. Tabellenzeilen besitzen gleichmäßiges Padding und einen Hover-Effekt.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 * **Flexible Player-Steuerleiste:** Bei schmalen Fenstern rutscht der Slider in eine zweite Zeile. Icons und Zeitangaben verkleinern sich automatisch.
+* **Fixierte Steuerleiste im Player:** Die Bedienelemente bleiben am unteren Rand verankert und sind immer erreichbar. Die Liste nutzt variabel 22 % Breite (min. 260 px, max. 320 px).
 
 ### 📊 Fortschritts‑Tracking
 

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -145,6 +145,11 @@ function adjustVideoPlayerSize(force = false) {
         - (header ? header.offsetHeight : 0)
         - (controls ? controls.offsetHeight : 0);
 
+    // Bereich unter dem Video fuer die Steuerleiste reservieren
+    if (controls) {
+        section.style.paddingBottom = controls.offsetHeight + 'px';
+    }
+
     if (hoehe > maxH) {
         hoehe = maxH;
     }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2475,7 +2475,7 @@ th:nth-child(6) {
     #closeVideoDlg { display: none; }
     .close-icon { display: inline-flex; }
     .close-icon.btn { padding: 4px 6px; }
-    .player-controls span { font-size: 0.9rem; }
+    .player-controls span { font-size: 0.8rem; }
 }
 
 /* Flex-Layout für Liste und Player,
@@ -2483,13 +2483,14 @@ th:nth-child(6) {
 .video-layout {
     /* Liste und Player nebeneinander ohne feste Höhe */
     display: flex;
-    gap: 1rem;
+    gap: 8px;
     overflow: hidden;
 }
 .video-list-section {
-    /* Linke Tabellenansicht mit flexibler Höhe */
-    width: 35%;
-    max-width: 480px; /* damit die Liste bei großen Fenstern nicht zu breit wird */
+    /* Linke Tabellenansicht mit flexibler Höhe und variabler Breite */
+    flex: 0 0 22%;
+    min-width: 260px;
+    max-width: 320px;
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -2500,6 +2501,8 @@ th:nth-child(6) {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    position: relative; /* Steuerleiste am unteren Rand fixieren */
+    padding-bottom: 56px; /* Platz für die Steuerleiste */
 }
 .video-player-section.hidden { display: none; }
 
@@ -2516,6 +2519,13 @@ th:nth-child(6) {
     background: #242424;
     font-weight: bold;
     box-shadow: 0 2px 4px rgba(0,0,0,0.5);
+    overflow: hidden; /* Titel kann abgeschnitten werden */
+}
+.video-player-section .player-header span {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 .video-player-section iframe {
     /* Video skaliert flexibel und behält 16:9 ohne feste Höhe */
@@ -2536,11 +2546,15 @@ th:nth-child(6) {
     padding: 0.5rem 1rem;
     background: #242424;
     box-shadow: 0 -2px 4px rgba(0,0,0,0.5);
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
 }
 .video-player-section .player-controls input[type=range] {
-    /* Slider darf schrumpfen, bleibt aber mindestens 150px breit */
-    flex: 1 1 150px;
-    min-width: 150px;
+    /* Slider darf schrumpfen, bleibt aber mindestens 140px breit */
+    flex: 1 1 140px;
+    min-width: 140px;
 }
 .video-player-section .player-controls button {
     /* Buttons behalten feste Breite und rutschen einfach um */
@@ -2561,7 +2575,7 @@ th:nth-child(6) {
 }
 
 /* Kleinere Dialoge: Icons und Zeitangaben verkleinern */
-@media (max-width: 500px) {
+@media (max-width: 600px) {
     .video-player-section .player-controls button {
         font-size: 24px;
         width: 24px;


### PR DESCRIPTION
## Summary
- Toolbar des eingebetteten Players fest am unteren Rand positioniert
- Slider bricht flexibel um und nutzt kleinere Mindestbreite
- Listenbereich mit variabler Breite und 8 px Abstand
- Titelzeile des Players mit Auslassungszeichen
- README um neue Funktionen erweitert

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68567cee87b8832786b1c96e2e0bb6ec