### PR TITLE
Clipboard-Fallback implementiert

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Ordnername in Zwischenablage:** Beim halbautomatischen Dubbing kopiert das Tool nur noch den reinen Ordnernamen in die Zwischenablage, sobald auf die fertige Datei gewartet wird.
 * **Bugfix:** Der Ordnername wird jetzt bereits beim Start des Halbautomatik-Dubbings automatisch kopiert.
 * **Zusätzlicher 📋-Button:** Im Fenster "Alles gesendet" kopiert ein Knopf den Ordnernamen erneut in die Zwischenablage.
+* **Robuster Zwischenablage-Zugriff:** Falls das Kopieren im Browser scheitert, verwendet das Tool automatisch die Electron-Clipboard-API.
 * **Versionierung pro Datei:** Eine neue Spalte zwischen Ordner und EN‑Text zeigt die Version nur an, wenn eine deutsche Audiodatei existiert. Linksklick öffnet ein Menü mit Version 1–10 oder einer frei wählbaren Zahl. Der Dialog besitzt jetzt die Schaltflächen **Abbrechen**, **Übernehmen** und **Für alle übernehmen**. Letztere setzt die Nummer ohne Rückfrage für alle Dateien im selben Ordner.
 * **Farbige Versionsnummern:** Der Hintergrund des Versions‑Buttons wird mit steigender Nummer zunehmend grün und ab Version 10 fast schwarzgrün.
 * **Automatische Versionsanpassung:** Beim manuellen Upload, Drag & Drop oder Dubben erhöht sich die Versionsnummer automatisch, falls bereits eine deutsche Datei vorhanden ist.
@@ -796,3 +797,4 @@ verwendet werden, um optionale Downloads zu überspringen.
 * **`syncProjectData(projects, filePathDatabase, textDatabase)`** – gleicht Projekte mit der Datenbank ab, korrigiert Dateiendungen und überträgt Texte.
 * **`repairFileExtensions(projects, filePathDatabase, textDatabase)`** – aktualisiert veraltete Dateiendungen in Projekten und verschiebt vorhandene Texte.
   Die Funktionen stehen im Browser direkt unter `window` zur Verfügung und können ohne Import genutzt werden.
+* **`safeCopy(text)`** – kopiert Text in die Zwischenablage und greift bei Fehlern auf Electron zurück.

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -18,7 +18,7 @@ if (typeof require !== 'function') {
   console.warn('Preload-Skript: "require" ist nicht verf\u00fcgbar. Das Skript wird beendet.');
 } else {
   // Desktop-Capturer wird nicht mehr benötigt
-  const { contextBridge, ipcRenderer } = require('electron');
+  const { contextBridge, ipcRenderer, clipboard } = require('electron');
   const fs = require('fs');
   // 'node:path' nutzen, damit das integrierte Modul auch nach dem Packen gefunden wird
   const path = require('node:path');
@@ -77,6 +77,8 @@ if (typeof require !== 'function') {
     // Automatische Steuerung der Dubbing-Seite
     autoDub: data => ipcRenderer.invoke('auto-dub', data),
     captureFrame: bounds => ipcRenderer.invoke('capture-frame', bounds),
+    // Text direkt über Electron in die Zwischenablage schreiben
+    writeClipboard: text => clipboard.writeText(text),
   });
 
   // Vereinfachtes API nur für Bildschirmaufnahmen


### PR DESCRIPTION
## Zusammenfassung
- Electron-Preload um `writeClipboard` erweitert
- neue Funktion `safeCopy` für robustes Kopieren in `web/src/main.js`
- alle Kopierfunktionen nutzen nun `safeCopy`
- README um Hinweise auf den Fallback ergänzt

## Testanweisungen
- `npm test` ausführen

------
https://chatgpt.com/codex/tasks/task_e_685d56ab972c8327a18bdb5bf106884a