### PR TITLE
Reset editing flags on upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Funkgeräte-Effekt:** Alle Parameter (Bandpass, Sättigung, Rauschen, Knackser, Wet) lassen sich bequem per Regler einstellen und werden dauerhaft gespeichert.
 * **Schneller Zugriff:** Die Funktionen Lautstärke angleichen – ⚡ und Funkgerät-Effekt – 📻 besitzen nun eigene Buttons mit Symbolen. Der Button **⟳ Standardwerte** befindet sich direkt daneben.
 * **Verbessertes Speichern:** Nach dem Anwenden von Lautstärke angleichen oder Funkgerät‑Effekt bleiben die Änderungen nun zuverlässig erhalten.
+* **Zurücksetzen nach Upload:** Beim Hochladen einer neuen deutschen Audiodatei werden Lautstärkeangleichung und Funkgerät‑Effekt automatisch deaktiviert.
 * **Fehlerhinweise beim Speichern:** Tritt ein Problem auf, erscheint eine rote Toast-Meldung statt eines stummen Abbruchs.
 * **Neue Meldung:** Scheitert das Anlegen einer History-Version, wird "Fehler beim Anlegen der History-Version" ausgegeben.
 * **Dynamische Download-Spalte:** Die Spalte erscheint nur bei Bedarf und blendet sich aus, ohne die Tabellenüberschriften zu verschieben.

--- a/tests/uploadResetsFlags.test.js
+++ b/tests/uploadResetsFlags.test.js
@@ -1,0 +1,25 @@
+const { expect, test } = require('@jest/globals');
+
+// Minimaler Mock der Upload-Funktion
+function uploadFileMock(file) {
+    if (!file) return;
+    // Flags wie im echten Upload zurücksetzen
+    file.trimStartMs = 0;
+    file.trimEndMs = 0;
+    file.volumeMatched = false;
+    file.radioEffect = false;
+}
+
+test('Upload setzt Bearbeitungs-Flags zurück', () => {
+    const file = {
+        trimStartMs: 12,
+        trimEndMs: 34,
+        volumeMatched: true,
+        radioEffect: true
+    };
+    uploadFileMock(file);
+    expect(file.trimStartMs).toBe(0);
+    expect(file.trimEndMs).toBe(0);
+    expect(file.volumeMatched).toBe(false);
+    expect(file.radioEffect).toBe(false);
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -7612,6 +7612,11 @@ async function handleDeUpload(input) {
         if (bestehendeDatei) {
             file.version = (file.version || 1) + 1;
         }
+        // Bearbeitungs-Flags zurücksetzen, da die hochgeladene Datei neu ist
+        file.trimStartMs = 0;
+        file.trimEndMs = 0;
+        file.volumeMatched = false;
+        file.radioEffect = false;
         // Fertig-Status ergibt sich nun automatisch
     }
 
@@ -11005,6 +11010,11 @@ function showChapterCustomization(chapterName, ev) {
                 if (vorhandene) {
                     f.version = (f.version || 1) + 1;
                 }
+                // Bearbeitungs-Flags zurücksetzen, da es sich um eine neue Datei handelt
+                f.trimStartMs = 0;
+                f.trimEndMs = 0;
+                f.volumeMatched = false;
+                f.radioEffect = false;
                 // Fertig-Status ergibt sich nun automatisch
             }
             isDirty = true;


### PR DESCRIPTION
## Summary
- reset Lautstärke- und Funkgeräte-Flags bei Upload neuer DE-Dateien
- beschreibe neues Verhalten in der README
- Test hinzugefügt, damit die Flags nach dem Upload zurückgesetzt werden

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a84fb466883278f635aeb2678a3ef