### PR TITLE
Fixe Video-Dialog-Layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Korrekte Spaltenbreite im Video-Manager:** Kopfzeile und Tabelle sind jetzt bündig, komplette Videotitel erscheinen als Tooltip.
 * **Fixer Dialog-Abstand:** Der Video-Manager steht nun stets mit 10 % Rand im Fenster. Die Funktion `adjustVideoDialogHeight` wurde entfernt.
 * **Behobenes Resize-Problem:** Nach einer Verkleinerung wächst der Videoplayer jetzt korrekt mit, sobald das Fenster wieder größer wird.
+* **Stabiler Startzustand:** CSS-Duplikate entfernt; `video-dialog` startet immer mit 10 % Abstand.
 * **Korrektes Skalieren nach erneutem Öffnen:** Der Player passt sich nach dem Wiedereinblenden automatisch an die aktuelle Fenstergröße an.
 * **Aktualisierung im Hintergrund:** Selbst bei geschlossenem Player wird die Größe im Hintergrund neu berechnet und beim nächsten Öffnen korrekt übernommen.
 * **Video & OCR Workbench:** Liste und Player teilen sich die obere Zeile, das OCR-Ergebnis belegt den gesamten Bereich darunter.

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2415,29 +2415,6 @@ th:nth-child(6) {
     margin-top: 10px;
 }
 
-/* ===== video-dialog ===== */
-.video-dialog {
-    position: fixed;                  /* immer relativ zum App-Fenster */
-    inset: 10vh 10vw;                 /* oben/unten 10 vh, rechts/links 10 vw */
-    display: grid;
-    grid-template-rows: auto 1fr auto;/* Kopf – Inhalt – Controls */
-    background: #1a1a1a;
-    color: #e0e0e0;
-    border: 2px solid #ffffff33;      /* dünne, weiße Linie */
-    box-shadow: 0 0 8px #000a;
-    overflow: hidden;                 /* kein Scrollen des Rahmens */
-    z-index: 2000;                    /* über sonstiger UI */
-}
-
-/* Dialog nur anzeigen, wenn geöffnet */
-.video-dialog:not([open]) {
-    display: none;
-}
-
-/* Abdunklung hinter dem Dialog */
-.video-dialog::backdrop {
-    background: rgba(0, 0, 0, 0.6);
-}
 
 /* Griff in der Ecke zum Skalieren (entfernt) */
 
@@ -2840,4 +2817,22 @@ th:nth-child(6) {
 }
 
 
+
+
+/* ===== video-dialog – finale Version ===== */
+.video-dialog{
+    position:fixed;            /* orientiert sich am App-Fenster */
+    inset:10vh 10vw;           /* überall 10 % Rand */
+    display:grid;
+    grid-template-rows:auto 1fr auto; /* Kopf | Inhalt | Controls */
+    background:#1a1a1a;
+    color:#e0e0e0;
+    border:2px solid #ffffff33;
+    box-shadow:0 0 8px #000a;
+    overflow:hidden;
+    z-index:2000;              /* sicher vor allen anderen Dialogen */
+}
+/* nur sichtbar, wenn wirklich geöffnet */
+.video-dialog:not([open]){display:none;}
+.video-dialog::backdrop{background:rgba(0,0,0,.6);}
 


### PR DESCRIPTION
## Zusammenfassung
- CSS-Duplikate fuer `.video-dialog` entfernt
- finale Version des Blocks ans Ende von `style.css` verschoben
- README um Hinweis auf stabilen Startzustand ergaenzt

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859727117c4832797a41e02dab30797