### PR TITLE
Fix Python package check

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 20. In `requirements.txt` gekennzeichnete Zeilen mit `# optional` werden bei `verify_environment.py` nur informativ geprüft und lassen den Test bestehen.
 21. `verify_environment.py` führt Befehle jetzt direkt im Projektordner aus, wodurch besonders Git-Kommandos zuverlässiger arbeiten.
 22. Sowohl `verify_environment.py` als auch `start_tool.py` prüfen nun die Python-Architektur und geben bei 32‑Bit-Versionen einen deutlichen Hinweis.
+23. Die Paketprüfung berücksichtigt jetzt abweichende Importnamen (z.B. `Pillow` ↦ `PIL`). Dadurch meldet `verify_environment.py` keine Fehlalarme mehr.
 
 ### ElevenLabs-Dubbing
 

--- a/verify_environment.py
+++ b/verify_environment.py
@@ -134,13 +134,18 @@ def check_python_packages(retry: bool = False) -> bool:
                 continue
 
             optional = "# optional" in zeile
-            mod = zeile.split("#")[0].split("==")[0].split(">=")[0].strip()
+            pip_pkg = zeile.split("#")[0].split("==")[0].split(">=")[0].strip()
+            # Einige Paketnamen weichen vom eigentlichen Importnamen ab
+            mod = {
+                "pillow": "PIL",
+                "opencv-python-headless": "cv2",
+            }.get(pip_pkg.lower(), pip_pkg)
 
             if importlib.util.find_spec(mod) is None:
                 if optional:
-                    fehlend_optional.append(mod)
+                    fehlend_optional.append(pip_pkg)
                 else:
-                    fehlend.append(mod)
+                    fehlend.append(pip_pkg)
 
     if fehlend or fehlend_optional:
         if FIX_MODE and not retry:


### PR DESCRIPTION
## Summary
- map Pillow und OpenCV-Python auf richtige Importnamen im Environment-Check
- Hinweis auf verbesserte Paketpruefung in der README

## Testing
- `python verify_environment.py --check-only`
- `npm test` *(scheiterte, da node-easyocr riesige Downloads ausfuehren will)*

------
https://chatgpt.com/codex/tasks/task_e_68588702d1fc8327a9540b027fcf8caa