### PR TITLE
Fix Subtitle Similarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ zum Öffnen der ElevenLabs-Seite sowie der gerade importierten Datei.
 Seit Patch 1.40.79 wird beim Dubben ebenfalls die Versionsnummer erhöht, wenn bereits eine deutsche Datei vorhanden ist.
 Seit Patch 1.40.80 speichert ein neuer 📓-Knopf englische Wörter zusammen mit deutscher Lautschrift.
 Seit Patch 1.40.81 erscheint unter der Lupe ein kleines 📝, wenn der DE-Text ein Wort aus diesem Wörterbuch enthält.
+Seit Patch 1.40.82 bewertet die Untertitel-Suche kurze Wörter strenger und vermeidet so falsche 100%-Treffer.
 
 Beispiel einer gültigen CSV:
 

--- a/tests/calculateTextSimilarity.test.js
+++ b/tests/calculateTextSimilarity.test.js
@@ -1,0 +1,29 @@
+let calculateTextSimilarity;
+
+function loadMain() {
+    jest.resetModules();
+    global.document = { addEventListener: jest.fn() };
+    global.window = { addEventListener: jest.fn() };
+    global.localStorage = {
+        getItem: () => null,
+        setItem: () => {},
+        removeItem: () => {},
+        clear: () => {}
+    };
+    ({ calculateTextSimilarity } = require('../web/src/main.js'));
+}
+
+beforeEach(loadMain);
+
+describe('calculateTextSimilarity', () => {
+    test('unterschiedliche Texte liefern keine 100% Treffer', () => {
+        const a = "Nope. I'm good, I'm good.";
+        const b = "Good. I hope they're good.";
+        const result = calculateTextSimilarity(a, b);
+        expect(result).toBeLessThan(0.95);
+    });
+
+    test('identische Texte ergeben 1', () => {
+        expect(calculateTextSimilarity('Hallo', 'Hallo')).toBe(1);
+    });
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2571,11 +2571,12 @@ function calculateTextSimilarity(text1, text2) {
     const allWords = new Set([...words1, ...words2]);
     
     words1.forEach(word1 => {
-        if (words2.some(word2 =>
-            // Exakte oder nahezu exakte Wortuebereinstimmung pruefen
-            word1 === word2 ||
-            levenshteinDistance(word1, word2) <= Math.max(1, Math.min(word1.length, word2.length) * 0.3)
-        )) {
+        if (words2.some(word2 => {
+            // Bei kurzen Wörtern nur genaue Treffer zulassen
+            const len = Math.min(word1.length, word2.length);
+            const schwelle = len < 5 ? 0 : Math.max(1, Math.floor(len * 0.3));
+            return word1 === word2 || levenshteinDistance(word1, word2) <= schwelle;
+        })) {
             commonWords++;
         }
     });
@@ -11485,6 +11486,7 @@ if (typeof module !== "undefined" && module.exports) {
         updateAutoTranslation,
         importClosecaptions,
         stripColorCodes,
+        calculateTextSimilarity,
         __setFiles: f => { files = f; },
         __setDeAudioCache: c => { deAudioCache = c; },
         __setRenderFileTable: fn => { renderFileTable = fn; },


### PR DESCRIPTION
## Summary
- verbessere die Untertitel-Ähnlichkeitsberechnung für kurze Wörter
- exportiere `calculateTextSimilarity`
- ergänze Patch-Notiz in der README
- füge Tests für `calculateTextSimilarity` hinzu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c32a3ae588327a2b9eea15b896f49