### PR TITLE
Fix CSP comment warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ Seit Patch 1.40.95 lädt die OT-Suche fehlende Text-Utilities automatisch nach.
 Seit Patch 1.40.96 meldet die Untertitel-Suche nun fehlende Text-Utilities.
 Seit Patch 1.40.97 greift ein Fallback auf die globale Funktion, falls die Text-Utilities nicht geladen werden können.
 Seit Patch 1.40.98 erlaubt die Content Security Policy nun auch Verbindungen zu `youtube.com`, damit Videotitel per oEmbed geladen werden können.
+Seit Patch 1.40.99 befindet sich der Hinweis zu oEmbed nicht mehr im Meta-Tag selbst. Dadurch zeigt der Browser keine CSP-Warnung mehr an.
 
 Beispiel einer gültigen CSV:
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -12,11 +12,12 @@
                    script-src 'self' https://www.youtube.com 'unsafe-inline';
                    style-src-elem 'self';
                    style-src-attr 'self' 'unsafe-inline';
-                   connect-src 'self' https://api.elevenlabs.io https://www.youtube.com; <!-- Für oEmbed-Anfragen an YouTube -->
+                   connect-src 'self' https://api.elevenlabs.io https://www.youtube.com;
                    frame-src https://www.youtube.com blob:;
                    img-src 'self' data: https://i.ytimg.com;
                    worker-src 'self' blob:;
                    media-src 'self' blob:;">
+    <!-- Für oEmbed-Anfragen an YouTube -->
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Zusammenfassung
- Kommentar in der CSP-Meta‑Angabe aus dem Attribut ausgelagert
- README mit Patch‑Hinweis aktualisiert

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fad5dc5c08327a5558bc36f79f84c