### PR TITLE
Fix Video-Manager showModal guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Beobachter pausieren beim Schließen:** Der ResizeObserver meldet sich ab, sobald der Dialog verborgen wird, und startet erst beim erneuten Öffnen. Dank zusätzlicher Prüfungen entstehen keine Endlos-Schleifen mehr.
 * **Kompatibles Öffnen des Video-Managers:** Erkennt fehlendes `showModal()` und zeigt den Dialog trotzdem an.
 * **Reaktivierter Klick-Listener:** Der "Videos"-Button öffnet den Manager nun zuverlässig.
+* **Sicheres Öffnen des Video-Managers:** `showModal()` wird nur noch aufgerufen, wenn der Dialog geschlossen ist.
 * **Optimal genutzter Player-Bereich:** Breite und Höhe orientieren sich jetzt an der größeren freien Dimension. Die Player-Sektion schrumpft exakt auf die IFrame-Höhe und vermeidet so schwarze Balken.
 * **Einheitliche Größenberechnung:** Auch `adjustVideoPlayerSize()` prüft nun freie Breite und Höhe und wählt automatisch das größere Maß.
 * **OCR-Funktion im Player:** Ein präzises Overlay deckt nur die Untertitel ab. Der Auto-Modus pausiert bei einem Treffer das Video und sammelt den Text im rechten Panel. F9 erstellt jetzt einen einzelnen OCR‑Screenshot. Ein neuer 🔍‑Button aktiviert den Dauerlauf.

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -213,6 +213,11 @@ window.addEventListener('resize', () => {
 // Dialog oeffnen mit Fallback fuer alte Electron-Versionen
 openVideoManager.onclick = async () => {
     await refreshTable();
+    // Bereits geoeffnet? Dann nur in den Vordergrund holen
+    if (videoMgrDialog.open) {
+        videoMgrDialog.focus();
+        return;
+    }
     if (window.videoDialogObserver) window.videoDialogObserver.observe(videoMgrDialog);
     if (typeof videoMgrDialog.showModal === 'function') {
         videoMgrDialog.showModal();


### PR DESCRIPTION
## Summary
- verhindere doppeltes Öffnen des Video-Managers
- Ergänzung in README zu neuer Fehlerbehebung

## Testing
- `npm test` *(fehlgeschlagen: Paketinstallation blockiert)*

------
https://chatgpt.com/codex/tasks/task_e_6857fd07458c8327b6bfbe75334561fa