### PR TITLE
Add color-coded length comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ Mit dem Backup-Dialog lassen sich alle Projekt-Daten als JSON speichern. Neu ist
 
 * **🧠 Smart Folder Detection:** Erkennt Half‑Life Charaktere automatisch
 * **📏 Auto‑Height Textboxen:** EN/DE Felder bleiben höhengleich
-* **📐 Längen-Vergleich:** Zeigt per Symbol an, ob die deutsche Audiodatei kürzer oder länger als das englische Original ist
+* **📐 Längen-Vergleich:** Farbige Symbole zeigen, ob die deutsche Audiodatei kürzer (grün) oder länger (rot) als das englische Original ist
 * **🎨 Theme‑System:** Automatische Icon‑ und Farb‑Zuweisungen
 * **💡 Context‑Awareness:** Funktionen passen sich dem aktuellen Kontext an
 * **🔄 Dateinamen-Prüfung:** Klick auf den Dateinamen öffnet einen Dialog mit passenden Endungen

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2079,16 +2079,25 @@ async function renderFileTableWithOrder(sortedFiles) {
         const dePath = getDeFilePath(file);
         const hasDeAudio = !!dePath;
         const hasHistory = await checkHistoryAvailable(file);
+        // Symbol und Farbe für den Längenvergleich vorbereiten
         let lengthIndicator = '';
+        let lengthClass = '';
         if (hasDeAudio) {
             const enUrl = audioFileCache[relPath] || `sounds/EN/${relPath}`;
             const deUrl = deAudioCache[dePath] || `sounds/DE/${dePath}`;
             const enDur = await getAudioDuration(enUrl);
             const deDur = await getAudioDuration(deUrl);
             if (enDur != null && deDur != null) {
-                if (deDur < enDur) lengthIndicator = '⬇️';
-                else if (deDur > enDur) lengthIndicator = '⬆️';
-                else lengthIndicator = '↔️';
+                if (deDur < enDur) {
+                    lengthIndicator = '⬇️';
+                    lengthClass = 'good'; // kürzer = positiv
+                } else if (deDur > enDur) {
+                    lengthIndicator = '⬆️';
+                    lengthClass = 'bad'; // länger = potentiell negativ
+                } else {
+                    lengthIndicator = '↔️';
+                    lengthClass = 'neutral';
+                }
             }
         }
         // Find original index for display
@@ -2172,7 +2181,7 @@ return `
         <td><button class="upload-btn" onclick="initiateDeUpload(${file.id})">⬆️</button></td>
         <td><button class="dubbing-btn" onclick="initiateDubbing(${file.id})">🔈</button></td>
         <td><span class="dub-status ${!file.dubbingId ? 'none' : (file.dubReady ? 'done' : 'pending')}" title="${!file.dubbingId ? 'kein Dubbing' : (file.dubReady ? 'fertig' : 'Studio generiert noch')}" ${(!file.dubbingId || file.dubReady) ? '' : `onclick="dubStatusClicked(${file.id})"`}>●</span></td>
-        <td><span class="length-diff">${lengthIndicator}</span></td>
+        <td><span class="length-diff ${lengthClass}">${lengthIndicator}</span></td>
         <td class="download-cell">${file.dubbingId ? `<button class="download-de-btn" data-file-id="${file.id}" onclick="downloadDe(${file.id})" disabled>⬇️</button>` : ''}</td>
         <td>${hasHistory ? `<button class="history-btn" onclick="openHistory(${file.id})">🕒</button>` : ''}</td>
         <td><div style="display:flex;align-items:flex-start;gap:5px;">

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -785,12 +785,21 @@ th:nth-child(6) {
         }
 
         /* Anzeige der Längen-Differenz */
-        .length-diff {
-            font-size: 18px;
-            display: inline-block;
-            width: 24px;
-            text-align: center;
-        }
+.length-diff {
+    font-size: 18px;
+    display: inline-block;
+    width: 24px;
+    text-align: center;
+}
+.length-diff.good {
+    color: #4caf50;
+}
+.length-diff.bad {
+    color: #f44336;
+}
+.length-diff.neutral {
+    color: #ffc107;
+}
 
         /* Vertikale Anordnung der Bearbeitungs-Symbole */
         .edit-column {


### PR DESCRIPTION
## Summary
- show length difference with colored icons
- add CSS classes for green/red/neutral icons
- document updated length indicator feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68598a8313cc83279968298b51f2bb06