### PR TITLE
Bugfix: Untertitel-Suche repariert

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ Seit Patch 1.40.90 prüft das Tool nach dem Schließen des "Alles gesendet"-Fens
 Seit Patch 1.40.91 löst der Dateiwächter den manuellen Import nur noch aus, wenn keine Zuordnung zu offenen Jobs möglich ist.
 Seit Patch 1.40.92 bricht der Dateiwächter nach 10 s ohne stabile Datei mit einer Fehlermeldung ab.
 Seit Patch 1.40.93 schließen sich nach erfolgreichem Import das Fenster „Alles gesendet“, der Studio-Hinweis und das Dubbing-Protokoll automatisch.
+Seit Patch 1.40.94 funktioniert die Untertitel-Suche über die Lupe wieder korrekt.
 
 Beispiel einer gültigen CSV:
 

--- a/web/src/fileUtils.mjs
+++ b/web/src/fileUtils.mjs
@@ -1,4 +1,15 @@
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-const { calculateTextSimilarity, levenshteinDistance } = require('./fileUtils.js');
+// Wrapper für die Funktionen in fileUtils.js
+// Funktioniert sowohl im Browser als auch unter Node
+let calculateTextSimilarity, levenshteinDistance;
+
+if (typeof window === 'undefined') {
+    // Node.js: CommonJS-Modul laden
+    const { createRequire } = await import('module');
+    const require = createRequire(import.meta.url);
+    ({ calculateTextSimilarity, levenshteinDistance } = require('./fileUtils.js'));
+} else {
+    // Browser: als ES-Modul importieren
+    ({ calculateTextSimilarity, levenshteinDistance } = await import('./fileUtils.js'));
+}
+
 export { calculateTextSimilarity, levenshteinDistance };


### PR DESCRIPTION
## Summary
- behebe Fehler in `fileUtils.mjs`, der das Laden der Textfunktionen im Browser verhinderte
- ergänze README mit Hinweis auf Patch 1.40.94

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685eb6499ae48327b28dc09f912574ab