### PR TITLE
Modernes Rasterlayout für gespeicherte Videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Überarbeitete Video-Manager-Oberfläche:** Neue Farbakzente und deutliche Aktions-Icons erleichtern die Bedienung.
 * **Stabiles Sortieren:** Nach Filterung oder Sortierung funktionieren die Video-Buttons dank Originalindex weiterhin korrekt.
 * **Thumbnail-Ansicht:** Die Tabelle zeigt Vorschaubilder, ein Klick auf Titel oder Bild öffnet das Video im Browser.
+* **Moderne Rasteransicht:** Gespeicherte Videos erscheinen jetzt in einem übersichtlichen Grid mit großem Thumbnail und direktem "Aktualisieren"-Knopf.
+* **Kompakter Video-Manager:** Die Überschriften-Leiste im Bookmark-Fenster entfällt.
+* **Intuitiver Hinzufügen-Button:** Der +‑Button sitzt nun direkt neben dem URL-Feld und speichert den Link auf Knopfdruck.
+* **Smarter Aktualisieren-Knopf:** Fehlt im Eingabefeld ein Link, wird automatisch die Zwischenablage nach einer YouTube‑URL durchsucht.
 * **Fixer Dialog-Abstand:** Der Video-Manager steht nun stets mit 10 % Rand im Fenster. Die Funktion `adjustVideoDialogHeight` wurde entfernt.
 * **Behobenes Resize-Problem:** Nach einer Verkleinerung wächst der Videoplayer jetzt korrekt mit, sobald das Fenster wieder größer wird.
 * **Stabiler Startzustand:** CSS-Duplikate entfernt; `video-dialog` startet immer mit 10 % Abstand.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -600,29 +600,18 @@
     <dialog id="videoMgrDialog" class="video-dialog">
         <div class="video-grid">
             <aside id="videoListSection" class="video-bookmarks">
-                <h2>📼 Gespeicherte Videos</h2>
                 <div class="video-toolbar">
                     <div class="video-search">
                         <input id="videoFilter" placeholder="Suche …" />
-                        <button id="addVideoBtn" class="btn">+ Hinzufügen</button>
                         <button id="closeVideoDlgSmall" class="btn btn-danger close-icon">❌</button>
                     </div>
                     <div class="video-url">
                         <input type="text" id="videoUrlInput" placeholder="YouTube-Link mit Startzeit …">
+                        <button id="addVideoBtn" class="btn">+ Hinzufügen</button>
                     </div>
                 </div>
                 <div id="videoTableWrapper">
-                    <table id="videoTable">
-                        <thead>
-                            <tr>
-                                <th data-asc="true">Bild</th>
-                                <th>Titel</th>
-                                <th>Zeit</th>
-                                <th>Aktionen</th>
-                            </tr>
-                        </thead>
-                        <tbody></tbody>
-                    </table>
+                    <div id="videoGrid" class="video-grid-container"></div>
                 </div>
             </aside>
         </div>

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -7,7 +7,7 @@ const openMgr   = document.getElementById('openVideoManager');
 const videoDlg  = document.getElementById('videoMgrDialog');
 const closeDlg  = document.getElementById('closeVideoDlg');
 const closeDlgSmall = document.getElementById('closeVideoDlgSmall');
-const videoTableBody = document.querySelector('#videoTable tbody');
+const videoGrid = document.getElementById('videoGrid');
 const videoFilter    = document.getElementById('videoFilter');
 
 // Fallback wenn keine externe API vorhanden ist
@@ -33,15 +33,36 @@ function extractTime(url) {
     return m ? Number(m[1]) : 0;
 }
 
