### PR TITLE
Disable Electron window for manual dubbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Seit Patch 1.40.73 erhöht ein Upload die Versionsnummer automatisch, wenn berei
 Seit Patch 1.40.74 funktioniert Drag & Drop korrekt: Die Versionsnummer steigt nur noch um eins.
 Seit Patch 1.40.75 zeigt der blaue Download-Pfeil beim Überfahren mit der Maus die gespeicherte Dubbing-ID an.
 Seit Patch 1.40.76 öffnet ein Klick auf diesen Pfeil die entsprechende V1-Dubbing-Seite bei ElevenLabs.
-Seit Patch 1.40.77 startet der halbautomatische Modus automatisch die passende Dubbing-Seite im Browser.
+Seit Patch 1.40.77 startet der halbautomatische Modus automatisch die passende Dubbing-Seite im externen Browser, nicht mehr im Electron-Fenster.
 Seit Patch 1.40.78 zeigt das "Alles gesendet"-Fenster die Dubbing-ID an und bietet Buttons
 zum Öffnen der ElevenLabs-Seite sowie der gerade importierten Datei.
 Seit Patch 1.40.79 wird beim Dubben ebenfalls die Versionsnummer erhöht, wenn bereits eine deutsche Datei vorhanden ist.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -8039,7 +8039,13 @@ function closeDownloadWaitDialog() {
 // Öffnet die neue Dubbing-Seite und zeigt einen Hinweis mit Download-Pfad an
 async function openStudioAndWait(dubId) {
     const url = `https://elevenlabs.io/v1/dubbing/${dubId}`;
-    window.open(url, '_blank');
+    // Wenn moeglich, externen Browser nutzen, um kein neues Electron-Fenster
+    // zu oeffnen
+    if (window.electronAPI && window.electronAPI.openExternal) {
+        await window.electronAPI.openExternal(url);
+    } else {
+        window.open(url, '_blank');
+    }
 
     // Pfad aus Electron abrufen, falls verfügbar
     let dlPath = 'Download';


### PR DESCRIPTION
## Summary
- open the ElevenLabs studio in the system browser when using the manual dub workflow
- document the change in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685abe1f8c6c8327a6d4699a5102e785