### PR TITLE
Angepasstes Versionsmenü

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Fehlerhinweise beim Speichern:** Tritt ein Problem auf, erscheint eine rote Toast-Meldung statt eines stummen Abbruchs.
 * **Neue Meldung:** Scheitert das Anlegen einer History-Version, wird "Fehler beim Anlegen der History-Version" ausgegeben.
 * **Dynamische Download-Spalte:** Die Spalte erscheint nur bei Bedarf und blendet sich aus, ohne die Tabellenüberschriften zu verschieben.
-* **Versionierung pro Datei:** Eine neue Spalte zwischen Ordner und EN‑Text zeigt die Version nur an, wenn eine deutsche Audiodatei existiert. Rechtsklick öffnet ein Menü mit Version 1–10 oder einer frei wählbaren Zahl. Über den Button **Ordner-Versionen** kannst du allen Dateien eines Ordners gemeinsam eine Nummer zuweisen.
+* **Versionierung pro Datei:** Eine neue Spalte zwischen Ordner und EN‑Text zeigt die Version nur an, wenn eine deutsche Audiodatei existiert. Linksklick öffnet ein Menü mit Version 1–10 oder einer frei wählbaren Zahl. Optional kann die Nummer sofort auf alle Dateien des gleichen Ordners angewendet werden.
 
 ### 🔍 Suche & Import
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -107,7 +107,6 @@
                     <button class="sort-btn" onclick="sortTable('filename', event)">Dateiname</button>
                     <button class="sort-btn" onclick="sortTable('folder', event)">Ordner</button>
                     <button class="sort-btn" onclick="sortTable('completion', event)">Fertig</button>
-                    <button class="version-folder-btn" onclick="openVersionFolderDialog()">Ordner-Versionen</button>
                 </div>
                 <div class="progress-info">
                     <div class="progress-stat" id="totalProgress">0% vollständig</div>
@@ -536,40 +535,6 @@
         </div>
     </div>
 
-    <!-- Version für Ordner Dialog -->
-    <div class="dialog-overlay hidden" id="versionFolderDialog">
-        <div class="dialog">
-<button class="dialog-close-btn" onclick="closeVersionFolderDialog()">×</button>
-            <h3>🔢 Version für Ordner</h3>
-            <div style="margin-bottom:10px;">
-                <label>Ordner:
-                    <select id="versionFolderSelect"></select>
-                </label>
-            </div>
-            <div style="margin-bottom:10px;">
-                <label>Version:
-                    <select id="versionFolderVersionSelect">
-                        <option value="1">1</option>
-                        <option value="2">2</option>
-                        <option value="3">3</option>
-                        <option value="4">4</option>
-                        <option value="5">5</option>
-                        <option value="6">6</option>
-                        <option value="7">7</option>
-                        <option value="8">8</option>
-                        <option value="9">9</option>
-                        <option value="10">10</option>
-                        <option value="custom">Benutzerdefiniert ...</option>
-                    </select>
-                    <input type="number" id="versionFolderCustomInput" min="1" style="width:60px; display:none;">
-                </label>
-            </div>
-            <div class="dialog-buttons">
-                <button class="btn btn-secondary" onclick="closeVersionFolderDialog()">Abbrechen</button>
-                <button class="btn btn-success" onclick="applyVersionToFolder()">Übernehmen</button>
-            </div>
-        </div>
-    </div>
 
     <!-- Audio Player -->
     <audio id="audioPlayer"></audio>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1941,67 +1941,22 @@ function addFiles() {
                 num = parseInt(input, 10);
                 if (isNaN(num) || num <= 0) return;
             }
