### PR TITLE
Fix Drag & Drop version increment

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Seit Patch 1.40.71 ersetzt ein Dialog die veraltete Funktion `prompt()` und verh
 Seit Patch 1.40.72 bietet dieser Dialog zusätzlich die Schaltfläche **Für alle übernehmen**,
 die alle Dateien im selben Ordner ohne Nachfrage aktualisiert.
 Seit Patch 1.40.73 erhöht ein Upload die Versionsnummer automatisch, wenn bereits eine deutsche Datei existiert.
+Seit Patch 1.40.74 funktioniert Drag & Drop korrekt: Die Versionsnummer steigt nur noch um eins.
 
 Beispiel einer gültigen CSV:
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -10966,9 +10966,12 @@ function showChapterCustomization(chapterName, ev) {
             }
         }
 
-        async function handleRowDrop(e) {
-            if (Array.from(e.dataTransfer.types).includes('Files')) {
+       async function handleRowDrop(e) {
+           if (Array.from(e.dataTransfer.types).includes('Files')) {
+                // Standardverhalten verhindern und Aufpropagieren stoppen,
+                // damit der Upload nur einmal erfolgt
                 e.preventDefault();
+                e.stopPropagation();
                 const row = e.currentTarget.closest('tr');
                 const fileId = parseFloat(row.dataset.id);
                 const fileObj = files.find(f => f.id === fileId);


### PR DESCRIPTION
## Summary
- stop event propagation during drag & drop upload so version only increases once
- document the fix in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a81be839c8327baa5b6e999577dba