### PR TITLE
Aktualisiertes EasyOCR-Skript

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 12. `start_tool.py` installiert nun zusätzlich alle Python-Abhängigkeiten aus `requirements.txt`. `translate_text.py` geht daher davon aus, dass `argostranslate` bereits vorhanden ist.
 13. Zudem erkennt das Skript automatisch eine vorhandene NVIDIA‑GPU und installiert PyTorch mitsamt EasyOCR wahlweise als CUDA- oder CPU-Version.
 14. Bereits vorhandene Python‑Pakete werden beim Start übersprungen, damit das Setup schneller abgeschlossen ist.
+15. `run_easyocr.py` verwendet eine globale EasyOCR-Instanz. Über die Umgebungsvariable `HLA_OCR_LANGS` lassen sich die Sprachen anpassen (Standard: `en,de`).
 
 ### ElevenLabs-Dubbing
 

--- a/run_easyocr.py
+++ b/run_easyocr.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import os
 import numpy as np
 import cv2
 import torch
@@ -9,6 +10,12 @@ try:
 except ModuleNotFoundError:
     sys.stderr.write("EasyOCR nicht installiert. Bitte start_tool.py ausführen.\n")
     sys.exit(1)
+
+# Sprachen aus Umgebungsvariable oder Standardwerte lesen
+LANGS = os.environ.get("HLA_OCR_LANGS", "en,de").split(',')
+
+# Reader einmalig erzeugen, um Startzeit zu reduzieren
+READER = easyocr.Reader(LANGS, gpu=torch.cuda.is_available())
 
 def main():
     data = sys.stdin.buffer.read()
@@ -21,8 +28,8 @@ def main():
     if img.shape[-1] == 4:
         img = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
     gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-    reader = easyocr.Reader(['en'], gpu=torch.cuda.is_available())
-    res = reader.readtext(gray, detail=0, paragraph=True)
+    # Globale EasyOCR-Instanz verwenden
+    res = READER.readtext(gray, detail=0, paragraph=True)
     text = " ".join(res).strip()
     print(text)
 


### PR DESCRIPTION
## Zusammenfassung
- run_easyocr.py nutzt jetzt eine globale Reader-Instanz und kann per Umgebungsvariable `HLA_OCR_LANGS` konfiguriert werden
- README um Hinweis auf das neue Verhalten ergänzt

## Testanweisungen
- `npm test` ausführen (installiert Abhängigkeiten und startet die Unit-Tests)


------
https://chatgpt.com/codex/tasks/task_e_6857cd167a148327b6539a5c86cb65d7