### PR TITLE
Fix Video manager visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Sicheres Öffnen des Video-Managers:** `showModal()` wird nur noch aufgerufen, wenn der Dialog geschlossen ist.
 * **Fehlerfreies Mehrfach-Öffnen:** Beide Klick-Handler prüfen jetzt das `open`-Attribut und vermeiden so eine DOMException.
 * **Schnellerer Dialog-Aufruf:** Die `open`-Prüfung passiert vor dem Neuladen der Tabelle und spart so unnötige Arbeit.
+* **Startet geschlossen:** Beim Laden der Anwendung bleibt der Video-Manager nun verborgen und öffnet sich erst nach Klick auf den "Videos"-Button.
 * **Mindestgröße für den Video-Dialog:** Beim Öffnen passt sich der Dialog an die Fenstergröße an, bleibt aber mindestens 600×400 px groß. Alle ❌-Buttons rufen jetzt sicher `videoDlg.close()` auf.
 * **Optimal genutzter Player-Bereich:** Breite und Höhe orientieren sich jetzt an der größeren freien Dimension. Die Player-Sektion schrumpft exakt auf die IFrame-Höhe und vermeidet so schwarze Balken.
 * **Einheitliche Größenberechnung:** Auch `adjustVideoPlayerSize()` prüft nun freie Breite und Höhe und wählt automatisch das größere Maß.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -58,7 +58,7 @@
                 </div>
             </div>
 
-            <button id="openVideoManager" class="toolbar-btn">Videos</button>
+            <button id="openVideoManager" class="btn btn-secondary">Videos</button>
 
             <!-- Spielstart-Leiste -->
             <div class="start-bar">

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2416,6 +2416,8 @@ th:nth-child(6) {
 }
 
 .video-dialog {
+    /* Ohne open-Attribut verstecken */
+    display: none;
     /* Platz auf großen Bildschirmen optimal ausnutzen */
     width: 80vw;
     max-width: 1080px;
@@ -2428,7 +2430,6 @@ th:nth-child(6) {
     color: #e0e0e0;
     padding: 24px;
     margin: 24px auto;
-    display: flex;
     flex-direction: column;
     overflow: auto;
     resize: both;            /* einfache Größenänderung per Maus */
@@ -2436,6 +2437,11 @@ th:nth-child(6) {
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
+}
+
+/* Dialog erst anzeigen, wenn geöffnet */
+.video-dialog[open] {
+    display: flex;
 }
 
 /* Abdunklung hinter dem Dialog */


### PR DESCRIPTION
## Summary
- Video-Dialog versteckt sich nun, bis er geöffnet wird
- Videos-Knopf nutzt die gleiche Klasse wie die anderen Buttons
- README um neuen Eintrag ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858365eb4808327a28d1eec0a2c88bc