### PR TITLE
Implement frame capture for video bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Überarbeitete Video-Manager-Oberfläche:** Neue Farbakzente und deutliche Aktions-Icons erleichtern die Bedienung.
 * **Stabiles Sortieren:** Nach Filterung oder Sortierung funktionieren die Video-Buttons dank Originalindex weiterhin korrekt.
 * **Thumbnail-Ansicht:** Die Tabelle zeigt Vorschaubilder, ein Klick auf Titel oder Bild öffnet das Video im Browser.
+* **Zeitspezifische Screenshots:** Beim ersten Laden erzeugt `ffmpeg` automatisch ein Bild an der hinterlegten Zeit und speichert es im Nutzerordner.
 * **Moderne Rasteransicht:** Gespeicherte Videos erscheinen jetzt in einem übersichtlichen Grid mit großem Thumbnail und direktem "Aktualisieren"-Knopf.
 * **Intuitiver Hinzufügen-Button:** Der +‑Button sitzt nun direkt neben dem URL-Feld und speichert den Link auf Knopfdruck.
 * **Fixer Dialog-Abstand:** Der Video-Manager steht nun stets mit 10 % Rand im Fenster. Die Funktion `adjustVideoDialogHeight` wurde entfernt.

--- a/electron/main.js
+++ b/electron/main.js
@@ -25,6 +25,7 @@ const { createSoundBackup, listSoundBackups, deleteSoundBackup } = require('../s
 // Fortschrittsbalken und FFmpeg für MP3->WAV-Konvertierung
 const ProgressBar = require('progress');
 const ffmpeg = require('ffmpeg-static');
+const { ensureFrame } = require('../videoFrameUtils');
 // Pfad zum App-Icon (im Ordner 'assets' als 'app-icon.png' ablegen)
 const iconPath = path.join(__dirname, 'assets', 'app-icon.png');
 // Workshop-Start erfolgt über ein Python-Skript mit hlvrcfg.exe
@@ -38,6 +39,9 @@ if (!fs.existsSync(DL_WATCH_PATH)) fs.mkdirSync(DL_WATCH_PATH);
 const userDataPath = path.join(app.getPath('home'), '.hla_translation_tool');
 fs.mkdirSync(userDataPath, { recursive: true });
 app.setPath('userData', userDataPath);
+// Ordner für Videoframes
+const framePath = path.join(userDataPath, 'videoFrames');
+fs.mkdirSync(framePath, { recursive: true });
 // Ordner für automatische Backups im Benutzerverzeichnis anlegen
 // Neuer Pfad 'Backups' laut Benutzerwunsch
 const backupPath = path.join(userDataPath, 'Backups');
@@ -373,6 +377,21 @@ app.whenReady().then(() => {
     const win = BrowserWindow.fromWebContents(event.sender);
     const img = await win.capturePage(bounds);
     return img.toPNG();
+  });
+
+  // Screenshot für ein Video speichern und als Base64 liefern
+  ipcMain.handle('get-video-frame', async (event, info) => {
+    const { url, time } = info || {};
+    if (!url) return null;
+    const p = await ensureFrame(url, time || 0, framePath);
+    if (!p) return null;
+    try {
+      const buf = fs.readFileSync(p);
+      return buf.toString('base64');
+    } catch (e) {
+      console.error('Frame konnte nicht gelesen werden', e);
+      return null;
+    }
   });
 
   // Bookmarks aus dem userData-Ordner laden

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -98,6 +98,7 @@ if (typeof require !== 'function') {
     saveBookmarks: list => ipcRenderer.invoke('save-bookmarks', list),
     // einzelnen Bookmark per Index löschen
     deleteBookmark: idx => ipcRenderer.invoke('delete-bookmark', idx),
+    getFrame: info => ipcRenderer.invoke('get-video-frame', info),
   });
   console.log('[Preload] erfolgreich geladen');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.40.7",
