### PR TITLE
Lagere extractRelevantFolder aus

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,6 +819,7 @@ verwendet werden, um optionale Downloads zu überspringen.
 * **`delete-sound-backup(name)`** – entfernt ein ZIP-Backup.
 * **`saveDeHistoryBuffer(relPath, data)`** – legt einen Buffer als neue History-Version ab.
 * **`copyDubbedFile(originalPath, tempDubPath)`** – verschiebt eine heruntergeladene Dub-Datei in den deutschen Ordnerbaum.
+* **`extractRelevantFolder(parts)`** – gibt den relevanten Abschnitt eines Dateipfades ab "vo" oder ohne führendes "sounds" zurück (siehe `web/src/pathUtils.js`).
 * **`calculateProjectStats(project)`** – ermittelt pro Projekt den Übersetzungs‑ und Audio‑Fortschritt. Diese Funktion wird auch in den Tests ausführlich geprüft.
 * **`ipcContracts.ts`** – definiert Typen für die IPC-Kommunikation zwischen Preload und Hauptprozess.
 * **`syncProjectData(projects, filePathDatabase, textDatabase)`** – gleicht Projekte mit der Datenbank ab, korrigiert Dateiendungen und überträgt Texte.

--- a/web/src/pathUtils.js
+++ b/web/src/pathUtils.js
@@ -1,0 +1,29 @@
+// Hilfsfunktionen für Pfadoperationen
+
+function extractRelevantFolder(folderParts, fullPath) {
+    // Gibt den relevanten Ordnerpfad einer Datei zurück.
+    // Enthält der Pfad einen "vo"-Ordner, liefern wir alles ab diesem Punkt
+    // (inklusive "vo") zurück, um die komplette Struktur zu bewahren.
+
+    if (folderParts.length === 0) return 'root';
+
+    const lowerParts = folderParts.map(p => p.toLowerCase());
+    const voIndex    = lowerParts.lastIndexOf('vo');
+
+    if (voIndex !== -1 && voIndex < folderParts.length) {
+        // Beispiel: ["sounds","vo","combine","grunt1"] => "vo/combine/grunt1"
+        return folderParts.slice(voIndex).join('/');
+    }
+
+    // Entferne führendes "sounds" falls vorhanden
+    const startIndex = lowerParts[0] === 'sounds' ? 1 : 0;
+    return folderParts.slice(startIndex).join('/');
+}
+
+// Exporte für Node.js und Browser
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { extractRelevantFolder };
+} else {
+    window.extractRelevantFolder = extractRelevantFolder;
+}
+

--- a/web/src/pathUtils.mjs
+++ b/web/src/pathUtils.mjs
@@ -1,0 +1,16 @@
+// Wrapper für Pfadfunktionen
+let extractRelevantFolder;
+
+if (typeof window === 'undefined') {
+    // Node.js: CommonJS-Modul laden
+    const { createRequire } = await import('module');
+    const require = createRequire(import.meta.url);
+    ({ extractRelevantFolder } = require('./pathUtils.js'));
+} else {
+    // Browser: Modul nur der Nebenwirkungen wegen laden
+    await import('./pathUtils.js');
+    extractRelevantFolder = window.extractRelevantFolder;
+}
+
+export { extractRelevantFolder };
+


### PR DESCRIPTION
## Zusammenfassung
- pathUtils.mjs jetzt per Promise einbinden
- DOMContentLoaded wartet auf pathUtils
- `verarbeiteGescannteDateien` lädt Pfadhelfer bei Bedarf nach
- README beschreibt Datei `pathUtils.js`

## Testanweisungen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f16024d808327af1482749ae431b7