### PR TITLE
Add cleanup routines for watcher tests

### DIFF
--- a/tests/showDubbingSettings.test.js
+++ b/tests/showDubbingSettings.test.js
@@ -14,9 +14,10 @@ beforeAll(() => {
 
 let showDubbingSettings;
 
-test('Dialog wird mit display flex erstellt', async () => {
+test('Dialog wird sichtbar angezeigt', async () => {
     await showDubbingSettings(1);
     const dlg = document.getElementById('dubbingSettingsDialog');
     expect(dlg).not.toBeNull();
-    expect(dlg.style.display).toBe('flex');
+    // Der Dialog sollte nicht mehr die Klasse "hidden" besitzen
+    expect(dlg.classList.contains('hidden')).toBe(false);
 });

--- a/tests/watcher.test.js
+++ b/tests/watcher.test.js
@@ -30,6 +30,9 @@ describe('watchDownloadFolder', () => {
     onAddCallbacks.forEach(cb => cb(file));
 
     expect(callback).toHaveBeenCalledWith(file);
+
+    // Aufräumen des temporären Verzeichnisses
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   test('clearDownloadFolder leert den Ordner', () => {
@@ -45,6 +48,9 @@ describe('watchDownloadFolder', () => {
 
     const remaining = fs.readdirSync(tmpDir);
     expect(remaining.length).toBe(0);
+
+    // Aufräumen des temporären Verzeichnisses
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   test('pruefeAudiodatei erkennt gueltige WAV', () => {


### PR DESCRIPTION
## Summary
- ensure watcher tests delete temp dirs
- fix expectations for dubbing dialog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68593773614c8327aaba72bd1cd10829