### PR TITLE
Fix subtitle search missing calculateTextSimilarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ Mit dem Backup-Dialog lassen sich alle Projekt-Daten als JSON speichern. Neu ist
 Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **web/src/main.js** – Initialisierung der App
 * **web/src/fileUtils.js** – Text-Funktionen wie `calculateTextSimilarity`
+* **web/src/fileUtils.mjs** – Wrapper, der die Textfunktionen sowohl im Browser als auch unter Node bereitstellt
 
 ---
 

--- a/web/src/fileUtils.mjs
+++ b/web/src/fileUtils.mjs
@@ -8,8 +8,11 @@ if (typeof window === 'undefined') {
     const require = createRequire(import.meta.url);
     ({ calculateTextSimilarity, levenshteinDistance } = require('./fileUtils.js'));
 } else {
-    // Browser: als ES-Modul importieren
-    ({ calculateTextSimilarity, levenshteinDistance } = await import('./fileUtils.js'));
+    // Browser: Modul nur der Nebenwirkungen wegen laden
+    await import('./fileUtils.js');
+    // Funktionen aus dem globalen Fenster holen
+    calculateTextSimilarity = window.calculateTextSimilarity;
+    levenshteinDistance = window.levenshteinDistance;
 }
 
 export { calculateTextSimilarity, levenshteinDistance };


### PR DESCRIPTION
## Summary
- fix browser import in `fileUtils.mjs`
- mention wrapper file in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ecfa9acd88327b1e701c2dcd50b10