### PR TITLE
Fehlerausgabe für Video-Screenshots verbessert

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Zeitspezifische Screenshots:** Beim ersten Laden erzeugt `ffmpeg` automatisch ein Bild an der hinterlegten Zeit und speichert es im Nutzerordner.
 * **Fortschrittsanzeige beim Screenshot:** Solange das Bild erstellt wird, zeigt ein Ladebalken den Vorgang an. Schlägt die Erstellung fehl, erscheint ein rotes Ausrufezeichen.
 * **Direkt geladene Screenshots:** Jedes Video zeigt sofort das Vorschaubild und ersetzt es automatisch durch den aktuellen Frame, sobald dieser verfügbar ist.
+* **Prüft Screenshot-Abhängigkeiten:** Konsole und Debug-Menü melden, ob `ffmpeg` und `ytdl-core` vorhanden sind und warum kein Bild erzeugt werden konnte.
 * **Screenshots nur in der Desktop-Version:** In der Web-Version ohne Electron-API bleibt das YouTube-Thumbnail bestehen.
 * **Moderne Rasteransicht:** Gespeicherte Videos erscheinen jetzt in einem übersichtlichen Grid mit großem Thumbnail und direktem "Aktualisieren"-Knopf.
 * **Intuitiver Hinzufügen-Button:** Der +‑Button sitzt nun direkt neben dem URL-Feld und speichert den Link auf Knopfdruck.


### PR DESCRIPTION
## Zusammenfassung
- Abhängigkeiten für Screenshot-Funktion prüfen
- Fehlermeldungen in electron/main.js ergänzen
- Debug-Informationen um ffmpeg-Status erweitern
- README um neuen Hinweis ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fbdd69498832792d6d47a36c62d62