### PR TITLE
Bugfix Video-Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Korrektes Skalieren nach erneutem Öffnen:** Der Player passt sich nach dem Wiedereinblenden automatisch an die aktuelle Fenstergröße an.
 * **Aktualisierung im Hintergrund:** Selbst bei geschlossenem Player wird die Größe im Hintergrund neu berechnet und beim nächsten Öffnen korrekt übernommen.
 * **Verbesserte Thumbnail-Ladefunktion:** Vorschaubilder werden über `i.ytimg.com` geladen und die gesamte Zeile ist zum Öffnen des Videos anklickbar.
+* **Fehlerhinweis bei fehlender YouTube-API:** Lädt der Player nicht, erscheint eine Meldung statt eines schwarzen Fensters.
 * **Hilfsfunktion `extractYoutubeId`:** Einheitliche Erkennung der Video-ID aus YouTube-Links.
 * **Schlankerer Video-Manager:** URL-Eingabefeld unter den Buttons und eine klar beschriftete Aktions-Spalte. Der Player behält auf allen Monitoren sein 16:9-Format, ohne seitlichen Beschnitt, und die Steuerleiste bleibt sichtbar.
 * **Maximierte Listenbreite:** Die gespeicherten Videos beanspruchen nun maximal 480 px Breite. Titelspalte und Vorschaubild bleiben schlank und das Thumbnail hält stets das Seitenverhältnis 16:9.

--- a/tests/openVideoDialog.test.js
+++ b/tests/openVideoDialog.test.js
@@ -71,4 +71,13 @@ describe('openVideoDialog und Slider', () => {
         slider.oninput();
         expect(window.currentYT.seekTo).toHaveBeenCalledWith(42, true);
     });
+
+    test('zeigt Meldung bei fehlender YT-API', () => {
+        window.YT = undefined;
+        const { openVideoDialog } = loadModule();
+        const bookmark = { url: 'https://youtu.be/xyz', title: 't', time: 0 };
+        openVideoDialog(bookmark, 0);
+        const err = document.querySelector('.yt-error');
+        expect(err).not.toBeNull();
+    });
 });

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2811,3 +2811,10 @@ th:nth-child(6) {
 #ocrSettingsDrawer .result-preview.yellow{ background:#664; }
 #ocrSettingsDrawer .result-preview.red   { background:#600; }
 
+/* Meldung, falls der YouTube-Player nicht geladen werden konnte */
+.yt-error {
+    padding: 1rem;
+    text-align: center;
+    color: #ff8080;
+}
+

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -590,6 +590,16 @@ export function openVideoDialog(bookmark, index) {
 
     // neue URL setzen und Player initialisieren
     iframe.src = `https://www.youtube.com/embed/${extractYoutubeId(bookmark.url)}?start=${Math.floor(bookmark.time)}&enablejsapi=1`;
+
+    // Fehlerhinweis, falls die YouTube-API fehlt
+    if (typeof YT === 'undefined' || !YT.Player) {
+        const warn = document.createElement('div');
+        warn.textContent = 'YouTube-Player konnte nicht geladen werden – Verbindung prüfen.';
+        warn.className = 'yt-error';
+        iframe.replaceWith(warn);
+        return;
+    }
+
     window.currentYT = new YT.Player('videoPlayerFrame');
 
     const slider = document.getElementById('videoSlider');


### PR DESCRIPTION
## Summary
- zeige eine Fehlermeldung an, wenn die YouTube-API fehlt
- kleine CSS-Klasse `yt-error` hinzugefügt
- Test für fehlende YouTube-API
- README mit neuem Feature aktualisiert

## Testing
- `npm test` *(fails: Operation cancelled while installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857ef8a362483278c751854d97674b1