### PR TITLE
Anzeige der Dubbing-ID im Dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ Seit Patch 1.40.74 funktioniert Drag & Drop korrekt: Die Versionsnummer steigt n
 Seit Patch 1.40.75 zeigt der blaue Download-Pfeil beim Überfahren mit der Maus die gespeicherte Dubbing-ID an.
 Seit Patch 1.40.76 öffnet ein Klick auf diesen Pfeil die entsprechende V1-Dubbing-Seite bei ElevenLabs.
 Seit Patch 1.40.77 startet der halbautomatische Modus automatisch die passende Dubbing-Seite im Browser.
+Seit Patch 1.40.78 zeigt das "Alles gesendet"-Fenster die Dubbing-ID an und bietet Buttons
+zum Öffnen der ElevenLabs-Seite sowie der gerade importierten Datei.
 
 Beispiel einer gültigen CSV:
 

--- a/electron/ipcContracts.ts
+++ b/electron/ipcContracts.ts
@@ -61,4 +61,5 @@ export type IpcChannels =
   | 'load-bookmarks'
   | 'save-bookmarks'
   | 'delete-bookmark'
-  | 'open-external';
+  | 'open-external'
+  | 'open-path';

--- a/electron/main.js
+++ b/electron/main.js
@@ -323,6 +323,12 @@ app.whenReady().then(() => {
     return true;
   });
 
+  // Beliebige Datei im Standardprogramm öffnen
+  ipcMain.handle('open-path', async (event, p) => {
+    shell.openPath(p);
+    return true;
+  });
+
   // Screenshot des aktuellen Fensters erstellen
   ipcMain.handle('capture-frame', async (event, bounds) => {
     const win = BrowserWindow.fromWebContents(event.sender);

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -73,6 +73,7 @@ if (typeof require !== 'function') {
     // Half-Life: Alyx starten (Modus und Sprache wählbar, optional Map)
     startHla: (mode, lang, map) => ipcRenderer.invoke('start-hla', { mode, lang, map }),
     openExternal: (url) => ipcRenderer.invoke('open-external', url),
+    openPath: (p) => ipcRenderer.invoke('open-path', p),
     captureFrame: bounds => ipcRenderer.invoke('capture-frame', bounds),
   });
 


### PR DESCRIPTION
## Zusammenfassung
- IPC-Kanal `open-path` hinzugefügt
- Wartefenster zeigt nun die Dubbing‑ID und Buttons zum Öffnen der Studio-Seite bzw. der fertigen Datei
- Funktion `openLocalFile` implementiert
- README um neuen Patch 1.40.78 ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a98f4e5cc832799a1182e8fc5d4e2