### PR TITLE
Löse highlightText in eigenes Modul aus

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ Mit dem Backup-Dialog lassen sich alle Projekt-Daten als JSON speichern. Neu ist
 Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **web/src/main.js** – Initialisierung der App
 * **web/src/fileUtils.js** – Text-Funktionen wie `calculateTextSimilarity`
+* **web/src/textUtils.js** – Enthält `escapeHtml` und `highlightText`
 * **web/src/colorUtils.js** – Farb-Hilfsfunktionen wie `getVersionColor`
 * **web/src/fileUtils.mjs** – Wrapper, der die Textfunktionen sowohl im Browser als auch unter Node bereitstellt
 

--- a/tests/highlightText.test.js
+++ b/tests/highlightText.test.js
@@ -2,22 +2,7 @@
  * @jest-environment jsdom
  */
 // Testet die Maskierung von highlightText
-function escapeHtml(text) {
-  const div = document.createElement('div');
-  div.textContent = text;
-  return div.innerHTML;
-}
-
-function highlightText(text, query) {
-  if (!text || !query) return escapeHtml(text);
-  const words = query
-    .split(/\s+/)
-    .filter(Boolean)
-    .map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-  const regex = new RegExp(`(${words.join('|')})`, 'gi');
-  const escaped = escapeHtml(text);
-  return escaped.replace(regex, '<span class="search-result-match">$1</span>');
-}
+const { highlightText } = require('../web/src/textUtils.js');
 
 describe('highlightText', () => {
   test('maskiert HTML korrekt', () => {

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -664,6 +664,7 @@
 
     <script src="https://www.youtube.com/iframe_api"></script>
     <script src="src/colorUtils.js"></script>
+    <script src="src/textUtils.js"></script>
     <script src="src/main.js"></script>
     <script src="renderer.js"></script>
 </body>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -151,7 +151,8 @@ const moduleStatus = {
     elevenlabsLib:    { loaded: false, source: '' },
     extensionUtils:   { loaded: false, source: '' },
     closecaptionParser:{ loaded: false, source: '' },
-    fileUtils:        { loaded: false, source: '' }
+    fileUtils:        { loaded: false, source: '' },
+    textUtils:        { loaded: false, source: '' }
 };
 
 // Gemeinsame Funktionen aus elevenlabs.js laden
@@ -159,6 +160,7 @@ let createDubbing, downloadDubbingAudio, renderLanguage, pollRender;
 let repairFileExtensions;
 let loadClosecaptions;
 let calculateTextSimilarity, levenshteinDistance;
+let escapeHtml, highlightText;
 if (typeof module !== 'undefined' && module.exports) {
     ({ createDubbing, downloadDubbingAudio, renderLanguage, pollRender } = require('../../elevenlabs'));
     moduleStatus.elevenlabs = { loaded: true, source: 'Main' };
@@ -171,6 +173,8 @@ if (typeof module !== 'undefined' && module.exports) {
 
     ({ calculateTextSimilarity, levenshteinDistance } = require('./fileUtils.js'));
     moduleStatus.fileUtils = { loaded: true, source: 'Main' };
+    ({ escapeHtml, highlightText } = require('./textUtils.js'));
+    moduleStatus.textUtils = { loaded: true, source: 'Main' };
 } else {
     import('./elevenlabs.js').then(mod => {
         createDubbing = mod.createDubbing;
@@ -196,6 +200,11 @@ if (typeof module !== 'undefined' && module.exports) {
         levenshteinDistance = mod.levenshteinDistance;
         moduleStatus.fileUtils = { loaded: true, source: 'Ausgelagert' };
     }).catch(() => { moduleStatus.fileUtils = { loaded: false, source: 'Ausgelagert' }; });
+    import('./textUtils.js').then(mod => {
+        escapeHtml = mod.escapeHtml;
+        highlightText = mod.highlightText;
+        moduleStatus.textUtils = { loaded: true, source: 'Ausgelagert' };
+    }).catch(() => { moduleStatus.textUtils = { loaded: false, source: 'Ausgelagert' }; });
 }
 
 // =========================== GLOBAL STATE END ===========================
@@ -1585,17 +1594,7 @@ function addFiles() {
         }
 
         // Search functionality with highlighting and similarity
-        // Hebt alle Vorkommen des Suchbegriffs hervor und maskiert HTML
-        function highlightText(text, query) {
-            if (!text || !query) return escapeHtml(text);
-            // Mehrere Suchbegriffe unterstuetzen
-            const words = query.split(/\s+/)
-                .filter(Boolean)
-                .map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-            const regex = new RegExp(`(${words.join('|')})`, 'gi');
-            const escaped = escapeHtml(text);
-            return escaped.replace(regex, '<span class="search-result-match">$1</span>');
-        }
+        // highlightText kommt nun aus textUtils.js
 
         function initializeEventListeners() {
             const searchInput = document.getElementById('searchInput');
@@ -11492,12 +11491,7 @@ function showChapterCustomization(chapterName, ev) {
             }
         }
 
-        // Utility functions
-        function escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
-        }
+        // escapeHtml wird jetzt in textUtils.js definiert
 
         // Hilfsfunktion für RegExp-Erstellung
         function escapeRegExp(str) {

--- a/web/src/textUtils.js
+++ b/web/src/textUtils.js
@@ -1,0 +1,27 @@
+// Hilfsfunktionen rund um Texte
+
+// Maskiert HTML-Zeichen
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+// Hebt alle Vorkommen des Suchbegriffs hervor und maskiert den Text
+function highlightText(text, query) {
+    if (!text || !query) return escapeHtml(text);
+    const words = query.split(/\s+/)
+        .filter(Boolean)
+        .map(w => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    const regex = new RegExp(`(${words.join('|')})`, 'gi');
+    const escaped = escapeHtml(text);
+    return escaped.replace(regex, '<span class="search-result-match">$1</span>');
+}
+
+// Export für Node.js und Browser
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { escapeHtml, highlightText };
+} else {
+    window.escapeHtml = escapeHtml;
+    window.highlightText = highlightText;
+}


### PR DESCRIPTION
## Zusammenfassung
- `highlightText` und `escapeHtml` nach `textUtils.js` verschoben
- `main.js` importiert diese Funktionen nun aus dem neuen Modul
- HTML-Datei lädt `textUtils.js`
- Tests passen `highlightText.test.js` entsprechend an
- README ergänzt um neue Datei

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ee92414d88327ac0a5c9e7e1a9f98