### PR TITLE
Fixierte Player-Leiste

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Responsiver Video-Manager:** Fester Dialog-Abstand, flexible Toolbar mit Min-Buttons und kompaktem ❌-Icon bei schmaler Breite. Tabellenzeilen besitzen gleichmäßiges Padding und einen Hover-Effekt.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 * **Flexible Player-Steuerleiste:** Bei schmalen Fenstern rutscht der Slider in eine zweite Zeile. Icons und Zeitangaben verkleinern sich automatisch.
-* **Fixierte Steuerleiste im Player:** Die Bedienelemente sitzen nun klar unter dem Video, bleiben am unteren Rand verankert und sind immer erreichbar. Die Liste nutzt variabel 22 % Breite (min. 260 px, max. 320 px).
+* **Fixierte Steuerleiste im Player:** Die Bedienelemente haften nun dank `position: sticky` direkt unter dem Video, besitzen volle Breite und liegen mit höherem `z-index` stets über dem Ergebnis-Panel. Die Liste nutzt variabel 22 % Breite (min. 260 px, max. 320 px).
 * **Scrollbarer Videobereich:** Wird das Video höher als der Dialog, lässt sich der Player innerhalb des Fensters scrollen und die Buttons bleiben sichtbar.
 * **OCR-Funktion im Player:** Ein präzises Overlay deckt nur die Untertitel ab. F9 oder der Auto-Modus schneiden den Screenshot exakt zu, pausieren bei einem Treffer das Video und sammeln den Text im rechten Panel. Nach erneutem Abspielen läuft die Erkennung automatisch weiter. Ein neuer 🔍‑Button schaltet die Funktion bequem ein und aus.
 * **Verbesserte OCR-Pipeline:** Overlay und Panel passen sich dynamisch an, starten nur nach Aktivierung und zeigen den erkannten Text gut lesbar im neuen Ergebnis‑Panel.

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2548,10 +2548,11 @@ th:nth-child(6) {
     padding: 0.5rem 1rem;
     background: #242424;
     box-shadow: 0 0 4px rgba(0,0,0,0.5);
-    margin-top: 8px; /* sorgt dafür, dass die Leiste nicht mehr über dem Video liegt */
-    position: sticky;
+    margin-top: 0; /* Abstand unter dem Video vermeiden */
+    position: sticky; /* Buttons haften am unteren Rand */
     bottom: 0;
-    z-index: 3;
+    width: 100%;
+    z-index: 5; /* liegt über Panel, aber unter dem Overlay */
 }
 .video-player-section .player-controls input[type=range] {
     /* Slider darf schrumpfen, bleibt aber mindestens 140px breit */


### PR DESCRIPTION
## Summary
- Steuerleiste unter dem Video bekommt `position: sticky`, volle Breite und höheren `z-index`
- README mit Erläuterung dieser Änderung ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856daf8ad44832781d35831284de694