### PR TITLE
CSP aktualisiert für YouTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Seit Patch 1.40.50 fügt die Richtlinie `'unsafe-eval'` erneut hinzu, damit der 
 Seit Patch 1.40.51 wurde die CSS-Klasse `.video-player-section` bereinigt. Jetzt gilt ein eindeutiger Block mit `overflow-x:hidden`, `overflow-y:auto` und `min-height:0`, damit die Steuerelement-Leiste nicht mehr abgeschnitten wird.
 Seit Patch 1.40.52 entfernt die Content Security Policy `'unsafe-eval'` erneut und erlaubt `worker-src 'self'`. Dadurch verschwindet die Electron-Sicherheitswarnung, ohne die App-Funktionalität einzuschränken.
 Seit Patch 1.40.53 nutzt die Content Security Policy eine minimale Konfiguration. Sie erlaubt Blob‑Worker für Tesseract, ohne `'unsafe-eval'` zu verwenden.
+Seit Patch 1.40.54 erlaubt die Richtlinie Skripte und Frames von `youtube.com` und `youtube-nocookie.com`. Vorschaubilder von `i.ytimg.com` bleiben erlaubt.
 
 Beispiel einer gültigen CSV:
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -5,13 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Half-Life: Alyx Translation Tool</title>
     <!-- Sicherheitsrichtlinie für Electron: verhindert Warnhinweise -->
-    <!-- Angepasste CSP: Blob-Worker für Tesseract ohne 'unsafe-eval' zulassen -->
+    <!-- Aktualisierte CSP: Erlaubt YouTube und Blob-Worker -->
     <meta http-equiv="Content-Security-Policy"
           content="default-src 'self';
-                   script-src 'self';
-                   style-src 'self' 'unsafe-inline';
-                   img-src 'self' data:;
-                   worker-src 'self' blob:;">
+                   script-src  'self' https://www.youtube.com https://www.youtube-nocookie.com;
+                   worker-src  'self' blob:;
+                   img-src     'self' data: https://i.ytimg.com;
+                   frame-src   'self' https://www.youtube.com https://www.youtube-nocookie.com;
+                   style-src   'self' 'unsafe-inline';">
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- nur ausgewählte Domains in der CSP zugelassen
- Patch-Historie um Eintrag zu YouTube-Freigaben ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856e7447f0483278414f859a6e366a4