### PR TITLE
Fix desktopCapturer check in OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Immer sichtbarer Player:** Eine Mindestgröße von 320×180 verhindert, dass der eingebettete Player verschwindet.
 * **Canvas-Fallback bei der OCR:** Falls `ImageCapture` versagt, wird der Screenshot über einen Canvas erstellt.
 * **Desktop-Capturer in Electron:** Die OCR nutzt nun `desktopCapturer` für zuverlässige Bildschirmaufnahmen.
+* **Prüfung auf fehlende `getSources`-Methode:** Fehlt diese Funktion, greift die OCR automatisch auf `getDisplayMedia` zurück.
 
 ### 📊 Fortschritts‑Tracking
 

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -112,7 +112,8 @@ async function captureAndOcr() {
         } catch(e) {}
 
         if (!fromFrame) {
-            if (window.desktopCapturer) {
+            // Nur nutzen, wenn der Desktop-Capturer samt Methode vorhanden ist
+            if (window.desktopCapturer && typeof window.desktopCapturer.getSources === 'function') {
                 const src = (await window.desktopCapturer.getSources({ types: ['screen'] }))[0];
                 const stream = await navigator.mediaDevices.getUserMedia({
                     audio: false,


### PR DESCRIPTION
## Summary
- avoid desktopCapturer errors by checking for getSources
- document fallback behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856d416d0f08327b700e1c64a0bc74e