### PR TITLE
Fix CSP for ElevenLabs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ Seit Patch 1.40.60 ignoriert `start_tool.py` Kommentare in `requirements.txt`, d
 Seit Patch 1.40.61 setzt `start_tool.py` den Pfad zum Python-Interpreter in Anführungszeichen, wodurch `pip install` auch bei Leerzeichen im Pfad funktioniert.
 Seit Patch 1.40.62 greift die Gestaltung des Video-Dialogs erst mit dem `open`-Attribut und das Öffnen erfolgt ohne Animation.
 Seit Patch 1.40.63 vereinfacht ein gemeinsamer Grid-Block die Video-Dialog-Definition.
+Seit Patch 1.40.64 erlaubt die Content Security Policy nun Verbindungen zu `api.elevenlabs.io`,
+damit die Status-Abfragen beim Dubbing nicht mehr blockiert werden.
 
 Beispiel einer gültigen CSV:
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -11,6 +11,7 @@
                    script-src 'self' https://www.youtube.com 'unsafe-inline';
                    style-src-elem 'self';
                    style-src-attr 'self' 'unsafe-inline';
+                   connect-src 'self' https://api.elevenlabs.io;
                    frame-src https://www.youtube.com blob:;
                    img-src 'self' data: https://i.ytimg.com;
                    worker-src 'self' blob:;">


### PR DESCRIPTION
## Summary
- allow API connections to api.elevenlabs.io
- document the new Content Security Policy change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685987c5e3248327a4752c34aa42aa65