-            versionMenuFile.version = num;
-            isDirty = true;
-            renderFileTable();
-            saveProjects();
-        }
-
-        function openVersionFolderDialog() {
-            const select = document.getElementById('versionFolderSelect');
-            select.innerHTML = '';
-            const folders = Array.from(new Set(files.map(f => f.folder))).sort();
-            folders.forEach(f => {
-                const opt = document.createElement('option');
-                const last = f.split('/').pop() || f;
-                opt.value = f;
-                opt.textContent = last;
-                select.appendChild(opt);
-            });
-
-            document.getElementById('versionFolderVersionSelect').value = '1';
-            document.getElementById('versionFolderCustomInput').value = '';
-            document.getElementById('versionFolderCustomInput').style.display = 'none';
-
-            document.getElementById('versionFolderDialog').classList.remove('hidden');
-        }
-
-        function closeVersionFolderDialog() {
-            document.getElementById('versionFolderDialog').classList.add('hidden');
-        }
-
-        if (typeof document !== 'undefined' && typeof document.getElementById === 'function') {
-            const verSel = document.getElementById('versionFolderVersionSelect');
-            if (verSel) {
-                verSel.addEventListener('change', () => {
-                    const custom = document.getElementById('versionFolderCustomInput');
-                    custom.style.display = verSel.value === 'custom' ? 'inline-block' : 'none';
+            // Nachfragen, ob die Nummer auf den gesamten Ordner angewendet werden soll
+            const applyFolder = confirm('Version auf kompletten Ordner anwenden?');
+            if (applyFolder) {
+                files.forEach(f => {
+                    if (f.folder === versionMenuFile.folder && getDeFilePath(f)) {
+                        f.version = num;
+                    }
                 });
-            }
-        }
-
-        function applyVersionToFolder() {
-            const folder = document.getElementById('versionFolderSelect').value;
-            let ver = document.getElementById('versionFolderVersionSelect').value;
-            if (ver === 'custom') {
-                ver = parseInt(document.getElementById('versionFolderCustomInput').value, 10);
-                if (isNaN(ver) || ver <= 0) {
-                    alert('Ungültige Versionsnummer');
-                    return;
-                }
             } else {
-                ver = parseInt(ver, 10);
+                versionMenuFile.version = num;
             }
-            files.forEach(f => {
-                if (f.folder === folder && getDeFilePath(f)) {
-                    f.version = ver;
-                }
-            });
             isDirty = true;
             renderFileTable();
             saveProjects();
-            closeVersionFolderDialog();
         }
+
 
         async function contextMenuAction(action) {
             if (!contextMenuFile) {
@@ -2241,7 +2196,7 @@ return `
             </span>
         </td>
         <td>
-            ${hasDeAudio ? `<span class="version-badge" oncontextmenu="openVersionMenu(event, ${file.id})">${file.version ?? 1}</span>` : ''}
+            ${hasDeAudio ? `<span class="version-badge" onclick="openVersionMenu(event, ${file.id})">${file.version ?? 1}</span>` : ''}
         </td>
         <td><div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
             <textarea class="text-input"

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -54,7 +54,7 @@
         }
 		
 		/* Debug column styling */
-td:nth-child(6) {
+td:nth-child(7) {
     max-width: 200px;
     font-size: 11px;
     color: #666;
@@ -62,7 +62,7 @@ td:nth-child(6) {
     line-height: 1.2;
 }
 
-th:nth-child(6) {
+th:nth-child(7) {
     max-width: 200px;
     font-size: 12px;
 }
@@ -647,13 +647,13 @@ th:nth-child(6) {
         }
 
         /* Flexible Spaltenbreite für EN und DE */
-        td:nth-child(5), td:nth-child(6) {
+        td:nth-child(6), td:nth-child(7) {
             width: 25%;
             min-width: 200px;
             vertical-align: top;
         }
 
-        th:nth-child(5), th:nth-child(6) {
+        th:nth-child(6), th:nth-child(7) {
             width: 25%;
             min-width: 200px;
         }
@@ -666,30 +666,30 @@ th:nth-child(6) {
 
 /* Make table responsive - aktualisierte Spalten-Nummern */
 @media (max-width: 1200px) {
-    td:nth-child(5), td:nth-child(6) {
+    td:nth-child(6), td:nth-child(7) {
         width: 25%;
         min-width: 180px;
     }
-    th:nth-child(5), th:nth-child(6) {
+    th:nth-child(6), th:nth-child(7) {
         width: 25%;
         min-width: 180px;
     }
     /* Debug-Spalte bei kleinen Bildschirmen ausblenden */
-    td:nth-child(7), th:nth-child(7) {
+    td:nth-child(8), th:nth-child(8) {
         display: none;
     }
 }
 
 @media (max-width: 900px) {
-    td:nth-child(5), td:nth-child(6) {
+    td:nth-child(6), td:nth-child(7) {
         width: 30%;
         min-width: 160px;
     }
-    th:nth-child(5), th:nth-child(6) {
+    th:nth-child(6), th:nth-child(7) {
         width: 30%;
         min-width: 160px;
     }
-    td:nth-child(7), th:nth-child(7) {
+    td:nth-child(8), th:nth-child(8) {
         display: none;
     }
 }


### PR DESCRIPTION
## Zusammenfassung
- Linksklick öffnet das Versionsmenü, Rechtsklick entfällt
- Wahl einer Versionsnummer kann nun auf den gesamten Ordner angewendet werden
- nicht mehr benötigten Dialog "Ordner-Versionen" entfernt
- CSS an neue Spaltenpositionen angepasst
- README für das neue Verhalten aktualisiert

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a6b88a0bc83279d25b982c13b703a