### PR TITLE
Optionales Paket-Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 17. Für die Bildvorverarbeitung installiert das Skript zusätzlich `opencv-python-headless` und `Pillow`.
 18. `start_tool.py` merkt sich den letzten Git-Stand und den Hash der `package-lock.json`. Sind keine Änderungen erkennbar, werden `git reset`, `git fetch` und `npm ci` übersprungen. Fehlende Python-Pakete installiert ein einziger `pip`-Aufruf.
 19. Der Hash wird in `.modules_hash` gespeichert, damit erneute `npm ci`-Aufrufe nur bei Änderungen erfolgen. Diese Datei ist ebenfalls vom Repository ausgeschlossen.
+20. In `requirements.txt` gekennzeichnete Zeilen mit `# optional` werden bei `verify_environment.py` nur informativ geprüft und lassen den Test bestehen.
 
 ### ElevenLabs-Dubbing
 

--- a/verify_environment.py
+++ b/verify_environment.py
@@ -94,19 +94,35 @@ def check_python_packages() -> bool:
     if not os.path.exists(req):
         report("requirements.txt", False, "nicht gefunden")
         return False
-    missing: list[str] = []
+
+    fehlend: list[str] = []          # Pflicht-Pakete, die fehlen
+    fehlend_optional: list[str] = []  # Optionale Pakete, die fehlen
+
     with open(req, "r", encoding="utf-8") as f:
         for line in f:
-            line = line.strip()
-            if not line or line.startswith("#"):
+            zeile = line.strip()
+            if not zeile or zeile.startswith("#"):
                 continue
-            mod = line.split("==")[0].split(">=")[0]
+
+            optional = "# optional" in zeile
+            mod = zeile.split("#")[0].split("==")[0].split(">=")[0].strip()
+
             if importlib.util.find_spec(mod) is None:
-                missing.append(mod)
-    if missing:
-        report("Python-Pakete", False, ", ".join(missing))
+                if optional:
+                    fehlend_optional.append(mod)
+                else:
+                    fehlend.append(mod)
+
+    if fehlend:
+        report("Python-Pakete", False, ", ".join(fehlend))
         return False
-    report("Python-Pakete", True, "alle vorhanden")
+
+    if fehlend_optional:
+        detail = "fehlend: " + ", ".join(fehlend_optional)
+        report("Optionale Pakete", True, detail)
+    else:
+        report("Python-Pakete", True, "alle vorhanden")
+
     return True
 
 


### PR DESCRIPTION
## Summary
- erweitere `verify_environment.py` um Erkennung optionaler Pakete
- beschreibe das neue Verhalten in der README

## Testing
- `python verify_environment.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685823b73f2c83279d725c965ce714b8