### PR TITLE
Fix Anzeige nach manuellem Dubbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Seit Patch 1.40.86 wird beim Kopieren des Ordnernamens nur noch der letzte Pfadt
 Seit Patch 1.40.87 kopiert das Tool den Ordnernamen direkt beim Start des Halbautomatik-Dubbings.
 Seit Patch 1.40.88 wartet der Dateiwächter auf eine stabile Dateigröße und löscht nach dem Import nur noch die verarbeitete Datei.
 Seit Patch 1.40.89 verhindert der Dateiwchter einen Abbruch, wenn die Datei kurzzeitig fehlt.
+Seit Patch 1.40.90 prüft das Tool nach dem Schließen des "Alles gesendet"-Fensters automatisch, ob neue Dub-Dateien erkannt wurden. So erscheint der grüne Haken auch dann, wenn der Dateiwächter bereits vorher reagiert hat.
 
 Beispiel einer gültigen CSV:
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -8135,6 +8135,10 @@ function closeDownloadWaitDialog() {
     const dlg = document.getElementById('downloadWaitDialog');
     if (dlg) dlg.remove();
     waitDialogFileId = null;
+    // Nach dem Schließen zur Sicherheit den Dubbing-Status aller Dateien prüfen
+    // So werden neu importierte Dateien auch dann erkannt, wenn das Watcher-Event
+    // vor dem Öffnen des Dialogs ausgelöst wurde
+    updateDubStatusForFiles();
 }
 
 // Kopiert einen Ordnernamen in die Zwischenablage (nur letzter Pfadteil)


### PR DESCRIPTION
## Summary
- "Alles gesendet"-Fenster schließt nun mit anschließendem Status-Check
- Patch-Historie in README ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db74d72308327bda893efd01fe553