### PR TITLE
Fix folder clipboard copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Dynamische Download-Spalte:** Die Spalte erscheint nur bei Bedarf und blendet sich aus, ohne die Tabellenüberschriften zu verschieben. Der blaue Download-Pfeil zeigt nun beim Überfahren mit der Maus die Dubbing-ID an und öffnet beim Anklicken die ElevenLabs-Seite des entsprechenden Jobs.
 * **Bugfix:** Ein Klick auf den Download-Pfeil öffnet jetzt zuverlässig die korrekte V1-Dubbing-Seite.
 * **Automatik-Button für halbautomatisches Dubbing:** Per Playwright werden alle notwendigen Klicks im ElevenLabs-Studio ausgeführt.
-* **Ordnername in Zwischenablage:** Beim halbautomatischen Dubbing kopiert das Tool den Ordnernamen automatisch, sobald auf die fertige Datei gewartet wird.
+* **Ordnername in Zwischenablage:** Beim halbautomatischen Dubbing kopiert das Tool nur noch den reinen Ordnernamen in die Zwischenablage, sobald auf die fertige Datei gewartet wird.
 * **Zusätzlicher 📋-Button:** Im Fenster "Alles gesendet" kopiert ein Knopf den Ordnernamen erneut in die Zwischenablage.
 * **Versionierung pro Datei:** Eine neue Spalte zwischen Ordner und EN‑Text zeigt die Version nur an, wenn eine deutsche Audiodatei existiert. Linksklick öffnet ein Menü mit Version 1–10 oder einer frei wählbaren Zahl. Der Dialog besitzt jetzt die Schaltflächen **Abbrechen**, **Übernehmen** und **Für alle übernehmen**. Letztere setzt die Nummer ohne Rückfrage für alle Dateien im selben Ordner.
 * **Farbige Versionsnummern:** Der Hintergrund des Versions‑Buttons wird mit steigender Nummer zunehmend grün und ab Version 10 fast schwarzgrün.
@@ -425,6 +425,7 @@ Seit Patch 1.40.82 bewertet die Untertitel-Suche kurze Wörter strenger und verm
 Seit Patch 1.40.83 führt der neue Button **Automatik** das halbautomatische Dubbing selbstständig aus. Die Desktop-Version nutzt dafür Playwright.
 Seit Patch 1.40.84 zeigt der Automatik-Modus im Terminal die ausgeführten Schritte an.
 Seit Patch 1.40.85 bietet das "Alles gesendet"-Fenster einen 📋-Button, um den Ordnernamen erneut zu kopieren.
+Seit Patch 1.40.86 wird beim Kopieren des Ordnernamens nur noch der letzte Pfadteil übernommen.
 
 Beispiel einer gültigen CSV:
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -8051,11 +8051,12 @@ async function showDownloadWaitDialog(fileId, dubId) {
     waitDialogFileId = fileId;
     const file = files.find(f => f.id === fileId) || {};
     const folder = escapeHtml(file.folder || '');
-    // Ordnername in die Zwischenablage kopieren
+    // Ordnername in die Zwischenablage kopieren (nur letzter Teil)
     if (file.folder) {
         try {
-            await navigator.clipboard.writeText(file.folder);
-            updateStatus('Ordner kopiert: ' + file.folder);
+            const baseFolder = file.folder.split(/[\\/]/).pop();
+            await navigator.clipboard.writeText(baseFolder);
+            updateStatus('Ordner kopiert: ' + baseFolder);
         } catch (err) {
             console.error('Kopieren fehlgeschlagen:', err);
         }
@@ -8117,8 +8118,9 @@ async function copyDownloadFolder() {
     const file = files.find(f => f.id === waitDialogFileId);
     if (!file || !file.folder) return;
     try {
-        await navigator.clipboard.writeText(file.folder);
-        updateStatus('Ordner kopiert: ' + file.folder);
+        const baseFolder = file.folder.split(/[\\/]/).pop();
+        await navigator.clipboard.writeText(baseFolder);
+        updateStatus('Ordner kopiert: ' + baseFolder);
     } catch (err) {
         console.error('Kopieren fehlgeschlagen:', err);
     }


### PR DESCRIPTION
## Summary
- copy only the final folder name when copying to clipboard
- adjust README to describe clipboard behaviour
- add changelog entry for patch `1.40.86`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d4c57d5148327a1a7f263e82ba17b