### PR TITLE
Add OCR overlay visibility test

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Löschen per Desktop-API:** Einzelne Bookmarks lassen sich nun über einen zusätzlichen IPC-Kanal entfernen.
 * **Tests für Video-Bookmarks:** Überprüfen Laden, Sortierung sowie Hinzufügen und Entfernen von Einträgen.
 * **Tests für den YouTube-Player:** Prüfen Speicherung über das Intervall, Löschfunktion sowie Dialog und Slider.
+* **Test für OCR-Overlay-Sichtbarkeit:** Stellt sicher, dass Overlay und Ergebnis-Panel korrekt ein- und ausgeblendet werden.
 * **Prüfung von Video-Links:** Eingaben müssen mit `https://` beginnen und dürfen keine Leerzeichen enthalten.
 * **Duplikat-Prüfung & dauerhafte Speicherung im Nutzerordner**
 * **Automatische YouTube-Titel:** Beim Hinzufügen lädt das Tool den Videotitel per oEmbed und sortiert die Liste alphabetisch. Schlägt dies fehl, wird die eingegebene URL als Titel gespeichert.

--- a/tests/ocrOverlayVisibility.test.js
+++ b/tests/ocrOverlayVisibility.test.js
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// Hilfsfunktion zum Laden der Player-Funktionen
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+function loadModule() {
+    const code = fs.readFileSync(path.join(__dirname, '../web/ytPlayer.js'), 'utf8')
+        .replace(/export\s+(async\s+)?function/g, '$1function');
+    const sandbox = { module: { exports: {} }, window, document, setInterval, clearInterval, YT: window.YT };
+    vm.runInNewContext(code, sandbox);
+    return sandbox.module.exports;
+}
+
+describe('OCR-Overlay sichtbar schalten', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        document.body.innerHTML = `
+            <dialog id="videoMgrDialog">
+                <div id="videoPlayerSection" class="video-player-section">
+                    <span id="playerDialogTitle"></span>
+                    <iframe id="videoPlayerFrame"></iframe>
+                    <input type="range" id="videoSlider" />
+                    <span id="videoCurrent"></span>
+                    <span id="videoDuration"></span>
+                    <button id="videoPlay"></button>
+                    <button id="videoBack"></button>
+                    <button id="videoForward"></button>
+                    <button id="videoReload"></button>
+                    <button id="ocrToggle"></button>
+                    <button id="videoDelete"></button>
+                    <button id="videoClose"></button>
+                    <div id="ocrOverlay" class="hidden"></div>
+                    <div id="ocrResultPanel" class="hidden"><pre id="ocrText"></pre></div>
+                </div>
+            </dialog>`;
+        window.videoApi = { loadBookmarks: async () => [], saveBookmarks: async () => true };
+        const dlg = document.getElementById('videoMgrDialog');
+        dlg.showModal = jest.fn();
+        window.dialogPolyfill = null;
+        window.YT = {
+            Player: jest.fn(() => ({
+                getDuration: () => 100,
+                getCurrentTime: () => 10,
+                getPlayerState: () => 1,
+                seekTo: jest.fn(),
+                pauseVideo: jest.fn(),
+                playVideo: jest.fn()
+            })),
+            PlayerState: { PLAYING: 1, PAUSED: 2, CUED: 5 }
+        };
+    });
+
+    test('OCR-Overlay und Panel werden ein- und ausgeblendet', () => {
+        const { openVideoDialog } = loadModule();
+        const bookmark = { url: 'https://youtu.be/xyz', title: 't', time: 0 };
+        openVideoDialog(bookmark, 0);
+        const ocrBtn = document.getElementById('ocrToggle');
+        const overlay = document.getElementById('ocrOverlay');
+        const panel = document.getElementById('ocrResultPanel');
+
+        // nach dem Öffnen sind beide Elemente versteckt
+        expect(overlay.classList.contains('hidden')).toBe(true);
+        expect(panel.classList.contains('hidden')).toBe(true);
+
+        // Aktivieren
+        ocrBtn.click();
+        expect(overlay.classList.contains('hidden')).toBe(false);
+        expect(panel.classList.contains('hidden')).toBe(false);
+
+        // Deaktivieren
+        ocrBtn.click();
+        expect(overlay.classList.contains('hidden')).toBe(true);
+        expect(panel.classList.contains('hidden')).toBe(true);
+    });
+});

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -244,12 +244,18 @@ export function openVideoDialog(bookmark, index) {
     const reloadBtn = document.getElementById('videoReload');
     const ocrBtn = document.getElementById('ocrToggle');
     const ocrOverlay = document.getElementById('ocrOverlay');
+    const ocrPanel = document.getElementById('ocrResultPanel');
     const deleteBtn = document.getElementById('videoDelete');
     const closeBtn = document.getElementById('videoClose');
 
     if (ocrBtn) {
+        // Standardzustand ohne aktive OCR
         ocrBtn.title = 'OCR aktivieren (F9)';
+        ocrBtn.classList.remove('active');
     }
+    player.classList.remove('ocr-active');
+    if (ocrOverlay) ocrOverlay.classList.add('hidden');
+    if (ocrPanel) ocrPanel.classList.add('hidden');
 
     function formatTime(sec){
         const m=Math.floor(sec/60); const s=Math.floor(sec%60); return m+':'+('0'+s).slice(-2);
@@ -309,8 +315,15 @@ export function openVideoDialog(bookmark, index) {
     if (ocrBtn) {
         ocrBtn.onclick = () => {
             ocrBtn.classList.toggle('active');
-            player.classList.toggle('ocr-active', ocrBtn.classList.contains('active'));
-            if (ocrBtn.classList.contains('active')) {
+            const active = ocrBtn.classList.contains('active');
+            player.classList.toggle('ocr-active', active);
+            if (ocrOverlay) {
+                ocrOverlay.classList.toggle('hidden', !active);
+            }
+            if (ocrPanel) {
+                ocrPanel.classList.toggle('hidden', !active);
+            }
+            if (active) {
                 ocrBtn.title = 'OCR an/aus (F9)';
                 startAutoLoop();
             } else {
@@ -382,7 +395,11 @@ export async function closeVideoDialog() {
     const frame = document.getElementById('videoPlayerFrame');
     if (frame) frame.src = '';
     const ocrBtn = document.getElementById('ocrToggle');
+    const ocrOverlay = document.getElementById('ocrOverlay');
+    const ocrPanel = document.getElementById('ocrResultPanel');
     if (ocrBtn) ocrBtn.classList.remove('active');
+    if (ocrOverlay) ocrOverlay.classList.add('hidden');
+    if (ocrPanel) ocrPanel.classList.add('hidden');
     player.classList.remove('ocr-active');
     terminateOcr();
 


### PR DESCRIPTION
## Summary
- ensure OCR overlay and result panel toggle visibility
- document new test in README
- hide and show OCR elements via JS when toggling
- add automated test for OCR overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856ba6d85188327842c1156a9000f83