### PR TITLE
Improve OCR overlay and panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 * **Flexible Player-Steuerleiste:** Bei schmalen Fenstern rutscht der Slider in eine zweite Zeile. Icons und Zeitangaben verkleinern sich automatisch.
 * **Fixierte Steuerleiste im Player:** Die Bedienelemente bleiben am unteren Rand verankert und sind immer erreichbar. Die Liste nutzt variabel 22 % Breite (min. 260 px, max. 320 px).
-* **OCR-Funktion im Player:** Mit einem Overlay lassen sich Untertitel per F9 oder Auto-Modus auslesen und im Panel rechts sammeln. Der OCR-Bereich richtet sich jetzt exakt nach dem IFrame, Steuerbuttons bleiben frei.
+* **OCR-Funktion im Player:** Ein präzises Overlay deckt nur die Untertitel ab. F9 oder der Auto-Modus schneiden den Screenshot exakt zu, pausieren bei einem Treffer das Video und sammeln den Text im rechten Panel. Nach erneutem Abspielen läuft die Erkennung automatisch weiter.
 
 ### 📊 Fortschritts‑Tracking
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -574,9 +574,9 @@
                     <button id="videoClose">❌</button>
                 </div>
                 <div id="ocrOverlay"></div>
-            </div>
-            <div id="ocrResultPanel">
-                <textarea id="ocrText" rows="10" readonly></textarea>
+                <div id="ocrResultPanel">
+                    <textarea id="ocrText" rows="10" readonly></textarea>
+                </div>
             </div>
         </div>
     </dialog>

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -154,7 +154,13 @@ function adjustVideoPlayerSize(force = false) {
         hoehe = maxH;
     }
 
-    // Breite bleibt flexibel, nur die maximale Höhe wird gesetzt
+    // Breite des OCR-Panels beruecksichtigen
+    const panel = document.getElementById('ocrResultPanel');
+    const panelW = panel ? Math.max(160, section.clientWidth * 0.22) : 0;
+    if (panel) panel.style.width = panelW + 'px';
+
+    // IFrame anpassen und maximale Hoehe setzen
+    frame.style.width = `calc(100% - ${panelW}px)`;
     frame.style.maxHeight = hoehe + 'px';
     if (typeof window.updateOcrOverlay === 'function') {
         window.updateOcrOverlay();

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2504,7 +2504,6 @@ th:nth-child(6) {
     overflow: hidden;
     position: relative; /* Steuerleiste am unteren Rand fixieren */
     padding-bottom: 56px; /* Platz für die Steuerleiste */
-    margin-right: 16%; /* Platz fuer das OCR-Panel */
 }
 .video-player-section.hidden { display: none; }
 
@@ -2688,21 +2687,36 @@ th:nth-child(6) {
     display: block;
 }
 
+#ocrToggle.active {
+    background: #3399ff;
+    color: #fff;
+}
+
+#ocrToggle.blink {
+    animation: pulse 1s infinite;
+}
+
 #ocrResultPanel {
     position: absolute;
     right: 0;
     top: 0;
-    width: 16%;
-    min-width: 140px;
     height: 100%;
+    min-width: 160px;
+    max-width: 22%;
+    background: #111;
+    color: #e0e0e0;
     display: flex;
     flex-direction: column;
-    overflow: auto;
+    overflow-y: auto;
 }
 #ocrResultPanel textarea {
     width: 100%;
     flex: 1 1 auto;
-    overflow: auto;
+    overflow-y: auto;
     white-space: pre-wrap;
+    background: #111;
+    color: #e0e0e0;
+    border: none;
+    resize: none;
 }
 


### PR DESCRIPTION
## Summary
- refine overlay positioning using iframe bounds
- crop OCR grabs to overlay region
- extend auto OCR loop with pause/resume logic and UI feedback
- adjust player width to spare space for OCR panel
- style OCR toggle and result panel
- document the improved OCR workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685682deb1e08327b4bd5a5f8a125fad