### PR TITLE
Add fallback when YouTube API unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Aktualisierung im Hintergrund:** Selbst bei geschlossenem Player wird die Größe im Hintergrund neu berechnet und beim nächsten Öffnen korrekt übernommen.
 * **Verbesserte Thumbnail-Ladefunktion:** Vorschaubilder werden über `i.ytimg.com` geladen und die gesamte Zeile ist zum Öffnen des Videos anklickbar.
 * **Fehlerhinweis bei fehlender YouTube-API:** Lädt der Player nicht, erscheint eine Meldung statt eines schwarzen Fensters.
+* **Fallback ohne YouTube-API:** Kann das Script nicht geladen werden, öffnet sich der Link automatisch im Browser.
 * **Toast bei gesperrten Videos:** Tritt ein YouTube-Fehler auf, informiert ein roter Hinweis über mögliche Proxy-Pflicht.
 * **Strg+Umschalt+V** liest eine YouTube-URL aus der Zwischenablage und fügt sie automatisch ein.
 * **Dialog frei verschieb- und skalierbar:** Der Video-Manager lässt sich per Maus verschieben und in der Größe anpassen.

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -590,12 +590,19 @@ export function openVideoDialog(bookmark, index) {
     // neue URL setzen und Player initialisieren
     iframe.src = `https://www.youtube.com/embed/${extractYoutubeId(bookmark.url)}?start=${Math.floor(bookmark.time)}&enablejsapi=1`;
 
-    // Fehlerhinweis, falls die YouTube-API fehlt
+    // Fehlerhinweis und Fallback, falls die YouTube-API fehlt
     if (typeof YT === 'undefined' || !YT.Player) {
         const warn = document.createElement('div');
         warn.textContent = 'YouTube-Player konnte nicht geladen werden – Verbindung prüfen.';
         warn.className = 'yt-error';
         iframe.replaceWith(warn);
+
+        // Link ersatzweise extern öffnen
+        if (window.electronAPI && window.electronAPI.openExternal) {
+            window.electronAPI.openExternal(bookmark.url);
+        } else {
+            window.open(bookmark.url, '_blank');
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary
- handle missing YouTube API by opening the link externally
- describe the new fallback in the README

## Testing
- `npm ci`
- `npm test --silent` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68584cfc9e7c8327ade738e4dd8049da