### PR TITLE
Improve YouTube error hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Fortschrittsanzeige beim Screenshot:** Solange das Bild erstellt wird, zeigt ein Ladebalken den Vorgang an. Schlägt die Erstellung fehl, erscheint ein rotes Ausrufezeichen.
 * **Direkt geladene Screenshots:** Jedes Video zeigt sofort das Vorschaubild und ersetzt es automatisch durch den aktuellen Frame, sobald dieser verfügbar ist.
 * **Prüft Screenshot-Abhängigkeiten:** Konsole und Debug-Menü melden, ob `ffmpeg` und `ytdl-core` vorhanden sind und warum kein Bild erzeugt werden konnte.
+* **Hinweis bei YouTube-Fehlern:** Tritt die Meldung "Could not extract functions" auf, erinnert das Tool an ein mögliches Update von `ytdl-core`.
 * **Screenshots nur in der Desktop-Version:** In der Web-Version ohne Electron-API bleibt das YouTube-Thumbnail bestehen.
 * **Moderne Rasteransicht:** Gespeicherte Videos erscheinen jetzt in einem übersichtlichen Grid mit großem Thumbnail und direktem "Aktualisieren"-Knopf.
 * **Intuitiver Hinzufügen-Button:** Der +‑Button sitzt nun direkt neben dem URL-Feld und speichert den Link auf Knopfdruck.

--- a/videoFrameUtils.js
+++ b/videoFrameUtils.js
@@ -33,6 +33,10 @@ async function captureFrame(url, sec, outPath) {
             input = fmt.url;
         } catch (e) {
             console.error('[captureFrame] YouTube-Info fehlgeschlagen', e.message);
+            // Zusätzlicher Hinweis, falls YouTube-Struktur geändert wurde
+            if (e.message && e.message.includes('Could not extract')) {
+                console.error('[captureFrame] Vermutlich ist ytdl-core veraltet – bitte per "npm update ytdl-core" aktualisieren');
+            }
         }
     }
     return await new Promise(resolve => {


### PR DESCRIPTION
## Summary
- log additional hint when `ytdl-core` can't extract YouTube functions
- document the new hint in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fbfb792e083278dd2f3bea35765f3