### PR TITLE
Fix CSP for Tesseract

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Seit Patch 1.40.44 entfällt das separate Element `ytPlayerBox`; der Player wird
 Seit Patch 1.40.45 erlaubt die Content Security Policy nun Web Worker aus `blob:`-URLs. Dadurch funktioniert die OCR wieder fehlerfrei.
 Seit Patch 1.40.46 darf die Content Security Policy auch Skripte von `cdn.jsdelivr.net` laden. Damit startet der Tesseract-Worker ohne Fehlermeldung.
 Seit Patch 1.40.47 erlaubt die Content Security Policy nun zusätzlich `'unsafe-eval'` und `'data:'` in den passenden Direktiven. Dadurch läuft die OCR ohne CSP-Fehler.
+Seit Patch 1.40.48 akzeptiert die Richtlinie auch `tessdata.projectnaptha.com`, damit Tesseract seine Sprachdaten herunterladen kann.
 
 Beispiel einer gültigen CSV:
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Half-Life: Alyx Translation Tool</title>
     <!-- Sicherheitsrichtlinie für Electron: verhindert Warnhinweise -->
-    <!-- CSP angepasst: erlaubt nun Inline-Skripte -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; img-src 'self' https://i.ytimg.com; connect-src 'self' data: https://api.elevenlabs.io; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://www.youtube.com https://cdn.jsdelivr.net; worker-src 'self' blob: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; media-src 'self' blob:; frame-src https://www.youtube.com https://www.youtube-nocookie.com;">
+    <!-- CSP angepasst: erlaubt Inline-Skripte und Tesseract-Downloads -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; img-src 'self' https://i.ytimg.com; connect-src 'self' data: https://api.elevenlabs.io https://tessdata.projectnaptha.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://www.youtube.com https://cdn.jsdelivr.net; worker-src 'self' blob: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; media-src 'self' blob:; frame-src https://www.youtube.com https://www.youtube-nocookie.com;">
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- erlauben Datenabruf von `tessdata.projectnaptha.com`
- Dokumentation zu neuer CSP-Domain in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856d023b9308327a4b9481cb05963b3