### PR TITLE
Add dev info script and extend debug data

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 24. Sowohl `verify_environment.py` als auch `start_tool.py` prüfen nun die Python-Architektur und geben bei 32‑Bit-Versionen einen deutlichen Hinweis.
 25. Die Paketprüfung berücksichtigt jetzt abweichende Importnamen (z.B. `Pillow` ↦ `PIL`). Dadurch meldet `verify_environment.py` keine Fehlalarme mehr.
 26. `start_tool.py` funktioniert jetzt auch ohne konfiguriertes Remote und setzt das Repository dann nur lokal zurück.
+27. `node dev_info.js` gibt alle relevanten Systemdaten im Terminal aus.
 
 ### ElevenLabs-Dubbing
 
@@ -736,6 +737,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **🔧 Debug-Konsole:** Über das Dropdown "Debug-Konsole" können Sie Logs einsehen. In der Desktop-Version öffnen sich die DevTools jetzt automatisch in einem separaten Fenster oder per `Ctrl+Shift+I`.
 * **💡 Neues Debug-Fenster:** Gruppiert System- und Pfadinformationen übersichtlich und bietet eine Kopierfunktion.
 * **📦 Modul-Status:** Neue Spalte im Debug-Fenster zeigt, ob alle Module korrekt geladen wurden und aus welcher Quelle sie stammen.
+* **🖥️ Erweiterte Systemdaten:** Das Debug-Fenster zeigt jetzt Betriebssystem, CPU-Modell und freien Arbeitsspeicher an.
 * **📝 Ausführliche API-Logs:** Alle Anfragen und Antworten werden im Dubbing-Log protokolliert
 * **🛠 Debug-Logging aktivieren:** Setze `localStorage.setItem('hla_debug_mode','true')` im Browser, um zusätzliche Konsolen-Ausgaben zu erhalten
 

--- a/dev_info.js
+++ b/dev_info.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// Gibt wichtige Systeminformationen für die Entwicklung aus
+// Verwendung: node dev_info.js
+
+const os = require('os');
+const { execSync } = require('child_process');
+const { checkVideoDependencies } = require('./videoFrameUtils');
+
+function exec(cmd) {
+  try {
+    return execSync(cmd).toString().trim();
+  } catch {
+    return 'n/a';
+  }
+}
+
+function human(bytes) {
+  return Math.round(bytes / 1024 / 1024) + ' MB';
+}
+
+const info = {
+  'Node-Version': exec('node --version'),
+  'npm-Version': exec('npm --version'),
+  'Python-Version': exec('python --version'),
+  'Betriebssystem': `${os.type()} ${os.release()}`,
+  'CPU': os.cpus()[0] ? os.cpus()[0].model : 'n/a',
+  'CPU-Kerne': os.cpus().length,
+  'Gesamt RAM': human(os.totalmem()),
+  'Freier RAM': human(os.freemem()),
+  'Arbeitsverzeichnis': process.cwd(),
+};
+
+const video = checkVideoDependencies();
+info['Video-Abhängigkeiten'] = video.ok ? '✔️' : 'Fehlt: ' + video.missing.join(', ');
+
+for (const [k, v] of Object.entries(info)) {
+  console.log(`${k}: ${v}`);
+}

--- a/electron/main.js
+++ b/electron/main.js
@@ -12,6 +12,7 @@ const { app, BrowserWindow, ipcMain, globalShortcut, dialog, shell, session } = 
 const path = require('node:path'); // Pfadmodul einbinden
 const fs = require('fs');
 const { execSync, spawnSync, spawn } = require('child_process');
+const os = require("os"); // Systeminformationen
 // Lade Konfiguration relativ zum aktuellen Verzeichnis
 const { DL_WATCH_PATH, projectRoot, SOUNDS_BASE_PATH, soundsDirName } = require(path.join(__dirname, '..', 'web', 'src', 'config.js'));
 const { chooseExisting } = require('../pathUtils');
@@ -491,6 +492,12 @@ app.whenReady().then(() => {
       chromeVersion: process.versions.chrome,
       processPlatform: process.platform,
       cpuArch: process.arch,
+      osType: os.type(),
+      osRelease: os.release(),
+      cpuModel: os.cpus()[0] ? os.cpus()[0].model : "",
+      cpuCount: os.cpus().length,
+      totalMemMB: Math.round(os.totalmem() / 1024 / 1024),
+      freeMemMB: Math.round(os.freemem() / 1024 / 1024),
       processType: 'browser',
       contextIsolation: true,
       sandbox: mainWindow ? mainWindow.webContents.getLastWebPreferences().sandbox : false,

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -7332,6 +7332,12 @@ async function scanAudioDuplicates() {
                     data: {
                         'Betriebssystem': info.processPlatform,
                         'CPU-Architektur': info.cpuArch,
+                        'OS-Typ': info.osType,
+                        'OS-Release': info.osRelease,
+                        'CPU-Modell': info.cpuModel,
+                        'CPU-Kerne': info.cpuCount,
+                        'Gesamt RAM (MB)': info.totalMemMB,
+                        'Freier RAM (MB)': info.freeMemMB,
                         'Prozess-Typ': info.processType,
                         'Kontext-Isolation': info.contextIsolation,
                         'Sandbox aktiviert': info.sandbox,


### PR DESCRIPTION
## Summary
- erweitere Electron Debug-Info um Betriebssystem- und Hardwaredaten
- füge neues Skript `dev_info.js` für Systemprüfungen im Terminal hinzu
- ergänze Debug-Anzeige im Web-Frontend um diese Daten
- update README mit Hinweisen zu `dev_info.js` und erweiterten Systeminformationen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc36fea3083278ce4c29e6bdd7b80