### PR TITLE
Fix pip path quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Seit Patch 1.40.57 akzeptiert die Richtlinie auch `'unsafe-inline'` in `style-sr
 Seit Patch 1.40.58 wird `style-src` aufgeteilt: `style-src-elem 'self'` und `style-src-attr 'self' 'unsafe-inline'`. Inline-Styles bleiben erlaubt, externe Styles müssen aber weiterhin lokal geladen werden.
 Seit Patch 1.40.59 entfernt die Web-App alle Tesseract-Dateien. Die OCR läuft jetzt ausschließlich über EasyOCR und benötigt keine zusätzlichen CSP-Ausnahmen.
 Seit Patch 1.40.60 ignoriert `start_tool.py` Kommentare in `requirements.txt`, damit `pip install` unter Windows nicht mehr scheitert.
+Seit Patch 1.40.61 setzt `start_tool.py` den Pfad zum Python-Interpreter in Anführungszeichen, wodurch `pip install` auch bei Leerzeichen im Pfad funktioniert.
 
 Beispiel einer gültigen CSV:
 

--- a/start_tool.py
+++ b/start_tool.py
@@ -17,6 +17,11 @@ import importlib.util
 import shutil
 import hashlib
 
+# Helfer, um Pfade mit Leerzeichen korrekt zu quoten
+def quote_path(path: str) -> str:
+    """Gibt den Pfad in Anführungszeichen zurück, falls nötig."""
+    return f'"{path}"' if " " in path else path
+
 # Pfad dieses Skripts und Log-Datei festlegen
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 LOGFILE = os.path.join(BASE_DIR, "setup.log")
@@ -223,7 +228,8 @@ if os.path.exists(req_file):
             if not has_module(mod):
                 missing.append(pkg)
         if missing:
-            run(f"{sys.executable} -m pip install --disable-pip-version-check -q " + " ".join(missing))
+            cmd = f"{quote_path(sys.executable)} -m pip install --disable-pip-version-check -q " + " ".join(missing)
+            run(cmd)
         log("pip install erfolgreich")
     except subprocess.CalledProcessError as e:
         print("pip install fehlgeschlagen. Weitere Details siehe setup.log")
@@ -241,13 +247,13 @@ cuda_available = shutil.which("nvidia-smi") is not None
 if not has_module("torch"):
     log("Installiere PyTorch")
     if cuda_available:
-        run(f"{sys.executable} -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121")
+        run(f"{quote_path(sys.executable)} -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121")
     else:
-        run(f"{sys.executable} -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu")
+        run(f"{quote_path(sys.executable)} -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu")
 
 if not has_module("easyocr"):
     log("Installiere EasyOCR")
-    run(f"{sys.executable} -m pip install easyocr opencv-python-headless Pillow")
+    run(f"{quote_path(sys.executable)} -m pip install easyocr opencv-python-headless Pillow")
 
 
 # ----------------------- Haupt-Abhaengigkeiten installieren -----------------


### PR DESCRIPTION
## Summary
- quote Python interpreter path in `start_tool.py`
- document pip quoting fix in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685881928638832797418ac66bab2504