### PR TITLE
Maintain minimal player size

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Feinschliff am OCR‑Panel:** Breite clamped, Panel überlappt keine Buttons mehr, Text scrollt automatisch und der 🔍‑Button blinkt kurz bei einem Treffer.
 * **Exakte Video-Positionierung:** Playerbreite, Steuerleiste und Overlay richten sich nun dynamisch nach Dialog- und Panelgröße aus. Das IFrame skaliert dabei rein per CSS und die Berechnung läuft auch im versteckten Zustand.
 * **Vollbreite ohne OCR:** Das Ergebnis-Panel bleibt standardmäßig verborgen und erscheint nur bei aktivierter Erkennung.
+* **Immer sichtbarer Player:** Eine Mindestgröße von 320×180 verhindert, dass der eingebettete Player verschwindet.
 
 ### 📊 Fortschritts‑Tracking
 

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -130,6 +130,9 @@ let layoutData = {};
 
 // ermittelt Breite und Höhe des verfügbaren Bereichs
 function calcUsableWidthHeight() {
+    const MIN_H = 180; // minimale Höhe für den Player
+    const MIN_W = 320; // minimale Breite für den Player
+
     const dlg      = document.getElementById('videoMgrDialog');
     const list     = document.querySelector('.video-list-section');
     const panel    = document.getElementById('ocrResultPanel');
@@ -155,6 +158,16 @@ function calcUsableWidthHeight() {
         width = height * 16 / 9;
     }
 
+    // Mindestgroesse erzwingen
+    if (width < MIN_W) {
+        width  = MIN_W;
+        height = width * 9 / 16;
+    }
+    if (height < MIN_H) {
+        height = MIN_H;
+        width  = height * 16 / 9;
+    }
+
     layoutData = { width, height, leftListWidth, panelWidth, pad, controlsH };
 }
 
@@ -162,10 +175,9 @@ function calcUsableWidthHeight() {
 function positionIframe() {
     const frame = document.getElementById('videoPlayerFrame');
     if (!frame) return;
-    // Breite und Höhe regelt jetzt komplett das CSS
-    const rect = frame.getBoundingClientRect();
-    layoutData.width  = rect.width;
-    layoutData.height = rect.height;
+    // Groesse laut Berechnung setzen
+    frame.style.width  = layoutData.width + 'px';
+    frame.style.height = layoutData.height + 'px';
 }
 
 // platziert die Steuerleiste direkt unter dem IFrame


### PR DESCRIPTION
## Summary
- prevent player from shrinking below `320x180`
- apply minimum dimensions to iframe
- document that player always remains visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856b9523f088327994206a485258e3a