### PR TITLE
Fix OCR panel overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Aufräumarbeiten am Panel-Layout:** Überflüssige CSS-Regeln entfernt und Höhe dynamisch gesetzt.
 * **Panelgröße korrekt berechnet:** Die Player-Anpassung zieht nun die Breite des Ergebnis-Panels ab und setzt dessen Höhe direkt nach dem Video.
 * **Schnell-Fix:** Das Ergebnis-Panel überdeckt das Video nicht mehr und passt seine Höhe exakt an die IFrame-Größe an.
+* **Responsive OCR-Anzeige:** Bei schmalen Dialogen rutscht das Ergebnis-Panel automatisch unter das Video.
 * **Robuster Auto‑OCR‑Loop:** Das Intervall startet nur bei aktivem Toggle, pausiert nach einem Treffer das Video, stoppt automatisch und setzt sich beim erneuten Abspielen fort.
 * **Korrektur der OCR-Breite:** Der blaue Rahmen deckt jetzt die komplette Videobreite ab.
 * **Verbesserte Positionierung:** Overlay und Ergebnis-Panel orientieren sich exakt am Video und umschiffen so Steuerleiste und Bild.

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -167,8 +167,14 @@ function adjustVideoPlayerSize(force = false) {
 
     const pad       = parseFloat(getComputedStyle(dialog).paddingLeft) || 0;
     const listW     = list ? list.offsetWidth : 0;
-    const panelW    = (ocrPanel && !ocrPanel.classList.contains('hidden'))
-        ? ocrPanel.offsetWidth : 0; // Breite des Ergebnis-Panels
+    let panelW = 0;
+    if (ocrPanel && !ocrPanel.classList.contains('hidden')) {
+        const style = getComputedStyle(ocrPanel);
+        // Breite nur abziehen, wenn das Panel neben dem Video steht
+        if (style.position !== 'static') {
+            panelW = ocrPanel.offsetWidth;
+        }
+    }
 
     // verfügbare Fläche im Dialog
     const dialogW   = dialog.clientWidth;
@@ -191,8 +197,13 @@ function adjustVideoPlayerSize(force = false) {
     frame.style.height = h + 'px';
     if (controls) controls.style.width = w + 'px';
     if (ocrPanel && !ocrPanel.classList.contains('hidden')) {
-        // Schnell-Fix: Panel-Höhe an die tatsächliche Video-Höhe anpassen
-        ocrPanel.style.height = frame.clientHeight + 'px';
+        const style = getComputedStyle(ocrPanel);
+        // Höhe nur setzen, wenn das Panel neben dem Video liegt
+        if (style.position !== 'static') {
+            ocrPanel.style.height = frame.clientHeight + 'px';
+        } else {
+            ocrPanel.style.height = 'auto';
+        }
     }
 }
 window.adjustVideoPlayerSize = adjustVideoPlayerSize;

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2507,6 +2507,12 @@ th:nth-child(6) {
     min-height: 0;
     position: relative; /* Steuerleiste wird dynamisch positioniert */
     padding-bottom: 0; /* kein fixer Platz mehr notwendig */
+    padding-right: 0; /* Platz für OCR-Panel wird dynamisch ergänzt */
+}
+
+/* Bei aktivem OCR-Panel Platz neben dem Video schaffen */
+.video-player-section.ocr-active {
+    padding-right: clamp(200px, 20%, 260px);
 }
 .video-player-section.hidden { display: none; }
 
@@ -2707,6 +2713,19 @@ th:nth-child(6) {
     overflow:auto;
     background:#1a1a1a;
     padding:8px;
+}
+
+@media (max-width: 600px) {
+    /* Panel rutscht unter das Video, wenn nicht genug Breite vorhanden ist */
+    .video-player-section.ocr-active {
+        padding-right: 0;
+    }
+    #ocrResultPanel {
+        position:static;
+        width:100%;
+        height:auto;
+        margin-top:8px;
+    }
 }
 #ocrResultPanel pre {
     margin: 0;


### PR DESCRIPTION
## Zusammenfassung
- erweitere CSS: Videoabschnitt reserviert bei aktivem OCR-Panel Platz und schiebt das Panel bei schmaler Breite unter das Video
- passe `adjustVideoPlayerSize` an das neue Layout an
- ergänze README um den Hinweis auf die responsive OCR-Anzeige

## Testanweisungen
- `npm test` ausführen

------
https://chatgpt.com/codex/tasks/task_e_6856f4a6fdc48327b20e628ba2d1d0c5