### PR TITLE
Fix OCR overlay position and capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 * **Flexible Player-Steuerleiste:** Bei schmalen Fenstern rutscht der Slider in eine zweite Zeile. Icons und Zeitangaben verkleinern sich automatisch.
 * **Fixierte Steuerleiste im Player:** Die Bedienelemente bleiben am unteren Rand verankert und sind immer erreichbar. Die Liste nutzt variabel 22 % Breite (min. 260 px, max. 320 px).
-* **OCR-Funktion im Player:** Mit einem Overlay lassen sich Untertitel per F9 oder Auto-Modus auslesen und im Panel rechts sammeln.
+* **OCR-Funktion im Player:** Mit einem Overlay lassen sich Untertitel per F9 oder Auto-Modus auslesen und im Panel rechts sammeln. Der OCR-Bereich richtet sich jetzt exakt nach dem IFrame, Steuerbuttons bleiben frei.
 
 ### 📊 Fortschritts‑Tracking
 

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -156,6 +156,9 @@ function adjustVideoPlayerSize(force = false) {
 
     // Breite bleibt flexibel, nur die maximale Höhe wird gesetzt
     frame.style.maxHeight = hoehe + 'px';
+    if (typeof window.updateOcrOverlay === 'function') {
+        window.updateOcrOverlay();
+    }
 }
 window.adjustVideoPlayerSize = adjustVideoPlayerSize;
 
@@ -164,6 +167,9 @@ window.addEventListener('resize', () => {
     adjustVideoDialogHeight();
     // Player auch im verborgenen Zustand neu skalieren
     adjustVideoPlayerSize(true);
+    if (typeof window.updateOcrOverlay === 'function') {
+        window.updateOcrOverlay();
+    }
 });
 
 openVideoManager.onclick = async () => {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2485,6 +2485,7 @@ th:nth-child(6) {
     display: flex;
     gap: 8px;
     overflow: hidden;
+    position: relative; /* erlaubt absolut positionierte OCR-Spalte */
 }
 .video-list-section {
     /* Linke Tabellenansicht mit flexibler Höhe und variabler Breite */
@@ -2503,6 +2504,7 @@ th:nth-child(6) {
     overflow: hidden;
     position: relative; /* Steuerleiste am unteren Rand fixieren */
     padding-bottom: 56px; /* Platz für die Steuerleiste */
+    margin-right: 16%; /* Platz fuer das OCR-Panel */
 }
 .video-player-section.hidden { display: none; }
 
@@ -2676,10 +2678,6 @@ th:nth-child(6) {
 /* ===== OCR-Funktionen ===== */
 #ocrOverlay {
     position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    height: 20%;
     background: rgba(0,128,255,.25);
     border: 2px dashed #fff;
     pointer-events: none;
@@ -2691,13 +2689,20 @@ th:nth-child(6) {
 }
 
 #ocrResultPanel {
-    flex: 0 0 160px;
-    min-width: 160px;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 16%;
+    min-width: 140px;
+    height: 100%;
     display: flex;
     flex-direction: column;
+    overflow: auto;
 }
 #ocrResultPanel textarea {
     width: 100%;
     flex: 1 1 auto;
+    overflow: auto;
+    white-space: pre-wrap;
 }
 


### PR DESCRIPTION
## Summary
- justiere den OCR-Bereich exakt auf das IFrame
- beschneide Screenshots nur auf den Videoausschnitt
- stoppe Auto-OCR nach Treffer und pausiere das Video
- positioniere das OCR-Panel absolut und passe die Breite an
- aktualisiere README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856816abe44832793206509caf83cd6