### PR TITLE
Fix Video-Dialog default width

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Maximierte Listenbreite:** Die gespeicherten Videos beanspruchen nun maximal 480 px Breite. Titelspalte und Vorschaubild bleiben schlank und das Thumbnail hält stets das Seitenverhältnis 16:9.
 * **Verbesserte dynamische Dialoghöhe:** Der Video-Manager schrumpft nun auch bei kleinen Fenstern und entfernt überflüssigen Leerraum.
 * **Automatische Dialogbreite:** Ohne geöffneten Player richtet sich die Breite des Video-Managers nach der Liste.
+* **Konstante Dialoggröße:** Dank `clamp()` bleibt das Fenster jetzt auch ohne geladenes Video angenehm breit und bietet Platz für künftige Erweiterungen.
 * **Flexibles Fenster für gespeicherte Videos:** Höhe passt sich jetzt automatisch an Videoplayer und Liste an.
 * **Voll ausgenutzte Video-Liste:** Das Tabellenfeld wächst bis zum unteren Rand des Dialogs und lässt keinen Leerraum unter dem Schließen-Button.
 * **Breitenbegrenzter Player:** Die Breite richtet sich nach der verfügbaren Höhe und überschreitet nie das Format 16:9.

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -185,22 +185,15 @@ function delayedPlayerResize() {
 // passt Höhe und Breite des Video-Managers dynamisch an
 function adjustVideoDialogHeight() {
     const dlg = videoDlg;
-    const maxH = Math.floor(window.innerHeight * 0.9);
+    const maxH = Math.floor(window.innerHeight * 0.85);
     const needH = dlg.scrollHeight;
     const newH  = Math.min(maxH, needH);
-    // Nur Werte setzen, wenn sie sich geaendert haben
+    // Nur setzen, wenn sich der Wert geändert hat
     if (dlg.__lastH !== newH) {
         dlg.style.height = newH + 'px';
         dlg.__lastH = newH;
     }
-
-    const maxW = Math.floor(window.innerWidth * 0.9);
-    const needW = dlg.scrollWidth;
-    const newW  = Math.min(maxW, needW);
-    if (dlg.__lastW !== newW) {
-        dlg.style.width = newW + 'px';
-        dlg.__lastW = newW;
-    }
+    // Breite wird durch CSS geregelt
 
     if (typeof adjustVideoPlayerSize === 'function') adjustVideoPlayerSize();
 }
@@ -283,9 +276,9 @@ openVideoManager.addEventListener('click', async () => {
     // schon offen? – dann einfach ignorieren
     if (videoDlg.open) return;
 
-    // Dialoggröße an Fenster anpassen
-    videoDlg.style.width  = Math.min(window.innerWidth  * 0.9, 1100) + 'px';
-    videoDlg.style.height = Math.min(window.innerHeight * 0.9,  750) + 'px';
+    // Größe wird überwiegend durch CSS geregelt
+    videoDlg.style.width  = '';
+    videoDlg.style.height = '';
 
     videoDlg.showModal();
     if (window.videoDialogObserver) window.videoDialogObserver.observe(videoDlg);

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2418,13 +2418,15 @@ th:nth-child(6) {
 .video-dialog {
     /* Ohne open-Attribut verstecken */
     display: none;
-    /* Platz auf großen Bildschirmen optimal ausnutzen */
-    width: 80vw;
-    max-width: 1080px;
-    height: 70vh;
-    max-height: 90vh;
+    /* Breite reagiert flexibel auf das Fenster
+       und bleibt zwischen 520 und 900px */
+    width: clamp(520px, 60vw, 900px);
+    max-width: 900px;
+    /* Höhe an Fenstergröße anpassen */
+    max-height: 85vh;
+    height: clamp(400px, 70vh, 85vh);
     /* Mindestgröße bleibt erhalten */
-    min-width: 600px;
+    min-width: 520px;
     min-height: 400px;
     background: #1a1a1a;
     color: #e0e0e0;


### PR DESCRIPTION
## Summary
- clamp width/height for the video dialog
- rely on CSS for opening width
- use a stable resize function
- document constant width in README

## Testing
- `npm test` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_685856d1ba0483278dcf76f1dff8248c