### PR TITLE
Implement Fallback for Video-Manager Dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Scrollbarer Videobereich:** Wird das Video höher als der Dialog, lässt sich der Player innerhalb des Fensters scrollen und die Buttons bleiben sichtbar.
 * **Verbesserte Scroll-Performance:** Der Wheel-Handler ist nun passiv und reagiert flüssiger auf Mausbewegungen.
 * **Beobachter pausieren beim Schließen:** Der ResizeObserver meldet sich ab, sobald der Dialog verborgen wird, und startet erst beim erneuten Öffnen. Dank zusätzlicher Prüfungen entstehen keine Endlos-Schleifen mehr.
+* **Kompatibles Öffnen des Video-Managers:** Erkennt fehlendes `showModal()` und zeigt den Dialog trotzdem an.
 * **Optimal genutzter Player-Bereich:** Breite und Höhe orientieren sich jetzt an der größeren freien Dimension. Die Player-Sektion schrumpft exakt auf die IFrame-Höhe und vermeidet so schwarze Balken.
 * **Einheitliche Größenberechnung:** Auch `adjustVideoPlayerSize()` prüft nun freie Breite und Höhe und wählt automatisch das größere Maß.
 * **OCR-Funktion im Player:** Ein präzises Overlay deckt nur die Untertitel ab. Der Auto-Modus pausiert bei einem Treffer das Video und sammelt den Text im rechten Panel. F9 erstellt jetzt einen einzelnen OCR‑Screenshot. Ein neuer 🔍‑Button aktiviert den Dauerlauf.

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -210,38 +210,40 @@ window.addEventListener('resize', () => {
     }
 });
 
+// Dialog oeffnen mit Fallback fuer alte Electron-Versionen
 openVideoManager.onclick = async () => {
     await refreshTable();
-    // ResizeObserver erneut aktivieren
     if (window.videoDialogObserver) window.videoDialogObserver.observe(videoMgrDialog);
-    videoMgrDialog.showModal();
+    if (typeof videoMgrDialog.showModal === 'function') {
+        videoMgrDialog.showModal();
+    } else {
+        videoMgrDialog.setAttribute('open', '');
+    }
     adjustVideoDialogHeight();
     adjustVideoPlayerSize(true);
     if (typeof calcLayout === 'function') {
         calcLayout();
     }
 };
-closeVideoDlg.onclick = () => {
-    videoMgrDialog.close();
+
+// Gemeinsame Funktion zum Schliessen des Dialogs
+function hideVideoDialog() {
+    if (typeof videoMgrDialog.close === 'function') {
+        videoMgrDialog.close();
+    } else {
+        videoMgrDialog.removeAttribute('open');
+    }
     if (typeof closeVideoDialog === 'function') closeVideoDialog();
     adjustVideoDialogHeight();
-    // Beobachtung stoppen, um Schleifen zu vermeiden
     if (window.videoDialogObserver) window.videoDialogObserver.unobserve(videoMgrDialog);
-};
+}
+
+closeVideoDlg.onclick = hideVideoDialog;
 if (closeVideoDlgSmall) {
     // kompakte Variante fuer schmale Fenster
-    closeVideoDlgSmall.onclick = () => {
-        videoMgrDialog.close();
-        if (typeof closeVideoDialog === 'function') closeVideoDialog();
-        adjustVideoDialogHeight();
-        if (window.videoDialogObserver) window.videoDialogObserver.unobserve(videoMgrDialog);
-    };
+    closeVideoDlgSmall.onclick = hideVideoDialog;
 }
-videoMgrDialog.addEventListener('cancel', () => {
-    if (typeof closeVideoDialog === 'function') closeVideoDialog();
-    adjustVideoDialogHeight();
-    if (window.videoDialogObserver) window.videoDialogObserver.unobserve(videoMgrDialog);
-});
+videoMgrDialog.addEventListener('cancel', hideVideoDialog);
 document.addEventListener('keydown', e => {
     if (e.key === 'Escape' && videoMgrDialog.open) {
         if (typeof closeVideoDialog === 'function') closeVideoDialog();


### PR DESCRIPTION
## Summary
- handle missing `showModal()` for older Electron builds
- close the dialog via helper function using fallback
- document compatibility update in README

## Testing
- `npm test` *(fails: Building easyocr dependencies requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_6857f63765188327bf0397ed820f17c0