### PR TITLE
Fix OT search by loading utils on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Seit Patch 1.40.91 löst der Dateiwächter den manuellen Import nur noch aus, we
 Seit Patch 1.40.92 bricht der Dateiwächter nach 10 s ohne stabile Datei mit einer Fehlermeldung ab.
 Seit Patch 1.40.93 schließen sich nach erfolgreichem Import das Fenster „Alles gesendet“, der Studio-Hinweis und das Dubbing-Protokoll automatisch.
 Seit Patch 1.40.94 funktioniert die Untertitel-Suche über die Lupe wieder korrekt.
+Seit Patch 1.40.95 lädt die OT-Suche fehlende Text-Utilities automatisch nach.
 
 Beispiel einer gültigen CSV:
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2396,7 +2396,7 @@ let fileExchangeData = {
 };
 
 // =========================== SHOW FILE EXCHANGE OPTIONS START ===========================
-function showFileExchangeOptions(fileId) {
+async function showFileExchangeOptions(fileId) {
     const file = files.find(f => f.id === fileId);
     if (!file) {
         console.error('Datei nicht gefunden:', fileId);
@@ -2412,6 +2412,13 @@ function showFileExchangeOptions(fileId) {
     debugLog(`[FILE EXCHANGE] Suche ähnliche Einträge für: ${file.filename}`);
     debugLog(`[FILE EXCHANGE] EN-Text: ${file.enText.substring(0, 50)}...`);
     
+    // Text-Utilities bei Bedarf nachladen
+    if (typeof calculateTextSimilarity !== 'function') {
+        const mod = await import('./fileUtils.mjs');
+        calculateTextSimilarity = mod.calculateTextSimilarity;
+        levenshteinDistance = mod.levenshteinDistance;
+    }
+
     // Suche ähnliche Einträge in der Datenbank
     const similarEntries = searchSimilarEntriesInDatabase(file);
     
@@ -2489,6 +2496,13 @@ async function openSubtitleSearch(fileId) {
     if (!file || !file.enText) return;
 
     // Lade das Modul bei Bedarf dynamisch nach, wenn die Funktion noch fehlt
+    if (typeof calculateTextSimilarity !== 'function') {
+        const mod = await import('./fileUtils.mjs');
+        calculateTextSimilarity = mod.calculateTextSimilarity;
+        levenshteinDistance = mod.levenshteinDistance;
+    }
+
+    // Lade den Parser bei Bedarf dynamisch nach, wenn die Funktion noch fehlt
     if (typeof loadClosecaptions !== 'function') {
         try {
             // Parser bei Bedarf dynamisch laden, auch wenn kein Export vorhanden ist


### PR DESCRIPTION
## Summary
- load text utilities on demand for file exchange and subtitle search
- note the patch in the README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685eb8a0fb6c8327a15bbefa97f9f19d