### PR TITLE
Fix Download-Pfeil

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Fehlerhinweise beim Speichern:** Tritt ein Problem auf, erscheint eine rote Toast-Meldung statt eines stummen Abbruchs.
 * **Neue Meldung:** Scheitert das Anlegen einer History-Version, wird "Fehler beim Anlegen der History-Version" ausgegeben.
 * **Dynamische Download-Spalte:** Die Spalte erscheint nur bei Bedarf und blendet sich aus, ohne die Tabellenüberschriften zu verschieben. Der blaue Download-Pfeil zeigt nun beim Überfahren mit der Maus die Dubbing-ID an und öffnet beim Anklicken die ElevenLabs-Seite des entsprechenden Jobs.
+* **Bugfix:** Ein Klick auf den Download-Pfeil öffnet jetzt zuverlässig die korrekte Studio-Seite.
 * **Versionierung pro Datei:** Eine neue Spalte zwischen Ordner und EN‑Text zeigt die Version nur an, wenn eine deutsche Audiodatei existiert. Linksklick öffnet ein Menü mit Version 1–10 oder einer frei wählbaren Zahl. Der Dialog besitzt jetzt die Schaltflächen **Abbrechen**, **Übernehmen** und **Für alle übernehmen**. Letztere setzt die Nummer ohne Rückfrage für alle Dateien im selben Ordner.
 * **Farbige Versionsnummern:** Der Hintergrund des Versions‑Buttons wird mit steigender Nummer zunehmend grün und ab Version 10 fast schwarzgrün.
 * **Automatische Versionsanpassung:** Beim manuellen Upload oder Drag & Drop erhöht sich die Versionsnummer automatisch, falls bereits eine deutsche Datei vorhanden ist.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2259,7 +2259,7 @@ return `
         <td><button class="dubbing-btn" onclick="initiateDubbing(${file.id})">🔈</button></td>
         <td><span class="dub-status ${!file.dubbingId ? 'none' : (file.dubReady ? 'done' : 'pending')}" title="${!file.dubbingId ? 'kein Dubbing' : (file.dubReady ? 'fertig' : 'Studio generiert noch')}" ${(!file.dubbingId || file.dubReady) ? '' : `onclick="dubStatusClicked(${file.id})"`}>●</span></td>
         <td><span class="length-diff ${lengthClass}">${lengthIndicator}</span></td>
-        <td class="download-cell">${file.dubbingId ? `<button class="download-de-btn" data-file-id="${file.id}" title="Dubbing-ID: ${file.dubbingId}" onclick="openDubbingPage(${file.id})" disabled>⬇️</button>` : ''}</td>
+        <td class="download-cell">${file.dubbingId ? `<button class="download-de-btn" data-file-id="${file.id}" title="Dubbing-ID: ${file.dubbingId}" onclick="openDubbingPage(${file.id})">⬇️</button>` : ''}</td>
         <td>${hasHistory ? `<button class="history-btn" onclick="openHistory(${file.id})">🕒</button>` : ''}</td>
         <td><div style="display:flex;align-items:flex-start;gap:5px;">
             <button class="edit-audio-btn" onclick="openDeEdit(${file.id})">✂️</button>
@@ -8410,7 +8410,8 @@ async function redownloadDubbing(fileId, mode = 'beta') {
 function openDubbingPage(fileId) {
     const file = files.find(f => f.id === fileId);
     if (!file || !file.dubbingId) return;
-    const url = `https://elevenlabs.io/v1/dubbing/${file.dubbingId}`;
+    // Öffnet die Studio-Seite statt des API-Endpunkts
+    const url = `https://elevenlabs.io/studio/dubbing/${file.dubbingId}`;
     if (window.electronAPI && window.electronAPI.openExternal) {
         window.electronAPI.openExternal(url);
     } else {


### PR DESCRIPTION
## Summary
- remove `disabled` from Download-DE button
- open the ElevenLabs Studio page instead of the API endpoint
- document the bugfix in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a9070f2448327bd47158329f9bbb2