### PR TITLE
Video-Manager in Grid umgestellt

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Exportfunktion für Video-Bookmarks:** Gespeicherte Links lassen sich als `videoBookmarks.json` herunterladen.
 * **Dauerhafte Video-Suche:** Der Suchbegriff im Video-Manager bleibt zwischen den Sitzungen erhalten.
 * **Responsiver Video-Manager:** Fester Dialog-Abstand, flexible Toolbar mit Min-Buttons und kompaktem ❌-Icon bei schmaler Breite. Tabellenzeilen besitzen gleichmäßiges Padding und einen Hover-Effekt.
-* **Dreispaltiges Video-Dashboard:** Links Bibliothek mit Suche (Ctrl+F), in der Mitte ein 16:9‑Player mit schwebender Steuerleiste und rechts eine vertikale Aktionsleiste für Export, Screenshot und OCR. Die zuletzt gewählte Zeile wird beim erneuten Öffnen hervorgehoben.
+* **Zweispaltiges Video-Dashboard:** Links steht die Videoliste, rechts der 16:9‑Player mit schwebender Leiste. Das OCR‑Panel füllt darunter die komplette Breite und die Aktions-Icons befinden sich direkt unter dem Player.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 * **Flexible Player-Steuerleiste:** Bei schmalen Fenstern rutscht der Slider in eine zweite Zeile. Icons und Zeitangaben verkleinern sich automatisch.
 * **Fixierte Steuerleiste im Player:** Die Bedienelemente haften nun dank `position: sticky` direkt unter dem Video, besitzen volle Breite und liegen mit höherem `z-index` stets über dem Ergebnis-Panel. Die Liste nutzt variabel 22 % Breite (min. 260 px, max. 320 px).

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -534,8 +534,8 @@
 
     <!-- Video-Manager mit integriertem Player -->
     <dialog id="videoMgrDialog" class="video-dialog">
-        <div class="video-layout">
-            <div class="video-list-section">
+        <div class="wb-grid">
+            <section class="video-list-section">
                 <h2>📼 Gespeicherte Videos</h2>
                 <div class="video-toolbar">
                     <div class="video-search">
@@ -562,11 +562,11 @@
                     </table>
                 </div>
                 <button id="closeVideoDlg" class="btn btn-danger">❌ Schließen</button>
-            </div>
-            <div id="videoPlayerSection" class="video-player-section hidden">
+            </section>
+            <section id="videoPlayerSection" class="video-player-section hidden">
                 <div class="player-header"><span id="playerDialogTitle"></span></div>
                 <iframe id="videoPlayerFrame" allow="autoplay; fullscreen"></iframe>
-                <div class="player-controls">
+                <div id="playerControls" class="player-controls">
                     <button id="videoPlay">▶️</button>
                     <button id="videoBack">⏮️</button>
                     <button id="videoForward">⏭️</button>
@@ -577,6 +577,11 @@
                     <button id="ocrCopy" title="OCR kopieren">📋</button>
                     <button id="ocrDebug" title="Debug-Fenster">🐞</button>
                     <button id="ocrSettings" title="OCR-Einstellungen">⚙️</button>
+                    <button id="exportVideoBtn" class="action-btn" title="Export (E)">⭳</button>
+                    <button id="screenshotBtn" class="action-btn" title="Screenshot (S)">📸</button>
+                    <button id="ocrToggle" class="action-btn" title="OCR an/aus (F9)">🔍</button>
+                    <button id="videoDelete" class="action-btn danger" title="Löschen (Entf)">🗑️</button>
+                    <button id="videoClose" class="action-btn danger" title="Schließen (Esc)">❌</button>
                 </div>
                 <div id="ocrOverlay">
                     <div class="handle nw"></div>
@@ -596,29 +601,19 @@
                     <div id="ocrResultPreview" class="result-preview"></div>
                     <button id="ocrReset" class="btn btn-danger">Reset</button>
                 </div>
