### PR TITLE
Fix Versionsauswahl

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,9 @@ Seit Patch 1.40.66 nutzt `start_tool.py` `subprocess.check_call` mit Argumentlis
 damit `pip install` ohne aufwendiges Quoting auch unter Windows funktioniert.
 Seit Patch 1.40.67 warnt `start_tool.py` vor Python 3.13 oder neuer und ermoeglicht einen Abbruch.
 Seit Patch 1.40.68 öffnet sich das Versionsmenü beim Klick auf die Nummer wieder korrekt.
+Seit Patch 1.40.69 ändert die Schnellwahl (Version 1–10) nur noch die angeklickte Datei.
+Beim Punkt "Benutzerdefiniert..." können Sie eine beliebige Nummer eingeben und entscheiden,
+ob alle Dateien mit demselben Namen im Projekt angepasst werden sollen.
 
 Beispiel einer gültigen CSV:
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1943,16 +1943,20 @@ function addFiles() {
                 if (!input) return;
                 num = parseInt(input, 10);
                 if (isNaN(num) || num <= 0) return;
-            }
-            // Nachfragen, ob die Nummer auf den gesamten Ordner angewendet werden soll
-            const applyFolder = confirm('Version auf kompletten Ordner anwenden?');
-            if (applyFolder) {
-                files.forEach(f => {
-                    if (f.folder === versionMenuFile.folder && getDeFilePath(f)) {
-                        f.version = num;
-                    }
-                });
+                // Nur bei benutzerdefinierter Nummer nach dem Anwendungsbereich fragen
+                const applyAll = confirm('F\u00fcr alle Dateien mit gleichem Namen im Projekt anwenden?');
+                if (applyAll) {
+                    // Version f\u00fcr alle gleichnamigen Dateien setzen
+                    files.forEach(f => {
+                        if (f.filename === versionMenuFile.filename) {
+                            f.version = num;
+                        }
+                    });
+                } else {
+                    versionMenuFile.version = num;
+                }
             } else {
+                // Voreingestellte Nummern 1-10 nur auf die aktuelle Datei anwenden
                 versionMenuFile.version = num;
             }
             isDirty = true;


### PR DESCRIPTION
## Summary
- korrigierte `selectVersion`-Logik: Voreingestellte Versionen ändern nur die aktuelle Datei, bei "Benutzerdefiniert" erfolgt eine Abfrage für alle gleichnamigen Dateien
- README um Erklärung des neuen Verhaltens ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a704e6c048327a9be92289a04a6d2