### PR TITLE
Add OCR pipeline tests and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Tests für Video-Bookmarks:** Überprüfen Laden, Sortierung sowie Hinzufügen und Entfernen von Einträgen.
 * **Tests für den YouTube-Player:** Prüfen Speicherung über das Intervall, Löschfunktion sowie Dialog und Slider.
 * **Test für OCR-Overlay-Sichtbarkeit:** Stellt sicher, dass Overlay und Ergebnis-Panel korrekt ein- und ausgeblendet werden.
+* **Neue Tests für die OCR-Pipeline:** Prüfen die Bildverarbeitung und den Auto-OCR-Start.
 * **Prüfung von Video-Links:** Eingaben müssen mit `https://` beginnen und dürfen keine Leerzeichen enthalten.
 * **Duplikat-Prüfung & dauerhafte Speicherung im Nutzerordner**
 * **Automatische YouTube-Titel:** Beim Hinzufügen lädt das Tool den Videotitel per oEmbed und sortiert die Liste alphabetisch. Schlägt dies fehl, wird die eingegebene URL als Titel gespeichert.

--- a/tests/ocrPipeline.test.js
+++ b/tests/ocrPipeline.test.js
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+function loadModule() {
+    const code = fs.readFileSync(path.join(__dirname, '../web/ytPlayer.js'), 'utf8')
+        .replace(/export\s+(async\s+)?function/g, '$1function');
+    const sandbox = { module: { exports: {} }, window, document, setInterval, clearInterval, YT: window.YT, Blob, createImageBitmap };
+    vm.runInNewContext(code, sandbox);
+    return sandbox;
+}
+
+describe('OCR-Pipeline', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <dialog id="videoMgrDialog" open>
+                <div id="videoPlayerSection">
+                    <iframe id="videoPlayerFrame"></iframe>
+                </div>
+                <button id="ocrToggle" class="active"></button>
+                <div id="ocrOverlay" style="top:0"></div>
+                <div id="ocrResultPanel"><pre id="ocrText"></pre></div>
+            </dialog>`;
+        window.api = { captureFrame: jest.fn().mockResolvedValue(new Uint8Array([0])) };
+        global.createImageBitmap = jest.fn(async () => ({ width: 10, height: 5 }));
+        window.YT = { PlayerState: { PLAYING: 1, PAUSED: 2 } };
+        window.positionOverlay = jest.fn();
+    });
+
+    test('captureAndOcr nutzt refineImage', async () => {
+        const sandbox = loadModule();
+        sandbox.initOcrWorker = jest.fn(async () => true);
+        sandbox.pruefeHelligkeit = jest.fn(async () => 0);
+        jest.spyOn(sandbox, 'refineImage').mockResolvedValue(new Blob(['x'], { type: 'image/png' }));
+
+        await sandbox.captureAndOcr();
+
+        expect(sandbox.refineImage).toHaveBeenCalled();
+    });
+
+    test('startAutoLoop startet nur bei PLAYING', () => {
+        jest.useFakeTimers();
+        const setSpy = jest.spyOn(global, 'setInterval');
+        const sandbox = loadModule();
+        const btn = document.getElementById('ocrToggle');
+        const dlg = document.getElementById('videoMgrDialog');
+        btn.classList.add('active');
+        dlg.open = true;
+
+        window.currentYT = { getPlayerState: () => window.YT.PlayerState.PAUSED };
+        sandbox.startAutoLoop();
+        expect(setSpy).not.toHaveBeenCalled();
+
+        window.currentYT.getPlayerState = () => window.YT.PlayerState.PLAYING;
+        sandbox.startAutoLoop();
+        expect(setSpy).toHaveBeenCalled();
+
+        setSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary
- test `captureAndOcr()` with mock Bitmap and ensure `refineImage()` is used
- verify `startAutoLoop()` only runs while video plays
- document new OCR tests in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68571ae26e8c8327a1cf3acd9525f95f