### PR TITLE
Add color gradient for version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Neue Meldung:** Scheitert das Anlegen einer History-Version, wird "Fehler beim Anlegen der History-Version" ausgegeben.
 * **Dynamische Download-Spalte:** Die Spalte erscheint nur bei Bedarf und blendet sich aus, ohne die Tabellenüberschriften zu verschieben.
 * **Versionierung pro Datei:** Eine neue Spalte zwischen Ordner und EN‑Text zeigt die Version nur an, wenn eine deutsche Audiodatei existiert. Linksklick öffnet ein Menü mit Version 1–10 oder einer frei wählbaren Zahl. Der Dialog besitzt jetzt die Schaltflächen **Abbrechen**, **Übernehmen** und **Für alle übernehmen**. Letztere setzt die Nummer ohne Rückfrage für alle Dateien im selben Ordner.
+* **Farbige Versionsnummern:** Der Hintergrund des Versions‑Buttons wird mit steigender Nummer zunehmend grün und ab Version 10 fast schwarzgrün.
 
 ### 🔍 Suche & Import
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -548,6 +548,23 @@ function setLevelIcon(levelName, icon) {
 }
 /* =========================== LEVEL-ICON-HILFSFUNKTIONEN ENDE =============== */
 
+/* =========================== VERSION-FARBEN START ========================== */
+// Liefert abhängig von der Versionsnummer einen Grünton.
+// Grau für Version 1, immer satteres Grün bis Version 10,
+// darüber hinaus sehr dunkles Schwarzgrün.
+function getVersionColor(v) {
+    if (!v || v <= 1) return '#555';
+    if (v > 10) return '#002200';
+    const ratio = (v - 1) / 9; // Wertebereich 0..1
+    const start = { r: 85, g: 85, b: 85 }; // Grau
+    const end = { r: 0, g: 68, b: 0 };     // Dunkelgrün
+    const r = Math.round(start.r + (end.r - start.r) * ratio);
+    const g = Math.round(start.g + (end.g - start.g) * ratio);
+    const b = Math.round(start.b + (end.b - start.b) * ratio);
+    return `rgb(${r},${g},${b})`;
+}
+/* =========================== VERSION-FARBEN ENDE =========================== */
+
 /* =========================== KAPITEL-HILFSFUNKTIONEN START ================= */
 function getLevelChapter(levelName) {
     return levelChapters[levelName] || '–';
@@ -2208,7 +2225,7 @@ return `
             </span>
         </td>
         <td>
-            ${hasDeAudio ? `<span class="version-badge" onclick="openVersionMenu(event, ${file.id})">${file.version ?? 1}</span>` : ''}
+            ${hasDeAudio ? `<span class="version-badge" style="background:${getVersionColor(file.version ?? 1)}" onclick="openVersionMenu(event, ${file.id})">${file.version ?? 1}</span>` : ''}
         </td>
         <td><div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
             <textarea class="text-input"

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1424,13 +1424,12 @@ th:nth-child(7) {
             font-size: 12px;
             font-weight: 500;
             cursor: pointer;
-            background: #555;
             color: #fff;
             user-select: none;
         }
 
         .version-badge:hover {
-            background: #666;
+            filter: brightness(1.1);
         }
 
 /* Speziell breiterer Dialog für die DE-Audio-Bearbeitung */


### PR DESCRIPTION
## Summary
- färbe Versions-Buttons abhängig von der Nummer
- passe CSS-Hover für version-badge an
- beschreibe neue Funktion in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a7c9f66748327b4df35aac60ed74e