### PR TITLE
Fix CSP for Tesseract

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Seit Patch 1.40.46 darf die Content Security Policy auch Skripte von `cdn.jsdeli
 Seit Patch 1.40.47 erlaubt die Content Security Policy nun zusätzlich `'unsafe-eval'` und `'data:'` in den passenden Direktiven. Dadurch läuft die OCR ohne CSP-Fehler.
 Seit Patch 1.40.48 akzeptiert die Richtlinie auch `tessdata.projectnaptha.com`, damit Tesseract seine Sprachdaten herunterladen kann.
 Seit Patch 1.40.49 entfernt die Content Security Policy `'unsafe-eval'` wieder, da alle eingebundenen Bibliotheken ohne diese Option auskommen. Dadurch entfallen die Sicherheitshinweise beim Start.
+Seit Patch 1.40.50 fügt die Richtlinie `'unsafe-eval'` erneut hinzu, damit der Tesseract-Worker ohne Fehler startet.
 
 Beispiel einer gültigen CSV:
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Half-Life: Alyx Translation Tool</title>
     <!-- Sicherheitsrichtlinie für Electron: verhindert Warnhinweise -->
-    <!-- CSP angepasst: erlaubt Inline-Skripte und Tesseract-Downloads -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; img-src 'self' https://i.ytimg.com; connect-src 'self' data: https://api.elevenlabs.io https://tessdata.projectnaptha.com; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://www.youtube.com https://cdn.jsdelivr.net; worker-src 'self' blob: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; media-src 'self' blob:; frame-src https://www.youtube.com https://www.youtube-nocookie.com;">
+    <!-- CSP angepasst: erlaubt Inline-Skripte, Tesseract-Downloads und 'unsafe-eval' -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; img-src 'self' https://i.ytimg.com; connect-src 'self' data: https://api.elevenlabs.io https://tessdata.projectnaptha.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://www.youtube.com https://cdn.jsdelivr.net; worker-src 'self' blob: https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; media-src 'self' blob:; frame-src https://www.youtube.com https://www.youtube-nocookie.com;">
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- allow `'unsafe-eval'` again so that Tesseract's WebAssembly worker can load
- document the CSP change in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856d6d76a748327a34e2c3a7035b703