### PR TITLE
Enable draggable OCR region with saved position

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
  * **Robuster Auto‑OCR‑Loop:** Das Intervall startet nur bei aktivem Toggle, pausiert nach einem Treffer das Video, stoppt automatisch und setzt sich beim erneuten Abspielen fort.
  * **CPU-schonendere OCR:** Nach jedem Durchlauf wird das Intervall angehalten und erst mit einem erneuten Play-Befehl wieder gestartet.
 * **Korrektur der OCR-Breite:** Der blaue Rahmen deckt jetzt die komplette Videobreite ab.
+* **Verschieb- und skalierbares OCR-Overlay:** Der Rahmen lässt sich per Maus anpassen und merkt sich die letzte Position.
 * **Verbesserte Positionierung:** Overlay und Ergebnis-Panel orientieren sich exakt am Video und umschiffen so Steuerleiste und Bild.
 * **Overlay kollidiert nicht mehr mit den Controls:** Der blaue Rahmen endet 48 px über dem Rand und liegt mit niedrigerem `z-index` unter den Bedienelementen.
 * **Neues OCR-Pop‑up:** Erkennt die OCR Text, pausiert das Video und öffnet ein separates Fenster mit dem gefundenen Text.

--- a/tests/ocrOverlayLoad.test.js
+++ b/tests/ocrOverlayLoad.test.js
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+const fs = require('fs');
+const vm = require('vm');
+const path = require('path');
+
+function loadModule() {
+    const code = fs.readFileSync(path.join(__dirname, '../web/ytPlayer.js'), 'utf8')
+        .replace(/export\s+(async\s+)?function/g, '$1function');
+    const sandbox = { module: { exports: {} }, window, document, localStorage, setInterval, clearInterval, YT: {} };
+    vm.runInNewContext(code, sandbox);
+    return sandbox;
+}
+
+describe('Overlay-Position wird geladen', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="videoPlayerSection">
+                <iframe id="videoPlayerFrame"></iframe>
+                <div class="player-controls"><input id="videoSlider" type="range"></div>
+                <div id="ocrOverlay"></div>
+            </div>`;
+        localStorage.clear();
+    });
+
+    test('positionOverlay nutzt gespeicherte Werte', async () => {
+        localStorage.setItem('hla_ocrOverlayRect', JSON.stringify({ left:0.1, top:0.2, width:0.5, height:0.25 }));
+        const sandbox = loadModule();
+        const iframe = document.getElementById('videoPlayerFrame');
+        iframe.getBoundingClientRect = () => ({ left:10, top:20, width:100, height:80, bottom:100 });
+        const section = document.getElementById('videoPlayerSection');
+        section.getBoundingClientRect = () => ({ left:0, top:0 });
+        const controls = document.querySelector('.player-controls');
+        controls.offsetHeight = 20;
+        controls.querySelector = () => ({ getBoundingClientRect: () => ({ top:100 }) });
+
+        await sandbox.positionOverlay();
+        const ov = document.getElementById('ocrOverlay');
+        expect(parseFloat(ov.style.left)).toBeCloseTo(20);
+        expect(parseFloat(ov.style.top)).toBeCloseTo(36);
+        expect(parseFloat(ov.style.width)).toBeCloseTo(50);
+        expect(parseFloat(ov.style.height)).toBeCloseTo(20);
+    });
+});

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2684,11 +2684,16 @@ th:nth-child(6) {
     position: absolute;
     background: rgba(0,128,255,.25);
     border: 2px dashed #fff;
-    pointer-events: none; /* Overlay ignoriert Mausereignisse */
+    /* Mausinteraktion erlaubt nun Verschieben und Skalieren */
     display: none;
     bottom: 48px;         /* Abstand zur Steuerleiste */
     z-index: 4;           /* liegt unter den Bedienelementen */
+    cursor: move;         /* zeigt Verschiebbarkeit an */
+    touch-action: none;   /* verhindert Scrollen beim Ziehen */
     /* genaue Position wird per JS gesetzt */
+}
+#ocrOverlay.resizing {
+    cursor: se-resize;
 }
 #videoPlayerSection.ocr-active #ocrOverlay {
     display: block;


### PR DESCRIPTION
## Summary
- allow OCR overlay dragging and resizing with pointer events
- remember OCR overlay position in localStorage
- load saved overlay settings when positioning overlay
- add regression test for overlay persistence
- document new feature in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6857215edec08327bcb16f4ad359f9a5