-            </div>
-            <div class="video-action-panel">
-                <button id="exportVideoBtn" class="action-btn" title="Export (E)">⭳</button>
-                <button id="screenshotBtn" class="action-btn" title="Screenshot (S)">📸</button>
-                <button id="ocrToggle" class="action-btn" title="OCR an/aus (F9)">🔍</button>
-                <div class="action-spacer"></div>
-                <button id="videoDelete" class="action-btn danger" title="Löschen (Entf)">🗑️</button>
-                <button id="videoClose" class="action-btn danger" title="Schließen (Esc)">❌</button>
-            </div>
-        </div>
-        <div id="ocrResultPanel" class="hidden">
-            <canvas id="roiPreview"></canvas>
-            <div id="ocrText"></div>
+            </section>
+            <section id="ocrResultPanel" class="ocr-panel hidden">
+                <canvas id="roiPreview"></canvas>
+                <div id="ocrText"></div>
+                <div class="ocr-controls">
+                    <span id="gpuInfo">GPU: unbekannt</span>
+                    <button id="ocrStart">Start OCR</button>
+                    <button id="ocrStop">Stop</button>
+                </div>
+            </section>
         </div>
         <div id="dlgResizeHandle" class="dialog-resize"></div>
     </dialog>
-    <footer id="ocrFooter">
-        <span id="gpuInfo">GPU: unbekannt</span>
-        <div class="footer-buttons">
-            <button id="ocrStart">Start OCR</button>
-            <button id="ocrStop">Stop</button>
-        </div>
-    </footer>
 
     <!-- Versionsanzeige -->
     <!-- Verlinkung zur aktuellen Version -->

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -20,6 +20,16 @@ const closeVideoDlg    = document.getElementById('closeVideoDlg');
 const closeVideoDlgSmall = document.getElementById('closeVideoDlgSmall');
 const exportVideoBtn   = document.getElementById('exportVideoBtn');
 const screenshotBtn    = document.getElementById('screenshotBtn');
+const playerControls   = document.getElementById('playerControls');
+
+// Aktions-Buttons direkt unter die Player-Steuerung hängen
+if (playerControls) {
+    ['exportVideoBtn','screenshotBtn','ocrToggle','videoDelete','videoClose']
+        .forEach(id => {
+            const el = document.getElementById(id);
+            if (el) playerControls.append(el);
+        });
+}
 
 // gespeicherten Suchbegriff wiederherstellen
 const gespeicherterFilter = localStorage.getItem('hla_videoFilter') || '';

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2898,3 +2898,26 @@ th:nth-child(6) {
     color: #ff8080;
 }
 
+/* ===== Neues Grid-Layout für Video-Manager ===== */
+.video-dialog{width:960px;height:600px}
+.wb-grid{
+    --gap:12px;
+    display:grid;
+    grid-template-columns:260px 1fr;
+    grid-template-rows:320px 1fr;
+    grid-template-areas:
+        "list player"
+        "ocr  ocr";
+    gap:var(--gap);
+    height:100%;
+    box-sizing:border-box;
+}
+.video-list-section{grid-area:list;border:1px solid #fff;padding:8px;overflow:auto;}
+.video-player-section{grid-area:player;border:1px solid #fff;padding:8px;position:relative;}
+.ocr-panel{grid-area:ocr;border:1px solid #fff;padding:8px;overflow:auto;}
+.player-controls .action-btn{margin-left:4px;}
+.video-action-panel{display:none;}
+@media(max-width:900px){
+  .wb-grid{grid-template-columns:1fr;grid-template-rows:auto auto 1fr;
+           grid-template-areas:"list" "player" "ocr";}
+}


### PR DESCRIPTION
## Zusammenfassung
- HTML des Video-Managers auf CSS-Grid umgestellt
- OCR-Steuerung direkt im Ergebnis-Panel untergebracht
- Aktions-Buttons ins Player-Control verschoben
- zugehörige Styles ergänzt
- README beschreibt nun das zweispaltige Dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685876db66e083279e38deeb0711caa9