### PR TITLE
Fix cwd handling in verify script

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,10 +237,11 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 14. Zudem erkennt das Skript automatisch eine vorhandene NVIDIA‑GPU und installiert PyTorch mitsamt EasyOCR wahlweise als CUDA- oder CPU-Version.
 15. Bereits vorhandene Python‑Pakete werden beim Start übersprungen, damit das Setup schneller abgeschlossen ist.
 16. `run_easyocr.py` verwendet eine globale EasyOCR-Instanz. Über die Umgebungsvariable `HLA_OCR_LANGS` lassen sich die Sprachen anpassen (Standard: `en,de`).
-17. Für die Bildvorverarbeitung installiert das Skript zusätzlich `opencv-python-headless` und `Pillow`.
+17. Für die Bildvorverarbeitung installiert das Skript `Pillow>=10.0`. `opencv-python-headless>=4.9.0` ist nun als optionales Paket gekennzeichnet.
 18. `start_tool.py` merkt sich den letzten Git-Stand und den Hash der `package-lock.json`. Sind keine Änderungen erkennbar, werden `git reset`, `git fetch` und `npm ci` übersprungen. Fehlende Python-Pakete installiert ein einziger `pip`-Aufruf.
 19. Der Hash wird in `.modules_hash` gespeichert, damit erneute `npm ci`-Aufrufe nur bei Änderungen erfolgen. Diese Datei ist ebenfalls vom Repository ausgeschlossen.
 20. In `requirements.txt` gekennzeichnete Zeilen mit `# optional` werden bei `verify_environment.py` nur informativ geprüft und lassen den Test bestehen.
+21. `verify_environment.py` führt Befehle jetzt direkt im Projektordner aus, wodurch besonders Git-Kommandos zuverlässiger arbeiten.
 
 ### ElevenLabs-Dubbing
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 argostranslate
 torch>=2.3
 easyocr>=1.7
-opencv-python-headless
-Pillow
+opencv-python-headless>=4.9.0      # optional
+Pillow>=10.0

--- a/verify_environment.py
+++ b/verify_environment.py
@@ -25,9 +25,9 @@ def report(name: str, ok: bool, detail: str = "") -> None:
     REPORTS.append((name, ok, detail))
 
 
-def run(cmd: str) -> str:
-    """Führt ein Kommando aus und gibt die Ausgabe zurück."""
-    return subprocess.check_output(cmd, shell=True, text=True).strip()
+def run(cmd: str, cwd: str | None = BASE_DIR) -> str:
+    """Führt ein Kommando im angegebenen Verzeichnis aus und gibt die Ausgabe zurück."""
+    return subprocess.check_output(cmd, shell=True, cwd=cwd, text=True).strip()
 
 
 def check_git_installed() -> bool:


### PR DESCRIPTION
## Summary
- allow `verify_environment.py` to run commands in a specific folder
- mark OpenCV as optional and require Pillow 10
- document optional OpenCV and new cwd option in README

## Testing
- `python verify_environment.py --check-only`
- `python verify_environment.py` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68582be77dc08327bbfb483b8545fc5f