### PR TITLE
Version-Spalte für Projektdaten

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Fehlerhinweise beim Speichern:** Tritt ein Problem auf, erscheint eine rote Toast-Meldung statt eines stummen Abbruchs.
 * **Neue Meldung:** Scheitert das Anlegen einer History-Version, wird "Fehler beim Anlegen der History-Version" ausgegeben.
 * **Dynamische Download-Spalte:** Die Spalte erscheint nur bei Bedarf und blendet sich aus, ohne die Tabellenüberschriften zu verschieben.
+* **Versionierung pro Datei:** Eine neue Spalte zwischen Ordner und EN‑Text zeigt die Version nur an, wenn eine deutsche Audiodatei existiert. Rechtsklick öffnet ein Menü mit Version 1–10 oder einer frei wählbaren Zahl. Über den Button **Ordner-Versionen** kannst du allen Dateien eines Ordners gemeinsam eine Nummer zuweisen.
 
 ### 🔍 Suche & Import
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -107,6 +107,7 @@
                     <button class="sort-btn" onclick="sortTable('filename', event)">Dateiname</button>
                     <button class="sort-btn" onclick="sortTable('folder', event)">Ordner</button>
                     <button class="sort-btn" onclick="sortTable('completion', event)">Fertig</button>
+                    <button class="version-folder-btn" onclick="openVersionFolderDialog()">Ordner-Versionen</button>
                 </div>
                 <div class="progress-info">
                     <div class="progress-stat" id="totalProgress">0% vollständig</div>
@@ -158,6 +159,7 @@
         <th width="50" title="Doppelklick auf Nummer um Position zu ändern">#</th>
         <th class="sortable">Dateiname</th>
         <th class="sortable">Ordner</th>
+        <th>Version</th>
         <th>EN Text</th>
         <th>DE Text</th>
         <th width="40">UT-Suche</th>
@@ -192,6 +194,21 @@
                 </div>
             </div>
         </main>
+    </div>
+
+    <!-- Version Menu -->
+    <div class="context-menu" id="versionMenu">
+        <div class="context-menu-item" onclick="selectVersion(1)">Version 1</div>
+        <div class="context-menu-item" onclick="selectVersion(2)">Version 2</div>
+        <div class="context-menu-item" onclick="selectVersion(3)">Version 3</div>
+        <div class="context-menu-item" onclick="selectVersion(4)">Version 4</div>
+        <div class="context-menu-item" onclick="selectVersion(5)">Version 5</div>
+        <div class="context-menu-item" onclick="selectVersion(6)">Version 6</div>
+        <div class="context-menu-item" onclick="selectVersion(7)">Version 7</div>
+        <div class="context-menu-item" onclick="selectVersion(8)">Version 8</div>
+        <div class="context-menu-item" onclick="selectVersion(9)">Version 9</div>
+        <div class="context-menu-item" onclick="selectVersion(10)">Version 10</div>
+        <div class="context-menu-item" onclick="selectVersion('custom')">Benutzerdefiniert...</div>
     </div>
 
     <!-- Context Menu -->
@@ -515,6 +532,41 @@
             <div class="dialog-buttons">
                 <button class="btn btn-danger" id="deleteAllMissingBtn">Alle löschen</button>
                 <button class="btn btn-secondary" onclick="closeMissingFoldersDialog()">Schließen</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Version für Ordner Dialog -->
+    <div class="dialog-overlay hidden" id="versionFolderDialog">
+        <div class="dialog">
+<button class="dialog-close-btn" onclick="closeVersionFolderDialog()">×</button>
+            <h3>🔢 Version für Ordner</h3>
+            <div style="margin-bottom:10px;">
+                <label>Ordner:
+                    <select id="versionFolderSelect"></select>
+                </label>
+            </div>
+            <div style="margin-bottom:10px;">
+                <label>Version:
+                    <select id="versionFolderVersionSelect">
+                        <option value="1">1</option>
+                        <option value="2">2</option>
+                        <option value="3">3</option>
+                        <option value="4">4</option>
+                        <option value="5">5</option>
+                        <option value="6">6</option>
+                        <option value="7">7</option>
+                        <option value="8">8</option>
+                        <option value="9">9</option>
+                        <option value="10">10</option>
+                        <option value="custom">Benutzerdefiniert ...</option>
+                    </select>
+                    <input type="number" id="versionFolderCustomInput" min="1" style="width:60px; display:none;">
+                </label>
+            </div>
+            <div class="dialog-buttons">
+                <button class="btn btn-secondary" onclick="closeVersionFolderDialog()">Abbrechen</button>
+                <button class="btn btn-success" onclick="applyVersionToFolder()">Übernehmen</button>
             </div>
         </div>
     </div>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -326,6 +326,22 @@ th:nth-child(6) {
             color: white;
         }
 
+        .version-folder-btn {
+            padding: 6px 12px;
+            background: #444;
+            border: none;
+            border-radius: 4px;
+            color: #e0e0e0;
+            cursor: pointer;
+            font-size: 12px;
+            transition: all 0.2s;
+            margin-left: 10px;
+        }
+
+        .version-folder-btn:hover {
+            background: #555;
+        }
+
         .progress-info {
             display: flex;
             gap: 15px;
@@ -1037,7 +1053,7 @@ th:nth-child(6) {
             border: 1px solid rgba(255,255,255,0.2);
         }
 
-        .folder-badge:hover {
+.folder-badge:hover {
             transform: scale(1.05);
             box-shadow: 0 2px 8px rgba(0,0,0,0.3);
             filter: brightness(1.1);
@@ -1400,6 +1416,22 @@ th:nth-child(6) {
     cursor:pointer;
     transition:color .2s, transform .2s;
 }
+
+        .version-badge {
+            display: inline-block;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+            font-weight: 500;
+            cursor: pointer;
+            background: #555;
+            color: #fff;
+            user-select: none;
+        }
+
+        .version-badge:hover {
+            background: #666;
+        }
 
 /* Speziell breiterer Dialog für die DE-Audio-Bearbeitung */
 #deEditDialog .dialog {


### PR DESCRIPTION
## Zusammenfassung
- Version-Spalte zwischen Ordner und EN-Text ergänzt
- Versionsnummer erscheint nur bei vorhandener DE-Datei
- Rechtsklick auf Versionszahl zeigt Auswahl 1–10 oder eigene Zahl
- Neuer Dialog „Ordner-Versionen“ weist ganze Ordner einer Version zu
- Styles und README angepasst

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a64b342848327872050291a048261