### PR TITLE
Bugfix: OCR Worker verwendet absolute URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Tesseract.js nun lokal eingebunden:** Die OCR-Engine wird direkt aus `src/lib` geladen und funktioniert damit auch ohne Internetzugang.
 * **Stabilere OCR-Initialisierung:** Das Tesseract-Modul wird nun korrekt importiert und die Worker starten zuverlässig.
 * **Lokaler Worker-Pfad festgelegt:** Die OCR lädt den Worker jetzt direkt aus `src/lib/tesseract-worker.min.js` und benötigt daher keine externen Skripte.
+* **Absolute Worker-URL:** Der Pfad wird jetzt relativ zum Fenster berechnet und verhindert CSP-Fehler.
 * **Exakte Video-Positionierung:** Playerbreite, Steuerleiste und Overlay richten sich nun dynamisch nach Dialog- und Panelgröße aus. Das IFrame skaliert dabei rein per CSS und die Berechnung läuft auch im versteckten Zustand.
 * **Vollbreite ohne OCR:** Das Ergebnis-Panel bleibt standardmäßig verborgen und erscheint nur bei aktivierter Erkennung.
 * **Immer sichtbarer Player:** Eine Mindestgröße von 320×180 verhindert, dass der eingebettete Player verschwindet.

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -38,9 +38,11 @@ async function initOcrWorker() {
         // Modul laden und createWorker extrahieren (Default- oder Named-Export)
         const mod = await import('./src/lib/tesseract.esm.min.js');
         const { createWorker } = mod.default || mod;
-        // Worker-Pfad explizit setzen, damit kein externer Download noetig ist
+        // Worker-Pfad absolut aufloesen, damit er auch in Electron korrekt
+        // gefunden wird und keine externen Skripte benoetigt werden
+        const workerUrl = new URL('./src/lib/tesseract-worker.min.js', window.location.href).href;
         ocrWorker = createWorker({
-            workerPath: './src/lib/tesseract-worker.min.js'
+            workerPath: workerUrl
         });
         await ocrWorker.load();
         await ocrWorker.loadLanguage('eng');


### PR DESCRIPTION
## Zusammenfassung
- OCR-Worker initialisiert nun mit absolutem Pfad
- Hinweis im README zu neuer Pfadlogik

## Testanweisungen
- `npm test` ausführen

------
https://chatgpt.com/codex/tasks/task_e_6856ca6d37ec8327a6aa3ebb53d26006