### PR TITLE
Fix audio preview CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,8 @@ Seit Patch 1.40.62 greift die Gestaltung des Video-Dialogs erst mit dem `open`-A
 Seit Patch 1.40.63 vereinfacht ein gemeinsamer Grid-Block die Video-Dialog-Definition.
 Seit Patch 1.40.64 erlaubt die Content Security Policy nun Verbindungen zu `api.elevenlabs.io`,
 damit die Status-Abfragen beim Dubbing nicht mehr blockiert werden.
+Seit Patch 1.40.65 akzeptiert die Richtlinie auch `blob:` in `media-src`.
+Damit funktionieren die Audio-Vorschauen wieder ohne CSP-Fehler.
 
 Beispiel einer gültigen CSV:
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -6,6 +6,7 @@
     <title>Half-Life: Alyx Translation Tool</title>
     <!-- Sicherheitsrichtlinie für Electron: verhindert Warnhinweise -->
     <!-- Aktualisierte CSP: Inline-Styles sind über style-src-attr erlaubt -->
+    <!-- Medien-Blobs werden über media-src zugelassen -->
     <meta http-equiv="Content-Security-Policy"
           content="default-src 'self';
                    script-src 'self' https://www.youtube.com 'unsafe-inline';
@@ -14,7 +15,8 @@
                    connect-src 'self' https://api.elevenlabs.io;
                    frame-src https://www.youtube.com blob:;
                    img-src 'self' data: https://i.ytimg.com;
-                   worker-src 'self' blob:;">
+                   worker-src 'self' blob:;
+                   media-src 'self' blob:;">
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- allow audio previews from blob URLs via `media-src`
- document CSP change in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859900171f48327aaafd8657f3193e5