### PR TITLE
Styleanpassung für Video-Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Dauerhafte Video-Suche:** Der Suchbegriff im Video-Manager bleibt zwischen den Sitzungen erhalten.
 * **Responsiver Video-Manager:** Fester Dialog-Abstand, flexible Toolbar mit Min-Buttons und kompaktem ❌-Icon bei schmaler Breite. Tabellenzeilen besitzen gleichmäßiges Padding und einen Hover-Effekt.
 * **Zweispaltiges Video-Dashboard:** Links steht die Videoliste, rechts der 16:9‑Player mit schwebender Leiste. Das OCR‑Panel füllt darunter die komplette Breite und die Aktions-Icons befinden sich direkt unter dem Player.
-* **Strukturiertes Grid-Layout:** Das Dashboard nutzt nun ein zweispaltiges CSS‑Grid (`260px 1fr`) mit weißen Rahmen. Bei weniger als 900 px Breite stapeln sich Liste, Player und OCR‑Panel automatisch.
-* **Robuster Video-Dialog:** Das Grid innerhalb des Dialogs steuert nun allein das Layout. Jede Sektion besitzt flexible Höhe und verhindert Überlappungen.
+* **Flexibles Dashboard-Layout:** Das Dashboard basiert jetzt auf einem vertikalen Flex-Layout. Liste, Player und OCR-Bereich ordnen sich untereinander an und passen sich dynamisch der Fensterhöhe an.
+* **Robuster Video-Dialog:** Das Flex-Layout verhindert Überlappungen und lässt jede Sektion dynamisch wachsen.
 * **Bereinigte CSS-Regeln:** Doppelte Definitionen entfernt und das OCR-Panel passt sich flexibler an.
 * **Aufgeräumtes Drei-Leisten-Layout** für Projektsteuerung, Spielstart und Dateifilter.
 * **Flexible Player-Steuerleiste:** Bei schmalen Fenstern rutscht der Slider in eine zweite Zeile. Icons und Zeitangaben verkleinern sich automatisch.

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2514,6 +2514,7 @@ th:nth-child(6) {
 .video-player-section {
     display: flex;
     flex-direction: column;
+    flex: 1 1 60%; /* nimmt 60% der Höhe ein */
     height: 100%;
     position: relative;
     overflow: hidden;
@@ -2525,9 +2526,10 @@ th:nth-child(6) {
 .ocr-panel {
     display: flex;
     flex-direction: column;
+    flex: 0 0 35%; /* feste Höhe für OCR-Ausgabe */
+    min-height: 120px;    /* Mindesthöhe */
     overflow: auto;        /* erkannter Text scrollt */
     border: 2px solid #fff;
-    min-height: 0;         /* verhindert Überlaufen */
     grid-area: ocr;
 }
 
@@ -2842,28 +2844,12 @@ th:nth-child(6) {
     color: #ff8080;
 }
 
-/* ===== Neues Grid-Layout für Video-Manager ===== */
+/* ===== Flex-Layout für den Video-Manager ===== */
 .wb-grid {
-    --gap: 12px;
-    display: grid;
-    grid-template-columns: 260px 1fr;    /* links Liste, rechts Player */
-    grid-template-rows: auto 1fr;        /* oberes Band wächst flexibel */
-    grid-template-areas:
-        "list player"
-        "ocr  ocr";
-    gap: var(--gap);
+    display: flex;
+    flex-direction: column;
     height: 100%;
 }
 
 
 
-@media (max-width: 900px) {
-    .wb-grid {
-        grid-template-columns: 1fr;
-        grid-template-rows: auto auto 1fr;
-        grid-template-areas:
-            "list"
-            "player"
-            "ocr";
-    }
-}


### PR DESCRIPTION
## Zusammenfassung
- Flex-Layout für `.wb-grid`
- `.video-player-section` nimmt 60% der Dialoghöhe ein
- `.ocr-panel` bekommt feste Höhe
- README aktualisiert

## Testanweisungen
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685921f1cddc8327aa132eec579c2394