### PR TITLE
Update Video-Dialog size handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Schnellerer Dialog-Aufruf:** Die `open`-Prüfung passiert vor dem Neuladen der Tabelle und spart so unnötige Arbeit.
 * **Startet geschlossen:** Beim Laden der Anwendung bleibt der Video-Manager nun verborgen und öffnet sich erst nach Klick auf den "Videos"-Button.
 * **Mindestgröße für den Video-Dialog:** Beim Öffnen passt sich der Dialog an die Fenstergröße an, bleibt aber mindestens 600×400 px groß. Alle ❌-Buttons rufen jetzt sicher `videoDlg.close()` auf.
+* **Dialog startet bei 80 % Fenstergröße:** Direkt nach `showModal()` setzt das Skript Breite und Höhe auf 80 % des Browserfensters. Ein `DOMContentLoaded`-Listener im IFrame stellt diese Werte nach dem Laden von YouTube erneut ein.
 * **Optimal genutzter Player-Bereich:** Breite und Höhe orientieren sich jetzt an der größeren freien Dimension. Die Player-Sektion schrumpft exakt auf die IFrame-Höhe und vermeidet so schwarze Balken.
 * **Einheitliche Größenberechnung:** Auch `adjustVideoPlayerSize()` prüft nun freie Breite und Höhe und wählt automatisch das größere Maß.
 * **OCR-Funktion im Player:** Ein präzises Overlay deckt nur die Untertitel ab. Der Auto-Modus pausiert bei einem Treffer das Video und sammelt den Text im rechten Panel. F9 erstellt jetzt einen einzelnen OCR‑Screenshot. Ein neuer 🔍‑Button aktiviert den Dauerlauf.

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -268,6 +268,9 @@ openVideoManager.addEventListener('click', async () => {
     videoDlg.style.height = '';
 
     videoDlg.showModal();
+    // Dialog direkt auf 80 % der Fenstergröße setzen
+    videoDlg.style.width  = '80vw';
+    videoDlg.style.height = '80vh';
     if (window.videoDialogObserver) window.videoDialogObserver.observe(videoDlg);
     await refreshTable();
     adjustVideoDialogHeight();

--- a/web/ytPlayer.js
+++ b/web/ytPlayer.js
@@ -593,6 +593,11 @@ export function openVideoDialog(bookmark, index) {
 
     // neue URL setzen und Player initialisieren
     iframe.src = `https://www.youtube.com/embed/${extractYoutubeId(bookmark.url)}?start=${Math.floor(bookmark.time)}&enablejsapi=1`;
+    // Nach dem Laden des IFrames erneut die Dialoggröße setzen
+    iframe.addEventListener('DOMContentLoaded', () => {
+        dlg.style.width  = '80vw';
+        dlg.style.height = '80vh';
+    }, { once: true });
 
     // Fehlerhinweis und Fallback, falls die YouTube-API fehlt
     if (typeof YT === 'undefined' || !YT.Player) {


### PR DESCRIPTION
## Summary
- stelle Video-Dialog beim Öffnen auf 80% von Fensterhöhe und -breite
- setze dieselben Werte erneut sobald der YouTube-iFrame geladen ist
- beschreibe neue Funktion in README

## Testing
- `npm test` *(fails: setup requires huge downloads)*

------
https://chatgpt.com/codex/tasks/task_e_6859237235e48327bda2e7b2c75af127