### PR TITLE
DesktopCapturer entfernen

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Verbesserte Player-Anpassung:** Die Höhe des IFrames ergibt sich jetzt aus der Dialogbreite und wird auf 90 % der Fensterhöhe begrenzt. Zwei `requestAnimationFrame`-Aufrufe sorgen nach jedem Öffnen oder Resize für korrekte Maße.
 * **Fehlerfreies Skalieren nach Schließen:** Ändert man die Fenstergröße bei geschlossenem Dialog, berechnet das IFrame seine Breite beim nächsten Öffnen korrekt neu.
 * **Stabilerer ResizeObserver:** Die Dialog-Anpassung nutzt `requestAnimationFrame` und verhindert so die Fehlermeldung "ResizeObserver loop limit exceeded".
+* **Gethrottleter Video-ResizeObserver:** `adjustVideoPlayerSize` und `positionOverlay` werden pro Frame gebündelt ausgeführt und umgehen so Endlos-Schleifen.
 * **Dynamische Größenberechnung:** `calcLayout()` ermittelt Breite und Höhe des Players aus Dialog- und Panelgröße und wird per `ResizeObserver` automatisch aufgerufen.
 * **Exportfunktion für Video-Bookmarks:** Gespeicherte Links lassen sich als `videoBookmarks.json` herunterladen.
 * **Dauerhafte Video-Suche:** Der Suchbegriff im Video-Manager bleibt zwischen den Sitzungen erhalten.
@@ -89,6 +90,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Robuster Auto‑OCR‑Loop:** Das Intervall startet nur bei aktivem Toggle, pausiert nach einem Treffer das Video, stoppt automatisch und setzt sich beim erneuten Abspielen fort.
 * **Korrektur der OCR-Breite:** Der blaue Rahmen deckt jetzt die komplette Videobreite ab.
 * **Verbesserte Positionierung:** Overlay und Ergebnis-Panel orientieren sich exakt am Video und umschiffen so Steuerleiste und Bild.
+* **Overlay kollidiert nicht mehr mit den Controls:** Der blaue Rahmen endet 48 px über dem Rand und liegt mit niedrigerem `z-index` unter den Bedienelementen.
 * **Neues OCR-Pop‑up:** Erkennt die OCR Text, pausiert das Video und öffnet ein separates Fenster mit dem gefundenen Text.
 * **Tesseract.js nun lokal eingebunden:** Die OCR-Engine wird direkt aus `src/lib` geladen und funktioniert damit auch ohne Internetzugang.
 * **Stabilere OCR-Initialisierung:** Das Tesseract-Modul wird nun korrekt importiert und die Worker starten zuverlässig.
@@ -101,6 +103,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Immer sichtbarer Player:** Eine Mindestgröße von 320×180 verhindert, dass der eingebettete Player verschwindet.
 * **Screenshot per IPC:** Der Kanal `capture-frame` liefert einen sofortigen Screenshot des Hauptfensters.
 * **Gesicherte Schnittstelle im Preload:** Über `window.api.captureFrame(bounds)` kann der Renderer nun sicher einen Screenshot anfordern.
+* **Desktop-Capturer entfernt:** Die API `desktopCapturer.getSources` steht nicht mehr zur Verfügung.
 * **Neuer Frame-Grab-Workflow im Renderer:** Für jeden OCR-Durchlauf wird das IFrame direkt fotografiert und das PNG ohne zusätzliche Berechtigungen verarbeitet.
 ### 📊 Fortschritts‑Tracking
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -17,7 +17,8 @@ console.log('[PRELOAD] gestartet', __filename);
 if (typeof require !== 'function') {
   console.warn('Preload-Skript: "require" ist nicht verf\u00fcgbar. Das Skript wird beendet.');
 } else {
-  const { contextBridge, ipcRenderer, desktopCapturer } = require('electron');
+  // Desktop-Capturer wird nicht mehr benötigt
+  const { contextBridge, ipcRenderer } = require('electron');
   const fs = require('fs');
   // 'node:path' nutzen, damit das integrierte Modul auch nach dem Packen gefunden wird
   const path = require('node:path');
@@ -79,11 +80,6 @@ if (typeof require !== 'function') {
   // So bleibt der Renderer klar von Node-Funktionen getrennt
   contextBridge.exposeInMainWorld('api', {
     captureFrame: b => ipcRenderer.invoke('capture-frame', b),
-  });
-
-  // Desktop-Capturer für Bildschirmaufnahmen bereitstellen
-  contextBridge.exposeInMainWorld('desktopCapturer', {
-    getSources: opts => desktopCapturer.getSources(opts),
   });
 
   // API für Video-Bookmarks bereitstellen

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -70,13 +70,18 @@ function ensureDialogSupport(d) {
 ensureDialogSupport(videoMgrDialog);
 
 // Beobachter passt Größe bei jeder Dialog-Änderung an
-// Vermeidet eine Endlosschleife durch Throttling über requestAnimationFrame
+// Vermeidet eine Endlosschleife durch Throttling per requestAnimationFrame
 let resizeScheduled = false;
 const resizeObserver = new ResizeObserver(() => {
     if (resizeScheduled) return;
     resizeScheduled = true;
     window.requestAnimationFrame(() => {
-        adjustVideoDialogHeight();
+        if (typeof adjustVideoPlayerSize === 'function') {
+            adjustVideoPlayerSize();
+        }
+        if (typeof window.positionOverlay === 'function') {
+            window.positionOverlay();
+        }
         resizeScheduled = false;
     });
 });

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2552,7 +2552,7 @@ th:nth-child(6) {
     position: sticky; /* Buttons haften am unteren Rand */
     bottom: 0;
     width: 100%;
-    z-index: 5; /* liegt über Panel, aber unter dem Overlay */
+    z-index: 5; /* liegt über dem Ergebnis-Panel, Overlay liegt darunter */
 }
 .video-player-section .player-controls input[type=range] {
     /* Slider darf schrumpfen, bleibt aber mindestens 140px breit */
@@ -2681,9 +2681,10 @@ th:nth-child(6) {
     position: absolute;
     background: rgba(0,128,255,.25);
     border: 2px dashed #fff;
-    pointer-events: none;
+    pointer-events: none; /* Overlay ignoriert Mausereignisse */
     display: none;
-    z-index: 10;
+    bottom: 48px;         /* Abstand zur Steuerleiste */
+    z-index: 4;           /* liegt unter den Bedienelementen */
     /* genaue Position wird per JS gesetzt */
 }
 #videoPlayerSection.ocr-active #ocrOverlay {


### PR DESCRIPTION
## Zusammenfassung
- Preload lädt keinen `desktopCapturer` mehr und entfernt die zugehörige API
- README ergänzt: Desktop-Capturer abgeschafft
- ResizeObserver für Video-Player ist nun gethrottelt
- Overlay liegt mit niedrigerem `z-index` unter der Steuerleiste und endet 48 px über dem Rand

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856e3e8cd9483279f63368e419f496b