### PR TITLE
Refaktor: Text-Utilities ausgelagert

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * [📥 Import](#-import)
 * [📁 Ordner-Management](#-ordner-management)
 * [💾 Backup](#-backup)
+* [🗂️ Projektstruktur](#-projektstruktur)
 * [🔧 Erweiterte Funktionen](#-erweiterte-funktionen)
 * [🐛 Troubleshooting](#-troubleshooting)
 ---
@@ -626,6 +627,13 @@ Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellunge
 ## 💾 Backup
 
 Mit dem Backup-Dialog lassen sich alle Projekt-Daten als JSON speichern. Neu ist die Option, die Ordner **Sounds/DE**, **DE-Backup** und **DE-History** als ZIP-Archiv zu sichern. Die ZIP-Dateien liegen im Benutzerordner unter `Backups/sounds`. Das Tool behält automatisch nur die fünf neuesten ZIP-Backups.
+
+
+## 🗂️ Projektstruktur
+
+Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
+* **web/src/main.js** – Initialisierung der App
+* **web/src/fileUtils.js** – Text-Funktionen wie `calculateTextSimilarity`
 
 ---
 

--- a/tests/calculateTextSimilarity.test.js
+++ b/tests/calculateTextSimilarity.test.js
@@ -10,7 +10,7 @@ function loadMain() {
         removeItem: () => {},
         clear: () => {}
     };
-    ({ calculateTextSimilarity } = require('../web/src/main.js'));
+    ({ calculateTextSimilarity } = require('../web/src/fileUtils.js'));
 }
 
 beforeEach(loadMain);

--- a/web/src/fileUtils.js
+++ b/web/src/fileUtils.js
@@ -1,0 +1,82 @@
+// Hilfsfunktionen für Text-Vergleiche
+
+function calculateTextSimilarity(text1, text2) {
+    // Normalisiere beide Texte
+    const normalize = (text) => {
+        return text.toLowerCase()
+                   .replace(/[^\w\s]/g, '') // Entferne Satzzeichen
+                   .replace(/\s+/g, ' ')    // Mehrfache Leerzeichen zu einem
+                   .trim();
+    };
+
+    const norm1 = normalize(text1);
+    const norm2 = normalize(text2);
+
+    // Exakte Übereinstimmung
+    if (norm1 === norm2) return 1.0;
+
+    // Enthaltensein-Test
+    if (norm1.includes(norm2) || norm2.includes(norm1)) {
+        const shorter = norm1.length < norm2.length ? norm1 : norm2;
+        const longer = norm1.length >= norm2.length ? norm1 : norm2;
+        return shorter.length / longer.length;
+    }
+
+    // Wort-basierte Ähnlichkeit
+    const words1 = norm1.split(/\s+/);
+    const words2 = norm2.split(/\s+/);
+
+    let commonWords = 0;
+    const allWords = new Set([...words1, ...words2]);
+
+    words1.forEach(word1 => {
+        if (words2.some(word2 => {
+            // Bei kurzen Wörtern nur genaue Treffer zulassen
+            const len = Math.min(word1.length, word2.length);
+            const schwelle = len < 5 ? 0 : Math.max(1, Math.floor(len * 0.3));
+            return word1 === word2 || levenshteinDistance(word1, word2) <= schwelle;
+        })) {
+            commonWords++;
+        }
+    });
+
+    const maxWords = Math.max(words1.length, words2.length);
+    const wordSimilarity = commonWords / maxWords;
+
+    // Levenshtein-Distanz für Zeichen-Ähnlichkeit
+    const maxLength = Math.max(norm1.length, norm2.length);
+    const editDistance = levenshteinDistance(norm1, norm2);
+    const charSimilarity = (maxLength - editDistance) / maxLength;
+
+    // Kombiniere beide Metriken
+    return Math.max(wordSimilarity, charSimilarity * 0.7);
+}
+
+// Hilfsfunktion: Levenshtein-Distanz
+function levenshteinDistance(str1, str2) {
+    const matrix = Array(str2.length + 1).fill(null).map(() => Array(str1.length + 1).fill(null));
+
+    for (let i = 0; i <= str1.length; i++) matrix[0][i] = i;
+    for (let j = 0; j <= str2.length; j++) matrix[j][0] = j;
+
+    for (let j = 1; j <= str2.length; j++) {
+        for (let i = 1; i <= str1.length; i++) {
+            const indicator = str1[i - 1] === str2[j - 1] ? 0 : 1;
+            matrix[j][i] = Math.min(
+                matrix[j][i - 1] + 1,     // Löschung
+                matrix[j - 1][i] + 1,     // Einfügen
+                matrix[j - 1][i - 1] + indicator // Ersetzen
+            );
+        }
+    }
+
+    return matrix[str2.length][str1.length];
+}
+
+// Exporte für Node.js und Browser
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { calculateTextSimilarity, levenshteinDistance };
+} else {
+    window.calculateTextSimilarity = calculateTextSimilarity;
+    window.levenshteinDistance = levenshteinDistance;
+}

--- a/web/src/fileUtils.mjs
+++ b/web/src/fileUtils.mjs
@@ -1,0 +1,4 @@
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { calculateTextSimilarity, levenshteinDistance } = require('./fileUtils.js');
+export { calculateTextSimilarity, levenshteinDistance };

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -149,10 +149,12 @@ const DEBUG_MODE = localStorage.getItem('hla_debug_mode') === 'true';
 let createDubbing, downloadDubbingAudio, renderLanguage, pollRender;
 let repairFileExtensions;
 let loadClosecaptions;
+let calculateTextSimilarity, levenshteinDistance;
 if (typeof module !== 'undefined' && module.exports) {
     ({ createDubbing, downloadDubbingAudio, renderLanguage, pollRender } = require('../../elevenlabs'));
     ({ repairFileExtensions } = require('../../extensionUtils'));
     ({ loadClosecaptions } = require('../../closecaptionParser'));
+    ({ calculateTextSimilarity, levenshteinDistance } = require('./fileUtils.js'));
 } else {
     import('./elevenlabs.js').then(mod => {
         createDubbing = mod.createDubbing;
@@ -168,6 +170,10 @@ if (typeof module !== 'undefined' && module.exports) {
     import('../../closecaptionParser.js').then(mod => {
         // Bei fehlendem Export wird die Funktion trotzdem unter window angelegt
         loadClosecaptions = mod.loadClosecaptions || window.loadClosecaptions;
+    });
+    import('./fileUtils.mjs').then(mod => {
+        calculateTextSimilarity = mod.calculateTextSimilarity;
+        levenshteinDistance = mod.levenshteinDistance;
     });
 }
 
@@ -2566,80 +2572,7 @@ function showSubtitleResults(fileId, results, searchText) {
     });
 }
 // =========================== SUBTITLE SEARCH END =============================
-// =========================== CALCULATE TEXT SIMILARITY START ===========================
-function calculateTextSimilarity(text1, text2) {
-    // Normalisiere beide Texte
-    const normalize = (text) => {
-        return text.toLowerCase()
-                   .replace(/[^\w\s]/g, '') // Entferne Satzzeichen
-                   .replace(/\s+/g, ' ')    // Mehrfache Leerzeichen zu einem
-                   .trim();
-    };
-    
-    const norm1 = normalize(text1);
-    const norm2 = normalize(text2);
-    
-    // Exakte Übereinstimmung
-    if (norm1 === norm2) return 1.0;
-    
-    // Enthaltensein-Test
-    if (norm1.includes(norm2) || norm2.includes(norm1)) {
-        const shorter = norm1.length < norm2.length ? norm1 : norm2;
-        const longer = norm1.length >= norm2.length ? norm1 : norm2;
-        return shorter.length / longer.length;
-    }
-    
-    // Wort-basierte Ähnlichkeit
-    const words1 = norm1.split(/\s+/);
-    const words2 = norm2.split(/\s+/);
-    
-    let commonWords = 0;
-    const allWords = new Set([...words1, ...words2]);
-    
-    words1.forEach(word1 => {
-        if (words2.some(word2 => {
-            // Bei kurzen Wörtern nur genaue Treffer zulassen
-            const len = Math.min(word1.length, word2.length);
-            const schwelle = len < 5 ? 0 : Math.max(1, Math.floor(len * 0.3));
-            return word1 === word2 || levenshteinDistance(word1, word2) <= schwelle;
-        })) {
-            commonWords++;
-        }
-    });
-    
-    const maxWords = Math.max(words1.length, words2.length);
-    const wordSimilarity = commonWords / maxWords;
-    
-    // Levenshtein-Distanz für Zeichen-Ähnlichkeit
-    const maxLength = Math.max(norm1.length, norm2.length);
-    const editDistance = levenshteinDistance(norm1, norm2);
-    const charSimilarity = (maxLength - editDistance) / maxLength;
-    
-    // Kombiniere beide Metriken
-    return Math.max(wordSimilarity, charSimilarity * 0.7);
-}
-
-// Hilfsfunktion: Levenshtein-Distanz
-function levenshteinDistance(str1, str2) {
-    const matrix = Array(str2.length + 1).fill(null).map(() => Array(str1.length + 1).fill(null));
-    
-    for (let i = 0; i <= str1.length; i++) matrix[0][i] = i;
-    for (let j = 0; j <= str2.length; j++) matrix[j][0] = j;
-    
-    for (let j = 1; j <= str2.length; j++) {
-        for (let i = 1; i <= str1.length; i++) {
-            const indicator = str1[i - 1] === str2[j - 1] ? 0 : 1;
-            matrix[j][i] = Math.min(
-                matrix[j][i - 1] + 1,     // deletion
-                matrix[j - 1][i] + 1,     // insertion
-                matrix[j - 1][i - 1] + indicator // substitution
-            );
-        }
-    }
-    
-    return matrix[str2.length][str1.length];
-}
-// =========================== CALCULATE TEXT SIMILARITY END ===========================
+// =========================== TEXT-ÄHNLICHKEIT (siehe fileUtils.js) =====================
 
 // =========================== DISPLAY FILE EXCHANGE DIALOG START ===========================
 function displayFileExchangeDialog(currentFile, similarEntries) {


### PR DESCRIPTION
## Summary
- extrahiere `calculateTextSimilarity` und `levenshteinDistance` nach `fileUtils.js`
- biete ESM-Wrapper `fileUtils.mjs` für den Browser
- passe `main.js` und die Tests an
- erweitere die README um einen Abschnitt zur Projektstruktur

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e79a30b5883278b0a2202cde54013