### PR TITLE
Fix Watcher ENOENT error

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Seit Patch 1.40.85 bietet das "Alles gesendet"-Fenster einen 📋-Button, um den
 Seit Patch 1.40.86 wird beim Kopieren des Ordnernamens nur noch der letzte Pfadteil übernommen.
 Seit Patch 1.40.87 kopiert das Tool den Ordnernamen direkt beim Start des Halbautomatik-Dubbings.
 Seit Patch 1.40.88 wartet der Dateiwächter auf eine stabile Dateigröße und löscht nach dem Import nur noch die verarbeitete Datei.
+Seit Patch 1.40.89 verhindert der Dateiwchter einen Abbruch, wenn die Datei kurzzeitig fehlt.
 
 Beispiel einer gültigen CSV:
 

--- a/tests/warteBisFertig.test.js
+++ b/tests/warteBisFertig.test.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Testet, ob warteBisFertig auch bei kurzzeitig fehlender Datei funktioniert
+
+test('warteBisFertig ignoriert temporaeres Entfernen', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wait-'));
+  const file = path.join(tmpDir, 'test.wav');
+  fs.writeFileSync(file, 'a');
+
+  jest.resetModules();
+  const { __test: { warteBisFertig } } = require('../watcher.js');
+
+  // Nach kurzer Zeit Datei loeschen und spaeter erneut anlegen
+  setTimeout(() => fs.unlinkSync(file), 100);
+  setTimeout(() => fs.writeFileSync(file, 'abc'), 200);
+
+  const p = warteBisFertig(file);
+
+  await p;
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});

--- a/watcher.js
+++ b/watcher.js
@@ -26,6 +26,8 @@ function warteBisFertig(datei) {
         const timer = setInterval(() => {
             fs.stat(datei, (err, stat) => {
                 if (err) {
+                    // ENOENT => Datei existiert noch nicht oder wurde kurz entfernt
+                    if (err.code === 'ENOENT') return;
                     clearInterval(timer);
                     return reject(err);
                 }
@@ -197,5 +199,7 @@ module.exports = {
     watchDownloadFolder,
     clearDownloadFolder: leereOrdner,
     pruefeAudiodatei,
-    matchPendingJob
+    matchPendingJob,
+    // Zusätzlicher Export für Tests
+    __test: { warteBisFertig }
 };


### PR DESCRIPTION
## Summary
- verhindere Abbruch des Dateiwächters bei temporär fehlender Datei
- exportiere `warteBisFertig` für Tests
- ergänze README um Hinweis auf Fehlerbehebung
- füge Test für `warteBisFertig` hinzu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db31aebd08327a35d54749a3880ce