### PR TITLE
Add dictionary hint icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Eigenes Wörterbuch:** Ein neuer 📚-Knopf speichert englische Wörter zusammen mit deutscher Lautschrift.
+* **Hinweis-Symbol bei Übersetzungen:** Unter der Lupe erscheint ein kleines 📝, wenn der DE-Text ein Wort aus dem Wörterbuch enthält.
 * **Schnellstart im Player:** YouTube-Links aus der URL-Eingabe starten direkt im eingebetteten Player; andere Links werden extern geöffnet. Beim Öffnen wird automatisch ein Bookmark angelegt.
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.
 * **Löschen per Desktop-API:** Einzelne Bookmarks lassen sich nun über einen zusätzlichen IPC-Kanal entfernen.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2307,7 +2307,10 @@ return `
         </div>
         <div class="auto-trans" data-file-id="${file.id}">${escapeHtml(file.autoTranslation || '')}</div></td>
         <!-- Untertitel-Suche Knopf -->
-        <td><button class="subtitle-search-btn" onclick="openSubtitleSearch(${file.id})" title="Ähnlichen Untertitel suchen">🔍</button></td>
+        <td><div class="btn-column">
+            <button class="subtitle-search-btn" onclick="openSubtitleSearch(${file.id})" title="Ähnlichen Untertitel suchen">🔍</button>
+            ${textContainsWord(file.deText) ? `<button class="word-indicator" onclick="openWordList()" title="Wörterbuch öffnen">📖</button>` : ''}
+        </div></td>
         <td class="path-cell" style="font-size: 11px; color: #666; word-break: break-all;">
             <div class="btn-column">
                 <span class="path-btn ${audioFileCache[relPath] ? 'exists' : 'missing'}" title="Pfad der EN-Datei">EN</span>
@@ -11343,6 +11346,22 @@ function showChapterCustomization(chapterName, ev) {
             const div = document.createElement('div');
             div.textContent = text;
             return div.innerHTML;
+        }
+
+        // Hilfsfunktion für RegExp-Erstellung
+        function escapeRegExp(str) {
+            return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        }
+
+        // Prüft, ob ein Wort aus dem Wörterbuch im angegebenen Text vorkommt
+        function textContainsWord(text) {
+            const lower = (text || '').toLowerCase();
+            return wordList.some(e => {
+                const w = (e.word || '').trim().toLowerCase();
+                if (!w) return false;
+                const re = new RegExp('\\b' + escapeRegExp(w) + '\\b');
+                return re.test(lower);
+            });
         }
 
         // Auto-save on input changes with debouncing

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -950,6 +950,33 @@ th:nth-child(7) {
             transform: scale(1.1);
         }
 
+        /* Kleines Symbol für vorhandene Wörterbuch-Einträge */
+        .word-indicator {
+            background: #444;
+            border: none;
+            color: #e0e0e0;
+            padding: 4px 6px;
+            border-radius: 3px;
+            cursor: pointer;
+            font-size: 11px;
+            transition: all 0.2s;
+            min-width: 24px;
+            height: 24px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .word-indicator:hover {
+            background: #5e92f3;
+            color: white;
+            transform: scale(1.1);
+        }
+
+        .word-indicator:active {
+            transform: scale(0.95);
+        }
+
         .subtitle-search-btn:active {
             transform: scale(0.95);
         }


### PR DESCRIPTION
## Summary
- füge ein neues Symbol unter der UT-Lupe ein
- öffne das Wörterbuch beim Klick auf dieses Symbol
- prüfe den DE-Text auf Wörter aus dem Wörterbuch
- erweitere CSS um die Darstellung des Symbols
- ergänze README um die neue Funktion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b117a1e348327814e5af586b946a9