### PR TITLE
Fix OCR worker initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Korrektur der OCR-Breite:** Der blaue Rahmen deckt jetzt die komplette Videobreite ab.
 * **Neues OCR-Pop‑up:** Erkennt die OCR Text, pausiert das Video und öffnet ein separates Fenster mit dem gefundenen Text.
 * **Tesseract.js nun lokal eingebunden:** Die OCR-Engine wird direkt aus `src/lib` geladen und funktioniert damit auch ohne Internetzugang.
+* **Stabilere OCR-Initialisierung:** Das Tesseract-Modul wird nun korrekt importiert und die Worker starten zuverlässig.
 * **Exakte Video-Positionierung:** Playerbreite, Steuerleiste und Overlay richten sich nun dynamisch nach Dialog- und Panelgröße aus. Das IFrame skaliert dabei rein per CSS und die Berechnung läuft auch im versteckten Zustand.
 * **Vollbreite ohne OCR:** Das Ergebnis-Panel bleibt standardmäßig verborgen und erscheint nur bei aktivierter Erkennung.
 * **Immer sichtbarer Player:** Eine Mindestgröße von 320×180 verhindert, dass der eingebettete Player verschwindet.

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -35,8 +35,10 @@ async function initOcrWorker() {
     if (ocrWorker) return true;
     try {
         // tesseract.js wird lokal geladen, damit die OCR auch ohne Internet funktioniert
-        const t = await import('./src/lib/tesseract.esm.min.js');
-        ocrWorker = t.createWorker();
+        // Modul laden und createWorker extrahieren (Default- oder Named-Export)
+        const mod = await import('./src/lib/tesseract.esm.min.js');
+        const { createWorker } = mod.default || mod;
+        ocrWorker = createWorker();
         await ocrWorker.load();
         await ocrWorker.loadLanguage('eng');
         await ocrWorker.initialize('eng');


### PR DESCRIPTION
## Summary
- import Tesseract worker correctly when only default export is provided
- update README to note more stable OCR initialisation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6856c5d5be10832785cd8c77e9b225d7