### PR TITLE
Verbessere Video-Dialog-Layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Dauerhafte Video-Suche:** Der Suchbegriff im Video-Manager bleibt zwischen den Sitzungen erhalten.
 * **Responsiver Video-Manager:** Fester Dialog-Abstand, flexible Toolbar mit Min-Buttons und kompaktem ❌-Icon bei schmaler Breite. Tabellenzeilen besitzen gleichmäßiges Padding und einen Hover-Effekt.
 * **Zweispaltiges Video-Dashboard:** Links steht die Videoliste, rechts der 16:9‑Player mit schwebender Leiste. Das OCR‑Panel füllt darunter die komplette Breite und die Aktions-Icons befinden sich direkt unter dem Player.
-* **Strukturiertes Grid-Layout:** Das Dashboard nutzt nun ein zweispaltiges CSS‑Grid (`260px 1fr`) mit weißen Rahmen. Bei weniger als 900 px Breite stapeln sich Liste, Player und OCR‑Panel automatisch.
+* **Strukturiertes Grid-Layout:** Das Dashboard nutzt nun ein zweispaltiges CSS‑Grid (`280px 1fr`) mit weißen Rahmen. Bei weniger als 900 px Breite stapeln sich Liste, Player und OCR‑Panel automatisch.
 * **Robuster Video-Dialog:** Das Grid innerhalb des Dialogs steuert nun allein das Layout. Jede Sektion besitzt flexible Höhe und verhindert Überlappungen.
+* **Stabiles Ausblenden des Players:** Eine neue Klasse `collapsed` versteckt die Player-Sektion nur per `visibility` und lässt das Grid unverändert.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 * **Flexible Player-Steuerleiste:** Bei schmalen Fenstern rutscht der Slider in eine zweite Zeile. Icons und Zeitangaben verkleinern sich automatisch.
 * **Steuerleiste unter dem Video:** Die Buttons sitzen jetzt statisch unter dem Player, nutzen die volle Breite und bleiben in einer Zeile.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -563,7 +563,7 @@
                 </div>
                 <button id="closeVideoDlg" class="btn btn-danger">❌ Schließen</button>
             </section>
-            <section id="videoPlayerSection" class="video-player-section hidden">
+            <section id="videoPlayerSection" class="video-player-section collapsed">
                 <div class="player-header"><span id="playerDialogTitle"></span></div>
                 <iframe id="videoPlayerFrame" allow="autoplay; fullscreen"></iframe>
                 <div id="playerControls" class="player-controls">

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -224,7 +224,7 @@ window.adjustVideoDialogHeight = adjustVideoDialogHeight;
 function adjustVideoPlayerSize(force = false) {
     const section = document.getElementById('videoPlayerSection');
     if (!section) return;
-    if (!force && section.classList.contains('hidden')) return;
+    if (!force && section.classList.contains('collapsed')) return;
 
     const header   = section.querySelector('.player-header');
     const controls = section.querySelector('.player-controls');

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -9,6 +9,13 @@
             display: none !important;
         }
 
+        /* Bereich im Grid ausblenden, Layout bleibt stabil */
+        .collapsed {
+            visibility: hidden;
+            pointer-events: none;
+            grid-area: none;
+        }
+
         /* Download-Spalte standardmäßig ausgeblendet */
         .download-cell {
             display: none;
@@ -2534,7 +2541,6 @@ th:nth-child(6) {
 .video-player-section.ocr-active {
     /* keine spezielle Behandlung mehr nötig */
 }
-.video-player-section.hidden { display: none; }
 
 /* Bereich für den eingebetteten Player */
 .video-player-section .player-header {
@@ -2848,7 +2854,7 @@ th:nth-child(6) {
 .wb-grid {
     --gap: 12px;
     display: grid;
-    grid-template-columns: 260px 1fr;    /* links Liste, rechts Player */
+    grid-template-columns: 280px 1fr;    /* Liste links, Player rechts */
     grid-template-rows: auto 1fr;        /* oberes Band wächst flexibel */
     grid-template-areas:
         "list player"

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -563,7 +563,8 @@ export function openVideoDialog(bookmark, index) {
         dlg.showModal();
     }
 
-    player.classList.remove('hidden');
+    // Abschnitt im Grid sichtbar schalten
+    player.classList.remove('collapsed');
     if (gpu) gpu.textContent = 'GPU: EasyOCR';
     // gleich nach dem Einblenden neu skalieren
     if (typeof window.adjustVideoPlayerSize === 'function') {
@@ -851,7 +852,8 @@ export async function closeVideoDialog() {
     if (!dlg || !player) return;
     if (dlg.__closing) return;
     dlg.__closing = true;
-    player.classList.add('hidden');
+    // Abschnitt im Grid ausblenden
+    player.classList.add('collapsed');
     if (window.videoDialogObserver) window.videoDialogObserver.unobserve(dlg);
     const frame = document.getElementById('videoPlayerFrame');
     if (frame) frame.src = '';
@@ -951,7 +953,7 @@ export async function closePlayer() {
 document.addEventListener('keydown', e => {
     const dlg    = document.getElementById('videoMgrDialog');
     const player = document.getElementById('videoPlayerSection');
-    if (!dlg || !dlg.open || !player || player.classList.contains('hidden')) return;
+    if (!dlg || !dlg.open || !player || player.classList.contains('collapsed')) return;
     const playBtn = document.getElementById('videoPlay');
     const backBtn = document.getElementById('videoBack');
     const fwdBtn  = document.getElementById('videoForward');


### PR DESCRIPTION
## Summary
- erweitere die Grid-Klasse `wb-grid` und entferne überflüssige Regeln
- füge eine neue CSS-Klasse `collapsed` zum sauberen Verstecken hinzu
- passe Dialog-HTML und JS an die `collapsed`-Logik an
- dokumentiere die Anpassungen im README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685914278ccc83278383b41a5ad0ff6c