### PR TITLE
Fix OCR panel layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Verbesserte OCR-Pipeline:** Overlay und Panel passen sich dynamisch an, starten nur nach Aktivierung und zeigen den erkannten Text gut lesbar im neuen Ergebnis‑Panel.
 * **Nahtloser Player mit OCR-Panel:** Die Breite des IFrames berücksichtigt die Panelbreite, die Steuerleiste reicht bis an den Rand und der blaue OCR‑Rahmen sitzt exakt auf dem Videobild.
 * **Feinschliff am OCR‑Panel:** Breite clamped, Panel überlappt keine Buttons mehr, Text scrollt automatisch und der 🔍‑Button blinkt kurz bei einem Treffer.
+* **Fest rechts verankertes Ergebnis-Panel:** Das Panel sitzt nun neben dem Video und passt seine Höhe automatisch an, ohne das Bild zu überdecken.
 * **Robuster Auto‑OCR‑Loop:** Das Intervall startet nur bei aktivem Toggle, pausiert nach einem Treffer das Video, stoppt automatisch und setzt sich beim erneuten Abspielen fort.
 * **Korrektur der OCR-Breite:** Der blaue Rahmen deckt jetzt die komplette Videobreite ab.
 * **Verbesserte Positionierung:** Overlay und Ergebnis-Panel orientieren sich exakt am Video und umschiffen so Steuerleiste und Bild.

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -173,7 +173,8 @@ function adjustVideoPlayerSize(force = false) {
     // verfügbare Fläche im Dialog
     const dialogW   = dialog.clientWidth;
     const dialogH   = dialog.clientHeight;
-    const freeW     = dialogW - listW - panelW - 2 * pad;
+    let freeW       = dialogW - listW - 2 * pad;
+    freeW          -= panelW; // Platz für das Ergebnis-Panel abziehen
     const headerH   = header ? header.offsetHeight : 0;
     const controlsH = controls ? controls.offsetHeight : 0;
     const freeH     = dialogH - headerH - controlsH - 2 * pad;
@@ -188,6 +189,10 @@ function adjustVideoPlayerSize(force = false) {
     frame.style.width  = w + 'px';
     frame.style.height = h + 'px';
     if (controls) controls.style.width = w + 'px';
+    if (panel && !panel.classList.contains('hidden')) {
+        // Panel-Höhe an die Video-Höhe anpassen
+        panel.style.height = frame.clientHeight + 'px';
+    }
 }
 window.adjustVideoPlayerSize = adjustVideoPlayerSize;
 

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2698,15 +2698,18 @@ th:nth-child(6) {
 }
 
 #ocrResultPanel {
+    /* Panel klebt rechts neben dem Video */
     position: absolute;
-    /* genaue Position und Höhe werden per JS gesetzt */
-    z-index: 4;
-    width: clamp(200px, 18%, 260px);
-    background: #181818;
-    color: #e0e0e0;
-    overflow: hidden;
+    top: 0;
+    right: 0;
+    height: 100%;
+    width: clamp(200px, 20%, 260px);
+    overflow: auto;
+    background: #1a1a1a;
     padding: 8px;
+    z-index: 4;
     font-family: monospace;
+    color: #e0e0e0;
 }
 #ocrResultPanel pre {
     margin: 0;


### PR DESCRIPTION
## Summary
- dock result panel to the right of the video
- adjust video player size calculation when panel is visible
- document the new panel behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856eddb2e788327afad5977d23e77d6