### PR TITLE
Fix CSP for local OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Seit Patch 1.40.43 verschwindet der YouTube-Player nicht mehr, wenn man dasselbe
 Seit Patch 1.40.44 entfällt das separate Element `ytPlayerBox`; der Player wird nun direkt im Dialog erzeugt.
 Seit Patch 1.40.45 erlaubt die Content Security Policy nun Web Worker aus `blob:`-URLs. Dadurch funktioniert die OCR wieder fehlerfrei.
 Seit Patch 1.40.46 darf die Content Security Policy auch Skripte von `cdn.jsdelivr.net` laden. Damit startet der Tesseract-Worker ohne Fehlermeldung.
+Seit Patch 1.40.47 erlaubt die Content Security Policy nun zusätzlich `'unsafe-eval'` und `'data:'` in den passenden Direktiven. Dadurch läuft die OCR ohne CSP-Fehler.
 
 Beispiel einer gültigen CSV:
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -6,7 +6,7 @@
     <title>Half-Life: Alyx Translation Tool</title>
     <!-- Sicherheitsrichtlinie für Electron: verhindert Warnhinweise -->
     <!-- CSP angepasst: erlaubt nun Inline-Skripte -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; img-src 'self' https://i.ytimg.com; connect-src 'self' https://api.elevenlabs.io; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://www.youtube.com https://cdn.jsdelivr.net; worker-src 'self' blob: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; media-src 'self' blob:; frame-src https://www.youtube.com https://www.youtube-nocookie.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; img-src 'self' https://i.ytimg.com; connect-src 'self' data: https://api.elevenlabs.io; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://www.youtube.com https://cdn.jsdelivr.net; worker-src 'self' blob: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; media-src 'self' blob:; frame-src https://www.youtube.com https://www.youtube-nocookie.com;">
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- allow data URLs and wasm eval for OCR WebAssembly
- document updated CSP requirements in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856cb9aac4083278b2cbccdb8b2c1c6