### PR TITLE
Verbesserung der Video-Listenhöhe

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Verbesserte dynamische Dialoghöhe:** Der Video-Manager schrumpft nun auch bei kleinen Fenstern und entfernt überflüssigen Leerraum.
 * **Automatische Dialogbreite:** Ohne geöffneten Player richtet sich die Breite des Video-Managers nach der Liste.
 * **Flexibles Fenster für gespeicherte Videos:** Höhe passt sich jetzt automatisch an Videoplayer und Liste an.
+* **Voll ausgenutzte Video-Liste:** Das Tabellenfeld wächst bis zum unteren Rand des Dialogs und lässt keinen Leerraum unter dem Schließen-Button.
 * **Breitenbegrenzter Player:** Die Breite richtet sich nach der verfügbaren Höhe und überschreitet nie das Format 16:9.
 * **Verbesserte Player-Anpassung:** Die Höhe des IFrames ergibt sich jetzt aus der Dialogbreite und wird auf 90 % der Fensterhöhe begrenzt. Zwei `requestAnimationFrame`-Aufrufe sorgen nach jedem Öffnen oder Resize für korrekte Maße.
 * **Fehlerfreies Skalieren nach Schließen:** Ändert man die Fenstergröße bei geschlossenem Dialog, berechnet das IFrame seine Breite beim nächsten Öffnen korrekt neu.

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2591,9 +2591,9 @@ th:nth-child(6) {
 }
 
 #videoTableWrapper {
-    /* Container für die Tabelle: wächst bei Bedarf, sonst passt er sich an */
+    /* Container für die Tabelle: füllt den verfügbaren Platz komplett aus */
     overflow-y: auto;
-    max-height: 60vh;
+    flex: 1 1 auto;
 }
 
 #videoTable {


### PR DESCRIPTION
## Summary
- Video-Liste im Manager nutzt jetzt dank `flex` den gesamten vertikalen Platz
- neue README-Notiz zur voll ausgenutzten Video-Liste

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856e8b0400883278a8f663b71608388