### PR TITLE
Auto-Schließen von Dub-Dialogen

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ Seit Patch 1.40.89 verhindert der Dateiwchter einen Abbruch, wenn die Datei kurz
 Seit Patch 1.40.90 prüft das Tool nach dem Schließen des "Alles gesendet"-Fensters automatisch, ob neue Dub-Dateien erkannt wurden. So erscheint der grüne Haken auch dann, wenn der Dateiwächter bereits vorher reagiert hat.
 Seit Patch 1.40.91 löst der Dateiwächter den manuellen Import nur noch aus, wenn keine Zuordnung zu offenen Jobs möglich ist.
 Seit Patch 1.40.92 bricht der Dateiwächter nach 10 s ohne stabile Datei mit einer Fehlermeldung ab.
+Seit Patch 1.40.93 schließen sich nach erfolgreichem Import das Fenster „Alles gesendet“, der Studio-Hinweis und das Dubbing-Protokoll automatisch.
 
 Beispiel einer gültigen CSV:
 


### PR DESCRIPTION
## Zusammenfassung
- Studio-Fenster merken und nach erfolgreichem Import schließen
- `updateDownloadWaitDialog` schließt jetzt automatisch alle Dub-Dialoge
- Patchnotes in der README ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dc38023b88327808e83a1f633c19d