### PR TITLE
Fix requirement parsing in start_tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ Seit Patch 1.40.56 erlaubt die Content Security Policy zusätzlich `wasm-unsafe-
 Seit Patch 1.40.57 akzeptiert die Richtlinie auch `'unsafe-inline'` in `style-src`. Damit funktionieren eingebettete Style-Attribute wieder ohne CSP-Warnung.
 Seit Patch 1.40.58 wird `style-src` aufgeteilt: `style-src-elem 'self'` und `style-src-attr 'self' 'unsafe-inline'`. Inline-Styles bleiben erlaubt, externe Styles müssen aber weiterhin lokal geladen werden.
 Seit Patch 1.40.59 entfernt die Web-App alle Tesseract-Dateien. Die OCR läuft jetzt ausschließlich über EasyOCR und benötigt keine zusätzlichen CSP-Ausnahmen.
+Seit Patch 1.40.60 ignoriert `start_tool.py` Kommentare in `requirements.txt`, damit `pip install` unter Windows nicht mehr scheitert.
 
 Beispiel einer gültigen CSV:
 

--- a/start_tool.py
+++ b/start_tool.py
@@ -209,7 +209,12 @@ req_file = os.path.join(repo_path, "requirements.txt")
 if os.path.exists(req_file):
     try:
         with open(req_file, "r", encoding="utf-8") as f:
-            packages = [ln.strip() for ln in f if ln.strip() and not ln.startswith("#")]
+            packages = []
+            for ln in f:
+                # Kommentare am Zeilenende entfernen, damit pip keine Fehlermeldung wirft
+                clean = ln.split("#", 1)[0].strip()
+                if clean:
+                    packages.append(clean)
         missing = []
         for pkg in packages:
             if pkg.startswith("torch") or pkg.startswith("easyocr"):


### PR DESCRIPTION
## Summary
- ignore comments in `requirements.txt` when installing packages
- document the fix in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68587fb3fddc832792d10881a0c99893