### PR TITLE
Fix icon layout for edit column

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Schneller Zugriff:** Die Funktionen Lautstärke angleichen – ⚡ und Funkgerät-Effekt – 📻 besitzen nun eigene Buttons mit Symbolen. Der Button **⟳ Standardwerte** befindet sich direkt daneben.
 * **Hall-Standardwerte:** Im Hall-Bereich setzt **⟳ Hall-Standardwerte** alle Parameter auf ihre Ausgangswerte zurück.
 * **Verbessertes Speichern:** Nach dem Anwenden von Lautstärke angleichen oder Funkgerät‑Effekt bleiben die Änderungen nun zuverlässig erhalten.
+* **Vier Bearbeitungssymbole:** Der Status neben der Schere zeigt nun bis zu vier Icons in zwei Reihen für Trimmen, Lautstärkeangleichung, Funkgerät- und Hall-Effekt an.
 * **Zurücksetzen nach Upload oder Dubbing:** Sowohl beim Hochladen als auch beim erneuten Erzeugen einer deutschen Audiodatei werden Lautstärkeangleichung, Funkgerät‑Effekt und Hall‑Effekt automatisch deaktiviert.
 * **Fehlerhinweise beim Speichern:** Tritt ein Problem auf, erscheint eine rote Toast-Meldung statt eines stummen Abbruchs.
 * **Neue Meldung:** Scheitert das Anlegen einer History-Version, wird "Fehler beim Anlegen der History-Version" ausgegeben.

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -817,11 +817,12 @@ th:nth-child(7) {
     color: #ffc107;
 }
 
-        /* Vertikale Anordnung der Bearbeitungs-Symbole */
+        /* Raster-Anordnung der Bearbeitungs-Symbole (maximal zwei pro Zeile) */
         .edit-column {
             display: flex;
-            flex-direction: column;
+            flex-wrap: wrap;
             gap: 3px;
+            width: 54px; /* 2 Symbole à 24px + Zwischenraum */
         }
 
         .upload-btn {


### PR DESCRIPTION
## Summary
- allow up to four status icons next to the ✂️ button
- document the new layout in the README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685f2e787c048327a055edac47a3d743