### PR TITLE
Fix start_tool without remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 21. `verify_environment.py` führt Befehle jetzt direkt im Projektordner aus, wodurch besonders Git-Kommandos zuverlässiger arbeiten.
 22. Sowohl `verify_environment.py` als auch `start_tool.py` prüfen nun die Python-Architektur und geben bei 32‑Bit-Versionen einen deutlichen Hinweis.
 23. Die Paketprüfung berücksichtigt jetzt abweichende Importnamen (z.B. `Pillow` ↦ `PIL`). Dadurch meldet `verify_environment.py` keine Fehlalarme mehr.
+24. `start_tool.py` funktioniert jetzt auch ohne konfiguriertes Remote und setzt das Repository dann nur lokal zurück.
 
 ### ElevenLabs-Dubbing
 


### PR DESCRIPTION
## Summary
- handle missing git remote in `start_tool.py`
- quote packages correctly for `pip install`
- document remote-less start option in README

## Testing
- `npm test` *(fails: installing python deps blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6858faa97ab483278af3493c3461f6df