### PR TITLE
Add OCR settings dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Stabilere Helligkeitsprüfung:** Überprüft zuerst die Abmessungen des Overlay-Bereichs und vermeidet so Fehlermeldungen.
 * **OffscreenCanvas mit Graustufen-Verarbeitung:** Screenshots werden doppelt skaliert, kontrastverstärkt und in Graustufen umgewandelt.
 * **willReadFrequently gesetzt:** Canvas-Kontexte nutzen das Attribut für schnellere Mehrfachzugriffe ohne Warnungen.
+* **Anpassbare OCR-Einstellungen:** Ein neuer ⚙️‑Button öffnet einen Dialog, in dem Helligkeit, Kontrast und Farb-Invertierung eingestellt werden können. Eine Vorschau zeigt sofort Bild und Erkennungsresultat.
 * **Präzisere Texterkennung:** Das Overlay endet jetzt 3 px über dem Slider und nutzt nur 14 % der Bildhöhe.
 * **Schnellerer Auto‑OCR‑Loop:** Läuft alle 750 ms und pausiert das Video ab vier erkannten Zeichen.
 ### 📊 Fortschritts‑Tracking

--- a/tests/ocrPipeline.test.js
+++ b/tests/ocrPipeline.test.js
@@ -39,7 +39,7 @@ describe('OCR-Pipeline', () => {
 
         await sandbox.captureAndOcr();
 
-        expect(sandbox.refineBlob).toHaveBeenCalled();
+        expect(sandbox.refineBlob).toHaveBeenCalledWith(expect.any(Blob), expect.any(Object));
     });
 
     test('startAutoLoop startet nur bei PLAYING', () => {

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -577,6 +577,7 @@
                     <button id="videoReload">🔄</button>
                     <button id="ocrToggle" title="OCR an/aus (F9)">🔍</button>
                     <button id="ocrDebug" title="Debug-Fenster">🐞</button>
+                    <button id="ocrSettings" title="OCR-Einstellungen">⚙️</button>
                     <button id="videoDelete">🗑️</button>
                     <button id="videoClose">❌</button>
                 </div>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2713,6 +2713,11 @@ th:nth-child(6) {
     color: #fff;
 }
 
+#ocrSettings.active {
+    background: #6699cc;
+    color: #fff;
+}
+
 #ocrResultPanel{
     /* Schnell-Fix: Panel sitzt fest rechts neben dem Video */
     position:absolute;


### PR DESCRIPTION
## Summary
- add `ocrSettings` button next to player controls
- style active state for OCR settings button
- implement `openOcrSettings` with live preview and recognition result
- make image refinement depend on customizable settings
- adapt tests for new `refineBlob` signature
- document new feature in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68572d8e1ff08327b65651c4ae820580