### PR TITLE
Escape schließt OCR-Drawer

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **OffscreenCanvas mit Graustufen-Verarbeitung:** Screenshots werden doppelt skaliert, kontrastverstärkt und in Graustufen umgewandelt.
 * **willReadFrequently gesetzt:** Canvas-Kontexte nutzen das Attribut für schnellere Mehrfachzugriffe ohne Warnungen.
 * **OCR-Tuning im Einstell-Drawer:** Der ⚙️‑Button klappt nun einen seitlichen Drawer aus. Darin lassen sich Helligkeit, Kontrast, Invertierung, Schärfen, Schwellenwert, PSM-Modus und Whitelist live anpassen. Eine kleine Vorschau zeigt sofort das gefilterte Bild und das erkannte Ergebnis.
+* **Escape schließt den Einstell-Drawer:** Mit der Escape-Taste verschwindet nur der Drawer, der Player bleibt sichtbar.
 * **Präzisere Texterkennung:** Das Overlay endet jetzt 3 px über dem Slider und nutzt nur 14 % der Bildhöhe.
 * **Schnellerer Auto‑OCR‑Loop:** Läuft alle 750 ms und pausiert das Video ab vier erkannten Zeichen.
 ### 📊 Fortschritts‑Tracking

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -895,7 +895,14 @@ document.addEventListener('keydown', e => {
     const playBtn = document.getElementById('videoPlay');
     const backBtn = document.getElementById('videoBack');
     const fwdBtn  = document.getElementById('videoForward');
+    const drawer  = document.getElementById('ocrSettingsDrawer');
     if (e.key === 'Escape') {
+        if (drawer && drawer.classList.contains('open')) {
+            // Bei Escape zuerst nur den Einstell-Drawer schließen
+            e.preventDefault();
+            openOcrSettings();
+            return;
+        }
         e.preventDefault();
         closeVideoDialog();
     }


### PR DESCRIPTION
## Zusammenfassung
- OCR-Drawer reagiert jetzt auf Escape und schließt ohne den Player zu beenden
- README um Hinweis auf Escape-Funktion ergänzt

## Testanweisungen
- `npm test` ausführen

------
https://chatgpt.com/codex/tasks/task_e_6857b22339248327af79eae644492ca8