### PR TITLE
Fix Video-Layout und OCR-Panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Strukturiertes Grid-Layout:** Das Dashboard nutzt nun ein zweispaltiges CSS‑Grid (`260px 1fr`) mit weißen Rahmen. Bei weniger als 900 px Breite stapeln sich Liste, Player und OCR‑Panel automatisch.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 * **Flexible Player-Steuerleiste:** Bei schmalen Fenstern rutscht der Slider in eine zweite Zeile. Icons und Zeitangaben verkleinern sich automatisch.
-* **Fixierte Steuerleiste im Player:** Die Bedienelemente haften nun dank `position: sticky` direkt unter dem Video, besitzen volle Breite und liegen mit höherem `z-index` stets über dem Ergebnis-Panel. Die Liste nutzt variabel 22 % Breite (min. 260 px, max. 320 px).
+* **Steuerleiste unter dem Video:** Die Buttons sitzen jetzt statisch unter dem Player, nutzen die volle Breite und bleiben in einer Zeile.
 * **Scrollbarer Videobereich:** Wird das Video höher als der Dialog, lässt sich der Player innerhalb des Fensters scrollen und die Buttons bleiben sichtbar.
 * **Verbesserte Scroll-Performance:** Der Wheel-Handler ist nun passiv und reagiert flüssiger auf Mausbewegungen.
 * **Beobachter pausieren beim Schließen:** Der ResizeObserver meldet sich ab, sobald der Dialog verborgen wird, und startet erst beim erneuten Öffnen. Dank zusätzlicher Prüfungen entstehen keine Endlos-Schleifen mehr.
@@ -129,7 +129,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Debug-Fenster für die OCR:** Ein 🐞‑Button öffnet ein separates Fenster. Jetzt wird nach jedem Durchlauf der Screenshot samt Rohtext per `postMessage` übertragen und in einer kleinen Galerie gesammelt; ein erneuter Klick schließt das Fenster und stoppt den Stream.
 * **OCR nur noch per EasyOCR-Worker:** Die aufwändigen Tesseract-Fallbacks wurden entfernt. Die Erkennung läuft komplett über den lokalen Python-Worker.
 * **Exakte Video-Positionierung:** Playerbreite, Steuerleiste und Overlay richten sich nun dynamisch nach Dialog- und Panelgröße aus. Das IFrame skaliert dabei rein per CSS und die Berechnung läuft auch im versteckten Zustand.
-* **Vollbreite ohne OCR:** Das Ergebnis-Panel bleibt standardmäßig verborgen und erscheint nur bei aktivierter Erkennung.
+* **OCR-Panel immer sichtbar:** Ein Platzhalter weist nun darauf hin, wenn noch kein Text erkannt wurde.
 * **Immer sichtbarer Player:** Eine Mindestgröße von 320×180 verhindert, dass der eingebettete Player verschwindet.
 * **Screenshot per IPC:** Der Kanal `capture-frame` liefert einen sofortigen Screenshot des Hauptfensters.
 * **Gesicherte Schnittstelle im Preload:** Über `window.api.captureFrame(bounds)` kann der Renderer nun sicher einen Screenshot anfordern.

