### PR TITLE
Add OCR footer and overlay handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Escape schließt den Einstell-Drawer:** Mit der Escape-Taste verschwindet nur der Drawer, der Player bleibt sichtbar.
 * **Präzisere Texterkennung:** Das Overlay endet jetzt 3 px über dem Slider und nutzt nur 14 % der Bildhöhe.
 * **Schnellerer Auto‑OCR‑Loop:** Läuft alle 750 ms und pausiert das Video ab vier erkannten Zeichen.
+* **Statusleiste mit GPU-Anzeige und Start-/Stop-Buttons** erleichtert die Kontrolle der Erkennung.
 ### 📊 Fortschritts‑Tracking
 
 * **Globale Dashboard‑Kacheln:** Gesamt, Übersetzt, Ordner komplett, **EN/DE/BEIDE/∑**

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -578,7 +578,12 @@
                     <button id="ocrDebug" title="Debug-Fenster">🐞</button>
                     <button id="ocrSettings" title="OCR-Einstellungen">⚙️</button>
                 </div>
-                <div id="ocrOverlay"></div>
+                <div id="ocrOverlay">
+                    <div class="handle nw"></div>
+                    <div class="handle ne"></div>
+                    <div class="handle sw"></div>
+                    <div class="handle se"></div>
+                </div>
                 <div id="ocrResultPanel">
                     <canvas id="roiPreview"></canvas>
                     <div id="ocrText"></div>
@@ -607,6 +612,13 @@
         </div>
         <div id="dlgResizeHandle" class="dialog-resize"></div>
     </dialog>
+    <footer id="ocrFooter">
+        <span id="gpuInfo">GPU: unbekannt</span>
+        <div class="footer-buttons">
+            <button id="ocrStart">Start OCR</button>
+            <button id="ocrStop">Stop</button>
+        </div>
+    </footer>
 
     <!-- Versionsanzeige -->
     <!-- Verlinkung zur aktuellen Version -->

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2864,6 +2864,38 @@ th:nth-child(6) {
 #ocrSettingsDrawer .result-preview.yellow{ background:#664; }
 #ocrSettingsDrawer .result-preview.red   { background:#600; }
 
+/* Footer mit GPU-Info und Start/Stop-Buttons */
+#ocrFooter {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 48px;
+    padding: 0 8px;
+    background: #242424;
+    color: #e0e0e0;
+}
+#ocrFooter button {
+    background: #333;
+    border: none;
+    color: #e0e0e0;
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+#ocrFooter button:hover { background: #444; }
+
+#ocrOverlay .handle {
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    background: #FFD54F;
+    border: 2px solid #fff;
+}
+#ocrOverlay .nw { top: -6px; left: -6px; cursor: nwse-resize; }
+#ocrOverlay .ne { top: -6px; right: -6px; cursor: nesw-resize; }
+#ocrOverlay .sw { bottom: -6px; left: -6px; cursor: nesw-resize; }
+#ocrOverlay .se { bottom: -6px; right: -6px; cursor: nwse-resize; }
+
 /* Meldung, falls der YouTube-Player nicht geladen werden konnte */
 .yt-error {
     padding: 1rem;

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -555,6 +555,7 @@ export function openPlayer(bookmark, index) {
 export function openVideoDialog(bookmark, index) {
     const dlg    = document.getElementById('videoMgrDialog');
     const player = document.getElementById('videoPlayerSection');
+    const gpu    = document.getElementById('gpuInfo');
     if (!dlg || !player) return;
     // Dialog nur oeffnen, wenn er noch nicht sichtbar ist
     if (!dlg.open) {
@@ -563,6 +564,7 @@ export function openVideoDialog(bookmark, index) {
     }
 
     player.classList.remove('hidden');
+    if (gpu) gpu.textContent = 'GPU: EasyOCR';
     // gleich nach dem Einblenden neu skalieren
     if (typeof window.adjustVideoPlayerSize === 'function') {
         window.adjustVideoPlayerSize(true);
@@ -632,6 +634,8 @@ export function openVideoDialog(bookmark, index) {
     const settingsBtn = document.getElementById('ocrSettings');
     const ocrOverlay = document.getElementById('ocrOverlay');
     const ocrPanel = document.getElementById('ocrResultPanel');
+    const startBtn = document.getElementById('ocrStart');
+    const stopBtn  = document.getElementById('ocrStop');
     const deleteBtn = document.getElementById('videoDelete');
     const closeBtn = document.getElementById('videoClose');
     if (ocrOverlay) {
@@ -769,6 +773,26 @@ export function openVideoDialog(bookmark, index) {
     }
     if (settingsBtn) {
         settingsBtn.onclick = openOcrSettings;
+    }
+    if (startBtn) {
+        // Startet die automatische OCR
+        startBtn.onclick = () => {
+            ocrActive = true;
+            player.classList.add('ocr-active');
+            ocrOverlay?.classList.remove('hidden');
+            ocrPanel?.classList.remove('hidden');
+            startAutoLoop();
+        };
+    }
+    if (stopBtn) {
+        // Stoppt die automatische OCR
+        stopBtn.onclick = () => {
+            stopAutoLoop();
+            ocrActive = false;
+            player.classList.remove('ocr-active');
+            ocrOverlay?.classList.add('hidden');
+            ocrPanel?.classList.add('hidden');
+        };
     }
     // Lösch-Button ruft nun die neue Funktion auf
     deleteBtn.onclick = deleteCurrentVideo;


### PR DESCRIPTION
## Summary
- add sichtbare Handles zum OCR-Overlay
- neue Footer-Leiste mit GPU-Info sowie Start/Stop-Buttons
- passenden CSS-Stil definiert
- README um neue Funktion ergaenzt
- Buttons starten und stoppen die OCR per ytPlayer.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68585dc861e48327b2a0add875e682bd