### PR TITLE
Dateiwächter mit Timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ Seit Patch 1.40.88 wartet der Dateiwächter auf eine stabile Dateigröße und l�
 Seit Patch 1.40.89 verhindert der Dateiwchter einen Abbruch, wenn die Datei kurzzeitig fehlt.
 Seit Patch 1.40.90 prüft das Tool nach dem Schließen des "Alles gesendet"-Fensters automatisch, ob neue Dub-Dateien erkannt wurden. So erscheint der grüne Haken auch dann, wenn der Dateiwächter bereits vorher reagiert hat.
 Seit Patch 1.40.91 löst der Dateiwächter den manuellen Import nur noch aus, wenn keine Zuordnung zu offenen Jobs möglich ist.
+Seit Patch 1.40.92 bricht der Dateiwächter nach 10 s ohne stabile Datei mit einer Fehlermeldung ab.
 
 Beispiel einer gültigen CSV:
 

--- a/tests/warteBisFertig.test.js
+++ b/tests/warteBisFertig.test.js
@@ -22,3 +22,16 @@ test('warteBisFertig ignoriert temporaeres Entfernen', async () => {
 
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
+
+// Testet, ob ein Timeout korrekt ausgeloest wird
+test('warteBisFertig bricht nach Ablauf des Timeouts ab', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wait-'));
+  const file = path.join(tmpDir, 'missing.wav');
+
+  jest.resetModules();
+  const { __test: { warteBisFertig } } = require('../watcher.js');
+
+  await expect(warteBisFertig(file, 300)).rejects.toThrow('Timeout');
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Zusammenfassung
- Dateigröße-Wartefunktion erhält optionalen Timeout
- Timeout an Dateiwächter übergeben
- neuen Test für Timeout-Verhalten ergänzt
- README mit Hinweis auf neuen Patch erweitert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dbeed75448327bb3b46aa46a060a7