### PR TITLE
Fix OCR worker to use local wasm core

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Seit Patch 1.40.51 wurde die CSS-Klasse `.video-player-section` bereinigt. Jetzt
 Seit Patch 1.40.52 entfernt die Content Security Policy `'unsafe-eval'` erneut und erlaubt `worker-src 'self'`. Dadurch verschwindet die Electron-Sicherheitswarnung, ohne die App-Funktionalität einzuschränken.
 Seit Patch 1.40.53 nutzt die Content Security Policy eine minimale Konfiguration. Sie erlaubt Blob‑Worker für Tesseract, ohne `'unsafe-eval'` zu verwenden.
 Seit Patch 1.40.54 erlaubt die Richtlinie Skripte und Frames von `youtube.com` und `youtube-nocookie.com`. Vorschaubilder von `i.ytimg.com` bleiben erlaubt.
+Seit Patch 1.40.55 wird die Datei `tesseract-core-simd.wasm.js` lokal eingebunden und über `corePath` geladen. Dadurch benötigt die OCR keine externen Skripte mehr.
 
 Beispiel einer gültigen CSV:
 

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -48,7 +48,9 @@ async function initOcrWorker() {
         // Worker-Pfad absolut aufloesen, damit er auch in Electron korrekt
         // gefunden wird und keine externen Skripte benoetigt werden
         const workerUrl = new URL('./src/lib/tesseract-worker.min.js', window.location.href).href;
-        ocrWorker = await createWorker({ workerPath: workerUrl });
+        const coreUrl   = new URL('./src/lib/tesseract-core-simd.wasm.js', window.location.href).href;
+        // Worker mit lokalem corePath starten, damit keine externen Ressourcen geladen werden
+        ocrWorker = await createWorker({ workerPath: workerUrl, corePath: coreUrl });
         // einige Builds liefern ein Promise zurück
         if (typeof ocrWorker.then === 'function') {
             ocrWorker = await ocrWorker;


### PR DESCRIPTION
## Summary
- use local wasm file for tesseract worker
- update CSP notes in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68570d0a368c83279c7c7dda72c91ae6