--- a/tests/ocrOverlayVisibility.test.js
+++ b/tests/ocrOverlayVisibility.test.js
@@ -34,7 +34,7 @@ describe('OCR-Overlay sichtbar schalten', () => {
                     <button id="videoDelete"></button>
                     <button id="videoClose"></button>
                     <div id="ocrOverlay" class="hidden"></div>
-                    <div id="ocrResultPanel" class="hidden"><pre id="ocrText"></pre></div>
+                    <div id="ocrResultPanel"><pre id="ocrText"></pre></div>
                 </div>
             </dialog>`;
         window.videoApi = { loadBookmarks: async () => [], saveBookmarks: async () => true };
@@ -62,9 +62,9 @@ describe('OCR-Overlay sichtbar schalten', () => {
         const overlay = document.getElementById('ocrOverlay');
         const panel = document.getElementById('ocrResultPanel');
 
-        // nach dem Öffnen sind beide Elemente versteckt
+        // nach dem Öffnen bleibt das Panel sichtbar
         expect(overlay.classList.contains('hidden')).toBe(true);
-        expect(panel.classList.contains('hidden')).toBe(true);
+        expect(panel.classList.contains('hidden')).toBe(false);
 
         // Aktivieren
         ocrBtn.click();
@@ -74,6 +74,6 @@ describe('OCR-Overlay sichtbar schalten', () => {
         // Deaktivieren
         ocrBtn.click();
         expect(overlay.classList.contains('hidden')).toBe(true);
-        expect(panel.classList.contains('hidden')).toBe(true);
+        expect(panel.classList.contains('hidden')).toBe(false);
     });
 });

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -602,9 +602,9 @@
                     <button id="ocrReset" class="btn btn-danger">Reset</button>
                 </div>
             </section>
-            <section id="ocrResultPanel" class="ocr-panel hidden">
+            <section id="ocrResultPanel" class="ocr-panel">
                 <canvas id="roiPreview"></canvas>
-                <div id="ocrText"></div>
+                <div id="ocrText">Noch kein OCR-Ergebnis</div>
                 <div class="ocr-controls">
                     <span id="gpuInfo">GPU: unbekannt</span>
                     <button id="ocrStart">Start OCR</button>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2509,7 +2509,7 @@ th:nth-child(6) {
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    max-height: 100%;
+    max-height: 320px;
     overflow-y: auto;
     border: 2px solid #fff;
 }
@@ -2518,6 +2518,7 @@ th:nth-child(6) {
     display: flex;
     flex-direction: column;
     height: 100%;
+    min-height: 320px;
     position: relative;
     overflow: hidden;
     border: 2px solid #fff;
@@ -2555,20 +2556,18 @@ th:nth-child(6) {
     margin: 0 auto;
 }
 .video-player-section .player-controls {
-    /* Bedienelemente schweben direkt auf dem Video */
+    /* Steuerelemente stehen unter dem Video und brechen nicht um */
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: center;
+    justify-content: center;
     gap: 8px;
     padding: 4px 6px;
-    background: rgba(36,36,36,0.8);
-    box-shadow: 0 0 4px rgba(0,0,0,0.5);
-    position: absolute;
-    bottom: 8px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 5;
-    border-radius: 4px;
+    background: #242424;
+    box-shadow: none;
+    position: static;
+    width: 100%;
+    margin-top: 8px;
 }
 .video-player-section .player-controls input[type=range] {
     /* Slider darf schrumpfen, bleibt aber mindestens 140px breit */
@@ -2770,16 +2769,14 @@ th:nth-child(6) {
     background: yellow;
 }
 
-/* Panel standardmäßig ausgeblendet; wird per JS ein-/ausgeblendet */
+/* Panel bleibt sichtbar und zeigt einen Platzhalter */
 #ocrResultPanel {
-    display: none;
+    display: flex;
 }
 
 /* damit das Panel nicht unter die Steuerleiste reicht */
 .player-controls {
-    position: sticky;
-    bottom: 0;
-    z-index: 5;
+    position: static;
 }
 
 /* Ausklappbarer Einstell-Drawer fuer das OCR-Tuning */
@@ -2844,12 +2841,12 @@ th:nth-child(6) {
 }
 
 /* ===== Neues Grid-Layout für Video-Manager ===== */
-.video-dialog{width:960px;height:600px}
+.video-dialog{width:clamp(600px,80vw,1200px);height:clamp(400px,60vh,800px)}
 .wb-grid{
     --gap:12px;
     display:grid;
-    grid-template-columns:260px 1fr;
-    grid-template-rows:320px 1fr;
+    grid-template-columns:280px 1fr;
+    grid-template-rows:auto 1fr;
     grid-template-areas:
         "list player"
         "ocr  ocr";
@@ -2859,7 +2856,7 @@ th:nth-child(6) {
 }
 .video-list-section{grid-area:list;border:1px solid #fff;padding:8px;overflow:auto;}
 .video-player-section{grid-area:player;border:1px solid #fff;padding:8px;position:relative;}
-.ocr-panel{grid-area:ocr;border:1px solid #fff;padding:8px;overflow:auto;}
+.ocr-panel{grid-area:ocr;border:1px solid #fff;padding:8px;overflow:auto;display:flex;flex-direction:column;min-height:140px;}
 .player-controls .action-btn{margin-left:4px;}
 .video-action-panel{display:none;}
 @media(max-width:900px){

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -651,7 +651,6 @@ export function openVideoDialog(bookmark, index) {
     ocrPaused = false;
     player.classList.remove('ocr-active');
     if (ocrOverlay) ocrOverlay.classList.add('hidden');
-    if (ocrPanel) ocrPanel.classList.add('hidden');
     if (debugBtn) {
         debugBtn.classList.remove('active');
     }
@@ -723,7 +722,7 @@ export function openVideoDialog(bookmark, index) {
                 ocrOverlay.classList.toggle('hidden', !active);
             }
             if (ocrPanel) {
-                ocrPanel.classList.toggle('hidden', !active);
+                // Panel bleibt sichtbar
             }
             if (active) {
                 ocrBtn.title = 'OCR an/aus (F9)';
@@ -780,7 +779,6 @@ export function openVideoDialog(bookmark, index) {
             ocrActive = true;
             player.classList.add('ocr-active');
             ocrOverlay?.classList.remove('hidden');
-            ocrPanel?.classList.remove('hidden');
             startAutoLoop();
         };
     }
@@ -791,7 +789,6 @@ export function openVideoDialog(bookmark, index) {
             ocrActive = false;
             player.classList.remove('ocr-active');
             ocrOverlay?.classList.add('hidden');
-            ocrPanel?.classList.add('hidden');
         };
     }
     // Lösch-Button ruft nun die neue Funktion auf
@@ -863,7 +860,6 @@ export async function closeVideoDialog() {
     const ocrPanel = document.getElementById('ocrResultPanel');
     if (ocrBtn) ocrBtn.classList.remove('active');
     if (ocrOverlay) ocrOverlay.classList.add('hidden');
-    if (ocrPanel) ocrPanel.classList.add('hidden');
     player.classList.remove('ocr-active');
     ocrActive = false;
     ocrPaused = false;


### PR DESCRIPTION
## Zusammenfassung
- Steuerleiste liegt nun unter dem Player
- Video-Liste und OCR-Panel besitzen feste Mindestgroessen
- OCR-Panel wird nicht mehr versteckt
- Test an neues Verhalten angepasst
- README ergaenzt

## Testanweisungen
- `npm test` ausfuehren

------
https://chatgpt.com/codex/tasks/task_e_685906e32ec48327a792ac4dd7909537