### PR TITLE
CSP vereinfacht

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Seit Patch 1.40.49 entfernt die Content Security Policy `'unsafe-eval'` wieder, 
 Seit Patch 1.40.50 fügt die Richtlinie `'unsafe-eval'` erneut hinzu, damit der Tesseract-Worker ohne Fehler startet.
 Seit Patch 1.40.51 wurde die CSS-Klasse `.video-player-section` bereinigt. Jetzt gilt ein eindeutiger Block mit `overflow-x:hidden`, `overflow-y:auto` und `min-height:0`, damit die Steuerelement-Leiste nicht mehr abgeschnitten wird.
 Seit Patch 1.40.52 entfernt die Content Security Policy `'unsafe-eval'` erneut und erlaubt `worker-src 'self'`. Dadurch verschwindet die Electron-Sicherheitswarnung, ohne die App-Funktionalität einzuschränken.
+Seit Patch 1.40.53 nutzt die Content Security Policy eine minimale Konfiguration. Sie erlaubt Blob‑Worker für Tesseract, ohne `'unsafe-eval'` zu verwenden.
 
 Beispiel einer gültigen CSV:
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -5,8 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Half-Life: Alyx Translation Tool</title>
     <!-- Sicherheitsrichtlinie für Electron: verhindert Warnhinweise -->
-    <!-- CSP angepasst: erlaubt Inline-Skripte, Tesseract-Downloads und Worker vom eigenen Ursprung -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; img-src 'self' https://i.ytimg.com; connect-src 'self' data: https://api.elevenlabs.io https://tessdata.projectnaptha.com; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://www.youtube.com https://cdn.jsdelivr.net; worker-src 'self'; style-src 'self' 'unsafe-inline'; media-src 'self' blob:; frame-src https://www.youtube.com https://www.youtube-nocookie.com;">
+    <!-- Angepasste CSP: Blob-Worker für Tesseract ohne 'unsafe-eval' zulassen -->
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self';
+                   script-src 'self';
+                   style-src 'self' 'unsafe-inline';
+                   img-src 'self' data:;
+                   worker-src 'self' blob:;">
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Zusammenfassung
- CSP in `web/hla_translation_tool.html` auf Minimalvariante umgestellt
- README um Patch-Hinweis zu neuer CSP erweitert

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856e355c4588327a076f45816a6447a