+  "version": "1.40.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.40.7",
+      "version": "1.40.8",
       "dependencies": {
         "archiver": "^6.0.2",
         "chokidar": "^4.0.3",
         "ffmpeg-static": "^5.2.0",
         "node-easyocr": "^1.0.9",
         "playwright": "^1.42.1",
-        "progress": "^2.0.3"
+        "progress": "^2.0.3",
+        "ytdl-core": "^4.11.5"
       },
       "devDependencies": {
         "jest": "^29.6.1",
@@ -3965,6 +3966,19 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/m3u8stream": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
+      "integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
+      "license": "MIT",
+      "dependencies": {
+        "miniget": "^4.2.2",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -4033,6 +4047,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/miniget": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.3.tgz",
+      "integrity": "sha512-SjbDPDICJ1zT+ZvQwK0hUcRY4wxlhhNpHL9nJOB2MEAXRGagTljsO8MEDzQMTFf0Q8g4QNi8P9lEm/g7e+qgzA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/minimatch": {
@@ -4666,6 +4689,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -5324,6 +5353,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ytdl-core": {
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.5.tgz",
+      "integrity": "sha512-27LwsW4n4nyNviRCO1hmr8Wr5J1wLLMawHCQvH8Fk0hiRqrxuIu028WzbJetiYH28K8XDbeinYW4/wcHQD1EXA==",
+      "license": "MIT",
+      "dependencies": {
+        "m3u8stream": "^0.8.6",
+        "miniget": "^4.2.2",
+        "sax": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/zip-stream": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ffmpeg-static": "^5.2.0",
     "node-easyocr": "^1.0.9",
     "playwright": "^1.42.1",
-    "progress": "^2.0.3"
+    "progress": "^2.0.3",
+    "ytdl-core": "^4.11.5"
   }
 }

--- a/videoFrameUtils.js
+++ b/videoFrameUtils.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+const ytdl = require('ytdl-core');
+const ffmpeg = require('ffmpeg-static');
+
+// Erstellt ein Standbild eines Videos
+// Bei YouTube-Links wird zunächst der Direktlink ermittelt
+async function captureFrame(url, sec, outPath) {
+    let input = url;
+    if (ytdl.validateURL(url)) {
+        try {
+            const info = await ytdl.getInfo(url);
+            const fmt = ytdl.chooseFormat(info.formats, { quality: '18', filter: 'audioandvideo' });
+            input = fmt.url;
+        } catch (e) {
+            console.error('[captureFrame] YouTube-Info fehlgeschlagen', e.message);
+        }
+    }
+    return await new Promise(resolve => {
+        const args = ['-ss', String(sec), '-i', input, '-frames:v', '1', '-q:v', '2', '-y', outPath];
+        const proc = spawn(ffmpeg, args);
+        proc.on('error', () => resolve(false));
+        proc.on('close', code => resolve(code === 0 && fs.existsSync(outPath)));
+    });
+}
+
+// Sichert das Bild im userData-Ordner und gibt den Pfad zurück
+async function ensureFrame(url, sec, dir) {
+    const safe = Buffer.from(url).toString('base64').replace(/[+/=]/g, '');
+    const file = path.join(dir, `${safe}_${sec}.jpg`);
+    if (!fs.existsSync(file)) {
+        fs.mkdirSync(dir, { recursive: true });
+        await captureFrame(url, sec, file);
+    }
+    return fs.existsSync(file) ? file : null;
+}
+
+module.exports = { ensureFrame };
+

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -53,18 +53,24 @@ async function refreshTable(sortKey='title', dir=true) {
     if (q) list = list.filter(b => b.title.toLowerCase().includes(q) || b.url.toLowerCase().includes(q));
     list.sort((a,b)=>a[sortKey].localeCompare ? (dir?a[sortKey].localeCompare(b[sortKey],'de'):b[sortKey].localeCompare(a[sortKey],'de')) : (dir?a[sortKey]-b[sortKey]:b[sortKey]-a[sortKey]));
     videoGrid.innerHTML = '';
-    list.forEach(b=>{
+    for (const b of list) {
         const div = document.createElement('div');
         div.className = 'video-item';
         div.dataset.idx = b.origIndex;
-        const thumb = `https://i.ytimg.com/vi/${extractYoutubeId(b.url)}/hqdefault.jpg`;
+        let thumb = `https://i.ytimg.com/vi/${extractYoutubeId(b.url)}/hqdefault.jpg`;
+        if (window.videoApi && window.videoApi.getFrame) {
+            try {
+                const data = await window.videoApi.getFrame({ url: b.url, time: b.time });
+                if (data) thumb = `data:image/jpeg;base64,${data}`;
+            } catch {}
+        }
         div.innerHTML = `<img src="${thumb}" class="video-thumb" data-idx="${b.origIndex}">`+
                        `<div class="video-title" data-idx="${b.origIndex}" title="${b.title}">${b.title}</div>`+
                        `<div class="video-time">${formatTime(b.time)}</div>`+
                        `<button class="btn btn-blue update" data-idx="${b.origIndex}">Aktualisieren</button>`+
                        `<button class="btn btn-danger delete" data-idx="${b.origIndex}" title="Video löschen">🗑️</button>`;
         videoGrid.appendChild(div);
-    });
+    }
 }
 
 videoGrid.addEventListener('click', async e=>{


### PR DESCRIPTION
## Summary
- speichern nun Videoframes im Benutzerordner und zeigen sie als Thumbnail
- IPC `get-video-frame` erstellt bei Bedarf ein Standbild mit ffmpeg
- `videoApi.getFrame` im Preload eingebunden
- Renderer lädt für jeden Bookmark das aktuelle Bild
- `ytdl-core` als Abhängigkeit für direkte YouTube-Links
- Dokumentation um neuen Screenshot-Workflow ergänzt
- Screenshot-Erstellung überarbeit: unterstützt YouTube und lokale Dateien

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685faf0510108327a0950b5c43637e26