+function isYoutubeUrl(raw){
+    const ytre = /^https?:\/\/(www\.)?youtube\.com\/watch\?v=/i;
+    const yb   = /^https?:\/\/youtu\.be\//i;
+    return ytre.test(raw) || yb.test(raw);
+}
+
+async function urlFromInputOrClipboard(){
+    let raw = urlInput.value.trim();
+    if(raw) return raw;
+    try{
+        const clip = await navigator.clipboard.readText();
+        if(clip) return clip.trim();
+    }catch(err){
+        console.warn('Keine Berechtigung für Zwischenablage', err);
+    }
+    return '';
+}
+
 async function getBookmarks() {
     const list = await window.videoApi.loadBookmarks();
     return list.map((b,i)=>({ ...b, origIndex:i }));
 }
 
 function formatTime(sec) {
-    const m = Math.floor(sec/60);
+    const h = Math.floor(sec/3600);
+    const m = Math.floor((sec%3600)/60);
     const s = Math.floor(sec%60);
-    return m + ':' + ('0'+s).slice(-2);
+    return h.toString().padStart(2,'0')+':' +
+           m.toString().padStart(2,'0')+':' +
+           s.toString().padStart(2,'0');
 }
 
 async function refreshTable(sortKey='title', dir=true) {
@@ -49,30 +70,37 @@ async function refreshTable(sortKey='title', dir=true) {
     const q = videoFilter.value.toLowerCase();
     if (q) list = list.filter(b => b.title.toLowerCase().includes(q) || b.url.toLowerCase().includes(q));
     list.sort((a,b)=>a[sortKey].localeCompare ? (dir?a[sortKey].localeCompare(b[sortKey],'de'):b[sortKey].localeCompare(a[sortKey],'de')) : (dir?a[sortKey]-b[sortKey]:b[sortKey]-a[sortKey]));
-    videoTableBody.innerHTML = '';
+    videoGrid.innerHTML = '';
     list.forEach(b=>{
-        const tr = document.createElement('tr');
-        tr.dataset.idx = b.origIndex;
-        const thumb = `https://i.ytimg.com/vi/${extractYoutubeId(b.url)}/default.jpg`;
-        tr.innerHTML = `<td><img src="${thumb}" class="video-thumb" data-idx="${b.origIndex}"></td>`+
-                       `<td class="video-title" data-idx="${b.origIndex}" title="${b.title}">${b.title}</td>`+
-                       `<td>${formatTime(b.time)}</td>`+
-                       `<td><button class="delete" data-idx="${b.origIndex}" title="Video löschen">🗑️</button></td>`;
-        videoTableBody.appendChild(tr);
+        const div = document.createElement('div');
+        div.className = 'video-item';
+        div.dataset.idx = b.origIndex;
+        const thumb = `https://i.ytimg.com/vi/${extractYoutubeId(b.url)}/hqdefault.jpg`;
+        div.innerHTML = `<img src="${thumb}" class="video-thumb" data-idx="${b.origIndex}">`+
+                       `<div class="video-title" data-idx="${b.origIndex}" title="${b.title}">${b.title}</div>`+
+                       `<div class="video-time">${formatTime(b.time)}</div>`+
+                       `<button class="btn btn-blue update" data-idx="${b.origIndex}">Aktualisieren</button>`+
+                       `<button class="btn btn-danger delete" data-idx="${b.origIndex}" title="Video löschen">🗑️</button>`;
+        videoGrid.appendChild(div);
     });
 }
 
-videoTableBody.addEventListener('click', async e=>{
+videoGrid.addEventListener('click', async e=>{
     const btn = e.target.closest('button');
-    const row = e.target.closest('tr');
+    const item = e.target.closest('.video-item');
     const list = await window.videoApi.loadBookmarks();
-    if (btn) {
+    if (btn && btn.classList.contains('delete')) {
         const idx = Number(btn.dataset.idx);
         list.splice(idx,1);
         await window.videoApi.saveBookmarks(list);
         refreshTable();
-    } else if (row) {
-        const idx = Number(row.dataset.idx);
+    } else if (btn && btn.classList.contains('update')) {
+        const idx = Number(btn.dataset.idx);
+        const raw = await urlFromInputOrClipboard();
+        if (!isYoutubeUrl(raw)) { alert('Kein gültiger YouTube-Link gefunden'); return; }
+        await updateBookmark(idx, raw, list);
+    } else if (item) {
+        const idx = Number(item.dataset.idx);
         const bm = list[idx];
         if (!bm) return;
         if (window.electronAPI && window.electronAPI.openExternal) {
@@ -103,17 +131,45 @@ async function addVideoFromUrl(raw){
     const yb = /^https?:\/\/youtu\.be\//i;
     if (!ytre.test(raw) && !yb.test(raw)) { alert('Keine gültige YouTube-Adresse'); return; }
     let list = await window.videoApi.loadBookmarks();
-    if (list.some(b=>b.url===raw)) return;
+    const id = extractYoutubeId(raw);
     let title = raw;
     try {
         const res = await fetch('https://www.youtube.com/oembed?url='+encodeURIComponent(raw)+'&format=json');
         if (res.ok) ({ title } = await res.json());
     } catch {}
-    list.push({ url: raw, title, time: extractTime(raw) });
+    const time = extractTime(raw);
+    const existingIdx = list.findIndex(b=>extractYoutubeId(b.url)===id);
+    if (existingIdx>=0) {
+        list[existingIdx] = { url: raw, title, time };
+    } else {
+        list.push({ url: raw, title, time });
+    }
     list.sort((a,b)=>a.title.localeCompare(b.title,'de'));
     await window.videoApi.saveBookmarks(list);
     urlInput.value='';
     updateAddBtn();
+    refreshTable();
+}
+
+async function updateBookmark(index, raw, list){
+    const id = extractYoutubeId(raw);
+    let title = raw;
+    try {
+        const res = await fetch('https://www.youtube.com/oembed?url='+encodeURIComponent(raw)+'&format=json');
+        if (res.ok) ({ title } = await res.json());
+    } catch {}
+    const time = extractTime(raw);
+    const sameIdx = list.findIndex((b,i)=>i!==index && extractYoutubeId(b.url)===id);
+    if (sameIdx>=0) {
+        list[sameIdx].time = time;
+        list.splice(index,1);
+    } else if (extractYoutubeId(list[index].url)===id) {
+        list[index].time = time;
+    } else {
+        list[index] = { url: raw, title, time };
+    }
+    list.sort((a,b)=>a.title.localeCompare(b.title,'de'));
+    await window.videoApi.saveBookmarks(list);
     refreshTable();
 }
 

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2591,6 +2591,7 @@ th:nth-child(7) {
     flex: 1 1 100%;
 }
 .video-url input { flex: 1 1 auto; }
+.video-url button { min-width: 90px; }
 
 .close-icon {
     /* kleines Schließen-Icon für mobile Ansicht */
@@ -2636,6 +2637,53 @@ th:nth-child(7) {
 
 /* ===== Teilbereiche ===== */
 .video-bookmarks{ overflow:auto; }
+
+/* === Grid-Anzeige der gespeicherten Videos === */
+.video-grid-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 12px;
+}
+
+.video-item {
+    background: #2a2a2a;
+    border: 1px solid #444;
+    border-radius: 6px;
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+}
+
+.video-item:hover {
+    background: #333;
+}
+
+.video-thumb {
+    width: 100%;
+    aspect-ratio: 16/9;
+    object-fit: cover;
+}
+
+.video-title {
+    text-align: center;
+    font-size: 0.9rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 100%;
+}
+
+.video-time {
+    font-size: 0.8rem;
+    opacity: 0.8;
+}
+
+.video-item .btn {
+    width: 100%;
+}
 
 /* === Tabelle für das Wörterbuch === */
 .word-list-table td{


### PR DESCRIPTION
## Zusammenfassung
- Video-Hinzufügen-Button jetzt direkt neben dem URL-Feld
- CSS um passenden Button-Style erweitert
- README aktualisiert
- Aktualisierungsbutton nutzt jetzt Zwischenablage, wenn kein Link eingegeben ist
- Weiße Überschrift aus dem Video-Manager entfernt

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fa5fcac5c8327b263e3f6c22519df