### PR TITLE
Verbesserte OCR-Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Optimierte OCR-Parameter für bessere Trefferquote**
 * **Genauere ROI-Erkennung dank Helligkeitsprüfung** – der erkannte Bereich wird um 2 % nach oben oder unten verschoben, falls zu wenig helle Pixel vorhanden sind.
 * **Stabilere Helligkeitsprüfung:** Überprüft zuerst die Abmessungen des Overlay-Bereichs und vermeidet so Fehlermeldungen.
+* **OffscreenCanvas mit Graustufen-Verarbeitung:** Screenshots werden doppelt skaliert, kontrastverstärkt und in Graustufen umgewandelt.
+* **Präzisere Texterkennung:** Das Overlay endet 2 px über dem Slider und nutzt nur 14 % der Bildhöhe.
+* **Schnellerer Auto‑OCR‑Loop:** Läuft alle 750 ms und pausiert das Video ab vier erkannten Zeichen.
 ### 📊 Fortschritts‑Tracking
 
 * **Globale Dashboard‑Kacheln:** Gesamt, Übersetzt, Ordner komplett, **EN/DE/BEIDE/∑**

--- a/tests/ocrPipeline.test.js
+++ b/tests/ocrPipeline.test.js
@@ -31,15 +31,15 @@ describe('OCR-Pipeline', () => {
         window.positionOverlay = jest.fn();
     });
 
-    test('captureAndOcr nutzt refineImage', async () => {
+    test('captureAndOcr nutzt refineBlob', async () => {
         const sandbox = loadModule();
         sandbox.initOcrWorker = jest.fn(async () => true);
         sandbox.pruefeHelligkeit = jest.fn(async () => 0);
-        jest.spyOn(sandbox, 'refineImage').mockResolvedValue(new Blob(['x'], { type: 'image/png' }));
+        jest.spyOn(sandbox, 'refineBlob').mockResolvedValue(new Blob(['x'], { type: 'image/png' }));
 
         await sandbox.captureAndOcr();
 
-        expect(sandbox.refineImage).toHaveBeenCalled();
+        expect(sandbox.refineBlob).toHaveBeenCalled();
     });
 
     test('startAutoLoop startet nur bei PLAYING', () => {


### PR DESCRIPTION
## Zusammenfassung
- OffscreenCanvas-Skalierung und Graustufenfilter in `refineBlob`
- Overlay auf 14% Höhe begrenzt und 2 px über Slider positioniert
- Auto-OCR läuft alle 750 ms und stoppt bei längerem Text
- Test und Dokumentation angepasst

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68571f771a888327a3b7639c45c1749a