### PR TITLE
Add secure captureFrame API via preload

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Prüfung auf fehlende `getSources`-Methode:** Fehlt diese Funktion, greift die OCR automatisch auf `getDisplayMedia` zurück.
 * **Fallback bei Capture-Fehlern:** Schlägt die Aufnahme über `desktopCapturer` fehl, wird ebenfalls `getDisplayMedia` verwendet.
 * **Screenshot per IPC:** Der neue Kanal `capture-frame` erstellt einen sofortigen Screenshot des Hauptfensters ohne Desktop-Capturer.
+* **Gesicherte Schnittstelle im Preload:** Über `window.api.captureFrame(bounds)` kann der Renderer nun sicher einen Screenshot anfordern, weitere Node-APIs bleiben ausgeblendet.
 
 ### 📊 Fortschritts‑Tracking
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -75,6 +75,12 @@ if (typeof require !== 'function') {
     captureFrame: bounds => ipcRenderer.invoke('capture-frame', bounds),
   });
 
+  // Vereinfachtes API nur für Bildschirmaufnahmen
+  // So bleibt der Renderer klar von Node-Funktionen getrennt
+  contextBridge.exposeInMainWorld('api', {
+    captureFrame: b => ipcRenderer.invoke('capture-frame', b),
+  });
+
   // Desktop-Capturer für Bildschirmaufnahmen bereitstellen
   contextBridge.exposeInMainWorld('desktopCapturer', {
     getSources: opts => desktopCapturer.getSources(opts),


### PR DESCRIPTION
## Summary
- expose `window.api.captureFrame` in the preload script
- note new capture API in `README`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856dcec79e883279bee43642e44eb90