### PR TITLE
Improve OCR image preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Gesicherte Schnittstelle im Preload:** Über `window.api.captureFrame(bounds)` kann der Renderer nun sicher einen Screenshot anfordern.
 * **Desktop-Capturer entfernt:** Die API `desktopCapturer.getSources` steht nicht mehr zur Verfügung.
 * **Neuer Frame-Grab-Workflow im Renderer:** Für jeden OCR-Durchlauf wird das IFrame direkt fotografiert und das PNG ohne zusätzliche Berechtigungen verarbeitet.
+* **Bildverarbeitung für exakteres OCR:** Der Screenshot wird vor der Erkennung kontrastreich nachgeschärft.
 ### 📊 Fortschritts‑Tracking
 
 * **Globale Dashboard‑Kacheln:** Gesamt, Übersetzt, Ordner komplett, **EN/DE/BEIDE/∑**


### PR DESCRIPTION
## Summary
- preprocess frame grab with new `refineImage()` for contrast and brightness
- use processed blob for OCR
- document improved image processing in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68571531fb908327aaae8d778d54079b