### PR TITLE
Aktualisierte CSP für Inline-Styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Seit Patch 1.40.54 erlaubt die Richtlinie Skripte und Frames von `youtube.com` u
 Seit Patch 1.40.55 wird die Datei `tesseract-core-simd.wasm.js` lokal eingebunden und über `corePath` geladen. Dadurch benötigt die OCR keine externen Skripte mehr.
 Seit Patch 1.40.56 erlaubt die Content Security Policy zusätzlich `wasm-unsafe-eval` und `connect-src data:`, damit Tesseract im Browser ohne Fehlermeldungen startet.
 Seit Patch 1.40.57 akzeptiert die Richtlinie auch `'unsafe-inline'` in `style-src`. Damit funktionieren eingebettete Style-Attribute wieder ohne CSP-Warnung.
+Seit Patch 1.40.58 wird `style-src` aufgeteilt: `style-src-elem 'self'` und `style-src-attr 'self' 'unsafe-inline'`. Inline-Styles bleiben erlaubt, externe Styles müssen aber weiterhin lokal geladen werden.
 
 Beispiel einer gültigen CSV:
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -5,11 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Half-Life: Alyx Translation Tool</title>
     <!-- Sicherheitsrichtlinie für Electron: verhindert Warnhinweise -->
-    <!-- Aktualisierte CSP: Erlaubt YouTube, Blob-Worker und Inline-Styles -->
+    <!-- Aktualisierte CSP: Inline-Styles sind über style-src-attr erlaubt -->
     <meta http-equiv="Content-Security-Policy"
           content="default-src 'self';
                    script-src 'self' https://www.youtube.com 'unsafe-inline';
-                   style-src 'self' 'unsafe-inline';
+                   style-src-elem 'self';
+                   style-src-attr 'self' 'unsafe-inline';
                    frame-src https://www.youtube.com blob:;
                    img-src 'self' data: https://i.ytimg.com;
                    worker-src 'self' blob:;">


### PR DESCRIPTION
## Zusammenfassung
- CSP in `hla_translation_tool.html` strenger gefasst: Inline-Styles nur noch über `style-src-attr`
- Hinweis auf neue Direktiven in der README ergänzt

## Testanweisungen
- `npm test` ausführen

------
https://chatgpt.com/codex/tasks/task_e_6857d968a82c83279b0f6b0e182d8a30