### PR TITLE
Fix CSP for Tesseract

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Seit Patch 1.40.52 entfernt die Content Security Policy `'unsafe-eval'` erneut u
 Seit Patch 1.40.53 nutzt die Content Security Policy eine minimale Konfiguration. Sie erlaubt Blob‑Worker für Tesseract, ohne `'unsafe-eval'` zu verwenden.
 Seit Patch 1.40.54 erlaubt die Richtlinie Skripte und Frames von `youtube.com` und `youtube-nocookie.com`. Vorschaubilder von `i.ytimg.com` bleiben erlaubt.
 Seit Patch 1.40.55 wird die Datei `tesseract-core-simd.wasm.js` lokal eingebunden und über `corePath` geladen. Dadurch benötigt die OCR keine externen Skripte mehr.
+Seit Patch 1.40.56 erlaubt die Content Security Policy zusätzlich `wasm-unsafe-eval` und `connect-src data:`, damit Tesseract im Browser ohne Fehlermeldungen startet.
 
 Beispiel einer gültigen CSV:
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -8,8 +8,9 @@
     <!-- Aktualisierte CSP: Erlaubt YouTube und Blob-Worker -->
     <meta http-equiv="Content-Security-Policy"
           content="default-src 'self';
-                   script-src  'self' https://www.youtube.com https://www.youtube-nocookie.com;
+                   script-src  'self' 'wasm-unsafe-eval' https://www.youtube.com https://www.youtube-nocookie.com;
                    worker-src  'self' blob:;
+                   connect-src 'self' data:;
                    img-src     'self' data: https://i.ytimg.com;
                    frame-src   'self' https://www.youtube.com https://www.youtube-nocookie.com;
                    style-src   'self' 'unsafe-inline';">


### PR DESCRIPTION
## Summary
- erweitere Content Security Policy um `wasm-unsafe-eval` und `connect-src data:`
- ergänze README um Patchhinweis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68571154ed4c83278f2833c26581479f