### PR TITLE
Lagere extractRelevantFolder aus

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,6 +819,7 @@ verwendet werden, um optionale Downloads zu überspringen.
 * **`delete-sound-backup(name)`** – entfernt ein ZIP-Backup.
 * **`saveDeHistoryBuffer(relPath, data)`** – legt einen Buffer als neue History-Version ab.
 * **`copyDubbedFile(originalPath, tempDubPath)`** – verschiebt eine heruntergeladene Dub-Datei in den deutschen Ordnerbaum.
+* **`extractRelevantFolder(parts)`** – gibt den relevanten Abschnitt eines Dateipfades ab "vo" oder ohne führendes "sounds" zurück.
 * **`calculateProjectStats(project)`** – ermittelt pro Projekt den Übersetzungs‑ und Audio‑Fortschritt. Diese Funktion wird auch in den Tests ausführlich geprüft.
 * **`ipcContracts.ts`** – definiert Typen für die IPC-Kommunikation zwischen Preload und Hauptprozess.
 * **`syncProjectData(projects, filePathDatabase, textDatabase)`** – gleicht Projekte mit der Datenbank ab, korrigiert Dateiendungen und überträgt Texte.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -154,7 +154,8 @@ const moduleStatus = {
     elevenlabsLib:    { loaded: false, source: '' },
     extensionUtils:   { loaded: false, source: '' },
     closecaptionParser:{ loaded: false, source: '' },
-    fileUtils:        { loaded: false, source: '' }
+    fileUtils:        { loaded: false, source: '' },
+    pathUtils:        { loaded: false, source: '' }
 };
 
 // Gemeinsame Funktionen aus elevenlabs.js laden
@@ -162,6 +163,7 @@ let createDubbing, downloadDubbingAudio, renderLanguage, pollRender;
 let repairFileExtensions;
 let loadClosecaptions;
 let calculateTextSimilarity, levenshteinDistance;
+let extractRelevantFolder;
 // Platzhalter für Dubbing-Funktionen
 let showDubbingSettings, createDubbingCSV, validateCsv, msToSeconds, isDubReady,
     startDubbing, redownloadDubbing, openDubbingPage, openLocalFile,
@@ -185,6 +187,8 @@ if (typeof module !== 'undefined' && module.exports) {
 
     ({ calculateTextSimilarity, levenshteinDistance } = require('./fileUtils.js'));
     moduleStatus.fileUtils = { loaded: true, source: 'Main' };
+    ({ extractRelevantFolder } = require('./pathUtils.js'));
+    moduleStatus.pathUtils = { loaded: true, source: 'Main' };
 } else {
     import('./elevenlabs.js').then(mod => {
         createDubbing = mod.createDubbing;
@@ -210,6 +214,10 @@ if (typeof module !== 'undefined' && module.exports) {
         levenshteinDistance = mod.levenshteinDistance;
         moduleStatus.fileUtils = { loaded: true, source: 'Ausgelagert' };
     }).catch(() => { moduleStatus.fileUtils = { loaded: false, source: 'Ausgelagert' }; });
+    import('./pathUtils.mjs').then(mod => {
+        extractRelevantFolder = mod.extractRelevantFolder;
+        moduleStatus.pathUtils = { loaded: true, source: 'Ausgelagert' };
+    }).catch(() => { moduleStatus.pathUtils = { loaded: false, source: 'Ausgelagert' }; });
     moduleStatus.dubbing = { loaded: false, source: 'Ausgelagert' };
 }
 
@@ -3047,27 +3055,6 @@ function repairProjectFolders() {
 
 
 
-// =========================== EXTRACTRELEVANTFOLDER START ===========================
-function extractRelevantFolder(folderParts, fullPath) {
-    // Gibt den relevanten Ordnerpfad einer Datei zurück.
-    // Enthält der Pfad einen "vo"-Ordner, liefern wir alles ab diesem Punkt
-    // (inklusive "vo") zurück, um die komplette Struktur zu bewahren.
-
-    if (folderParts.length === 0) return 'root';
-
-    const lowerParts = folderParts.map(p => p.toLowerCase());
-    const voIndex    = lowerParts.lastIndexOf('vo');
-
-    if (voIndex !== -1 && voIndex < folderParts.length) {
-        // Beispiel: ["sounds","vo","combine","grunt1"] => "vo/combine/grunt1"
-        return folderParts.slice(voIndex).join('/');
-    }
-
-    // Entferne führendes "sounds" falls vorhanden
-    const startIndex = lowerParts[0] === 'sounds' ? 1 : 0;
-    return folderParts.slice(startIndex).join('/');
-}
-// =========================== EXTRACTRELEVANTFOLDER END ===========================
 
 // =========================== GETFULLPATH START ===========================
 // Liefert den vollständigen relativen Pfad einer Datei anhand der Datenbank

--- a/web/src/pathUtils.js
+++ b/web/src/pathUtils.js
@@ -1,0 +1,29 @@
+// Hilfsfunktionen für Pfadoperationen
+
+function extractRelevantFolder(folderParts, fullPath) {
+    // Gibt den relevanten Ordnerpfad einer Datei zurück.
+    // Enthält der Pfad einen "vo"-Ordner, liefern wir alles ab diesem Punkt
+    // (inklusive "vo") zurück, um die komplette Struktur zu bewahren.
+
+    if (folderParts.length === 0) return 'root';
+
+    const lowerParts = folderParts.map(p => p.toLowerCase());
+    const voIndex    = lowerParts.lastIndexOf('vo');
+
+    if (voIndex !== -1 && voIndex < folderParts.length) {
+        // Beispiel: ["sounds","vo","combine","grunt1"] => "vo/combine/grunt1"
+        return folderParts.slice(voIndex).join('/');
+    }
+
+    // Entferne führendes "sounds" falls vorhanden
+    const startIndex = lowerParts[0] === 'sounds' ? 1 : 0;
+    return folderParts.slice(startIndex).join('/');
+}
+
+// Exporte für Node.js und Browser
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { extractRelevantFolder };
+} else {
+    window.extractRelevantFolder = extractRelevantFolder;
+}
+

--- a/web/src/pathUtils.mjs
+++ b/web/src/pathUtils.mjs
@@ -1,0 +1,16 @@
+// Wrapper für Pfadfunktionen
+let extractRelevantFolder;
+
+if (typeof window === 'undefined') {
+    // Node.js: CommonJS-Modul laden
+    const { createRequire } = await import('module');
+    const require = createRequire(import.meta.url);
+    ({ extractRelevantFolder } = require('./pathUtils.js'));
+} else {
+    // Browser: Modul nur der Nebenwirkungen wegen laden
+    await import('./pathUtils.js');
+    extractRelevantFolder = window.extractRelevantFolder;
+}
+
+export { extractRelevantFolder };
+


### PR DESCRIPTION
## Zusammenfassung
- neue Datei `pathUtils.js` mit `extractRelevantFolder`
- ES‑Modul `pathUtils.mjs` zum dynamischen Laden
- `main.js` importiert nun die Funktion statt sie selbst zu definieren
- Dokumentation um neuen Helfer ergänzt

## Testanweisungen
- `npm test` ausführen

------
https://chatgpt.com/codex/tasks/task_e_685f16024d808327af1482749ae431b7