### PR TITLE
Add module debug overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **📊 Datenquellen‑Analyse:** Console‑Logs für Entwickler
 * **🎯 Access‑Status:** Echtzeit‑Anzeige der Dateiberechtigungen
 * **🔧 Debug-Konsole:** Über das Dropdown "Debug-Konsole" können Sie Logs einsehen. In der Desktop-Version öffnen sich die DevTools jetzt automatisch in einem separaten Fenster oder per `Ctrl+Shift+I`.
+* **📦 Modul-Check:** Neuer Button listet alle geladenen Module und zeigt, ob sie funktionieren.
 * **📝 Ausführliche API-Logs:** Alle Anfragen und Antworten werden im Dubbing-Log protokolliert
 * **🛠 Debug-Logging aktivieren:** Setze `localStorage.setItem('hla_debug_mode','true')` im Browser, um zusätzliche Konsolen-Ausgaben zu erhalten
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -568,7 +568,9 @@
     <details id="debugConsoleWrapper" style="margin:10px 0;">
         <summary>🛠️ Debug-Konsole</summary>
         <button class="btn btn-secondary" onclick="showFolderDebug()">🐞 Ordner prüfen</button>
+        <button class="btn btn-secondary" onclick="showModuleDebug()">📦 Module prüfen</button>
         <div id="folderDebug" style="margin:10px 0;"></div>
+        <div id="moduleDebug" style="margin:10px 0;"></div>
         <pre id="debugConsole" style="max-height:200px; overflow:auto; background:#000; color:#0f0; padding:5px;"></pre>
     </details>
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -4945,6 +4945,47 @@ function showFolderDebug() {
 }
 // =========================== SHOWFOLDERDEBUG END =============================
 
+// =========================== SHOWMODULEDEBUG START ===========================
+// Listet alle geladenen Module und markiert fehlende
+function showModuleDebug() {
+    const wrapper = document.getElementById('debugConsoleWrapper');
+    wrapper.open = true;
+
+    const listDiv = document.getElementById('moduleDebug');
+    if (!listDiv) return;
+    listDiv.innerHTML = '';
+
+    // Zu prüfende Module
+    const modules = {
+        createDubbing,
+        downloadDubbingAudio,
+        renderLanguage,
+        pollRender,
+        repairFileExtensions,
+        loadClosecaptions,
+        calculateTextSimilarity,
+        levenshteinDistance
+    };
+
+    const ul = document.createElement('ul');
+    ul.style.listStyle = 'none';
+    ul.style.padding = '0';
+
+    for (const [name, fn] of Object.entries(modules)) {
+        const li = document.createElement('li');
+        li.style.marginBottom = '4px';
+        const ok = typeof fn !== 'undefined';
+        const status = document.createElement('span');
+        status.textContent = ok ? '✅' : '❌';
+        li.appendChild(status);
+        li.append(' ' + name);
+        ul.appendChild(li);
+    }
+
+    listDiv.appendChild(ul);
+}
+// =========================== SHOWMODULEDEBUG END =============================
+
 // =========================== SHOWMISSINGFOLDERSDIALOG START =================
 // Öffnet ein Dialogfenster mit allen Ordnern, die keine vorhandenen Dateien mehr besitzen
 function showMissingFoldersDialog() {


### PR DESCRIPTION
## Summary
- add a module overview button in the debug section
- implement `showModuleDebug` to list loaded modules
- document the new module check in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ee3e9b354832785b2d89fe566acef