### PR TITLE
Verbesserter Datei-Watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@
 * Neues Wörterbuch speichert englische Begriffe mit deutscher Lautschrift.
 ## 🛠️ Patch in 1.40.33
 * Ein kleines 📝 zeigt in der Tabelle an, wenn der DE-Text einen Eintrag aus dem Wörterbuch enthält.
+## 🛠️ Patch in 1.40.34
+* Dateiwächter wartet auf stabile Dateigröße und löscht nur noch die importierte Datei.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Nach erfolgreichem Download merkt sich das Projekt die zugehörige **Dubbing-ID*
 So können Sie das Ergebnis später erneut herunterladen oder neu generieren.
 Beim erneuten Download fragt das Tool nun ebenfalls, ob die Beta-API oder der halbautomatische Modus genutzt werden soll.
 
-Ein Watcher überwacht automatisch den Ordner `web/Download` bzw. `web/Downloads` im Projekt. Taucht dort eine fertig gerenderte Datei auf, meldet das Tool „Datei gefunden“ und verschiebt sie nach `web/sounds/DE`. Seit Version 1.40.5 klappt das auch nach einem Neustart: Legen Sie die Datei einfach in den Ordner, sie wird anhand der Dubbing‑ID automatisch der richtigen Zeile zugeordnet. Der Status springt anschließend auf *fertig*. Alle 15 Sekunden erfolgt zusätzlich eine Status-Abfrage der offenen Jobs, allerdings nur im Beta-Modus. Beta-Jobs werden nun automatisch aus dieser Liste entfernt, sobald sie fertig sind. Der halbautomatische Modus verzichtet auf diese Abfrage. Der Download-Ordner wird zu Beginn jedes neuen Dubbings und nach dem Import automatisch geleert. Seit Version 1.40.17 findet der Watcher auch Dateien mit leicht verändertem Namen und warnt bei fehlender Zuordnung im Terminal.
+Ein Watcher überwacht automatisch den Ordner `web/Download` bzw. `web/Downloads` im Projekt. Taucht dort eine fertig gerenderte Datei auf, meldet das Tool „Datei gefunden“ und verschiebt sie nach `web/sounds/DE`. Seit Version 1.40.5 klappt das auch nach einem Neustart: Legen Sie die Datei einfach in den Ordner, sie wird anhand der Dubbing‑ID automatisch der richtigen Zeile zugeordnet. Der Status springt anschließend auf *fertig*. Alle 15 Sekunden erfolgt zusätzlich eine Status-Abfrage der offenen Jobs, allerdings nur im Beta-Modus. Beta-Jobs werden nun automatisch aus dieser Liste entfernt, sobald sie fertig sind. Der halbautomatische Modus verzichtet auf diese Abfrage. Der Download-Ordner wird zu Beginn jedes neuen Dubbings geleert. Nach dem Import entfernt der Watcher nur noch die bearbeitete Datei, damit parallel abgelegte Downloads erhalten bleiben. Seit Version 1.40.17 findet der Watcher auch Dateien mit leicht verändertem Namen und warnt bei fehlender Zuordnung im Terminal.
 Persönliche Zusätze wie `_Alex` oder `-Bob` entfernt er dabei automatisch.
 Seit Patch 1.40.7 merkt sich das Tool außerdem den fertigen Status dauerhaft. Auch nach einem erneuten Download bleibt der grüne Haken erhalten.
 Seit Patch 1.40.8 werden Dateien auch dann korrekt verschoben, wenn sich Download- und Projektordner auf unterschiedlichen Laufwerken befinden.
@@ -429,6 +429,7 @@ Seit Patch 1.40.84 zeigt der Automatik-Modus im Terminal die ausgeführten Schri
 Seit Patch 1.40.85 bietet das "Alles gesendet"-Fenster einen 📋-Button, um den Ordnernamen erneut zu kopieren.
 Seit Patch 1.40.86 wird beim Kopieren des Ordnernamens nur noch der letzte Pfadteil übernommen.
 Seit Patch 1.40.87 kopiert das Tool den Ordnernamen direkt beim Start des Halbautomatik-Dubbings.
+Seit Patch 1.40.88 wartet der Dateiwächter auf eine stabile Dateigröße und löscht nach dem Import nur noch die verarbeitete Datei.
 
 Beispiel einer gültigen CSV:
 


### PR DESCRIPTION
## Summary
- verbessere `watchDownloadFolder` um `awaitWriteFinish`
- prüfe Dateigröße zweimal, bevor das Kopieren startet
- lösche nach dem Import nur noch die verarbeitete Datei
- ergänze Tests um neue Optionen
- passe Doku und Changelog an

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d5911cadc83279f8f2066fc2e58c0