### PR TITLE
Fix brightness check for zero-sized overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Bildverarbeitung für exakteres OCR:** Der Screenshot wird vor der Erkennung kontrastreich nachgeschärft.
 * **Optimierte OCR-Parameter für bessere Trefferquote**
 * **Genauere ROI-Erkennung dank Helligkeitsprüfung** – der erkannte Bereich wird um 2 % nach oben oder unten verschoben, falls zu wenig helle Pixel vorhanden sind.
+* **Stabilere Helligkeitsprüfung:** Überprüft zuerst die Abmessungen des Overlay-Bereichs und vermeidet so Fehlermeldungen.
 ### 📊 Fortschritts‑Tracking
 
 * **Globale Dashboard‑Kacheln:** Gesamt, Übersetzt, Ordner komplett, **EN/DE/BEIDE/∑**

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -18,8 +18,10 @@ let ocrWindow = null;        // separates Fenster für erkannte Texte
 // prueft die Helligkeit des potenziellen Textbereichs
 async function pruefeHelligkeit(bitmap, roi, frameH) {
     const canvas = document.createElement('canvas');
+    // fruehzeitig abbrechen, falls der Bereich keine gueltige Groesse besitzt
+    if (roi.width <= 0 || roi.height <= 0) return 0;
     const tmpW = 32;                              // kleines Hilfs-Canvas fuer schnelle Analyse
-    const tmpH = Math.max(1, Math.round(tmpW * roi.height / roi.width));
+    const tmpH = Math.max(1, Math.round(tmpW * roi.height / Math.max(1, roi.width)));
     canvas.width = tmpW;
     canvas.height = tmpH;
     const ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- avoid `getImageData` TypeError when overlay has zero width or height
- document the more robust brightness check

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68571d3258108327b66cb623a47ca02d