### PR TITLE
Improve debug info for video frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,8 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 24. Sowohl `verify_environment.py` als auch `start_tool.py` prüfen nun die Python-Architektur und geben bei 32‑Bit-Versionen einen deutlichen Hinweis.
 25. Die Paketprüfung berücksichtigt jetzt abweichende Importnamen (z.B. `Pillow` ↦ `PIL`). Dadurch meldet `verify_environment.py` keine Fehlalarme mehr.
 26. `start_tool.py` funktioniert jetzt auch ohne konfiguriertes Remote und setzt das Repository dann nur lokal zurück.
-27. `node dev_info.js` gibt alle relevanten Systemdaten im Terminal aus.
+27. `node dev_info.js` gibt alle relevanten Systemdaten sowie die Versionen von `ffmpeg`, `ytdl-core` und `play-dl` aus.
+28. Das Debug-Fenster zeigt jetzt zusätzlich den Pfad zum VideoFrame-Ordner und die installierten Versionen der Video-Abhängigkeiten.
 
 ### ElevenLabs-Dubbing
 
@@ -738,6 +739,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **💡 Neues Debug-Fenster:** Gruppiert System- und Pfadinformationen übersichtlich und bietet eine Kopierfunktion.
 * **📦 Modul-Status:** Neue Spalte im Debug-Fenster zeigt, ob alle Module korrekt geladen wurden und aus welcher Quelle sie stammen.
 * **🖥️ Erweiterte Systemdaten:** Das Debug-Fenster zeigt jetzt Betriebssystem, CPU-Modell und freien Arbeitsspeicher an.
+* **📸 VideoFrame-Details:** Zusätzlich werden der Pfad zum Frame-Ordner und die Versionen der Video-Abhängigkeiten angezeigt.
 * **📝 Ausführliche API-Logs:** Alle Anfragen und Antworten werden im Dubbing-Log protokolliert
 * **🛠 Debug-Logging aktivieren:** Setze `localStorage.setItem('hla_debug_mode','true')` im Browser, um zusätzliche Konsolen-Ausgaben zu erhalten
 

--- a/dev_info.js
+++ b/dev_info.js
@@ -3,8 +3,10 @@
 // Verwendung: node dev_info.js
 
 const os = require('os');
+const path = require('path');
 const { execSync } = require('child_process');
 const { checkVideoDependencies } = require('./videoFrameUtils');
+const ffmpeg = require('ffmpeg-static');
 
 function exec(cmd) {
   try {
@@ -28,6 +30,22 @@ const info = {
   'Gesamt RAM': human(os.totalmem()),
   'Freier RAM': human(os.freemem()),
   'Arbeitsverzeichnis': process.cwd(),
+  'VideoFrame-Ordner': path.join(os.homedir(), '.hla_translation_tool', 'videoFrames'),
+  'ffmpeg-Pfad': ffmpeg || 'n/a',
+  'ffmpeg-Version': (() => {
+    if (!ffmpeg) return 'n/a';
+    try {
+      return exec(`"${ffmpeg}" -version`).split(/\r?\n/)[0];
+    } catch {
+      return 'n/a';
+    }
+  })(),
+  'ytdl-core-Version': (() => {
+    try { return require('ytdl-core/package.json').version; } catch { return 'n/a'; }
+  })(),
+  'play-dl-Version': (() => {
+    try { return require('play-dl/package.json').version; } catch { return 'n/a'; }
+  })(),
 };
 
 const video = checkVideoDependencies();

--- a/electron/main.js
+++ b/electron/main.js
@@ -518,8 +518,30 @@ app.whenReady().then(() => {
       setupLog,
       admin: isElevated(),
       ffmpegPath: videoDeps.ffmpegPath,
+      ffmpegVersion: (() => {
+        try {
+          return execSync(`"${videoDeps.ffmpegPath}" -version`).toString().split(/\r?\n/)[0];
+        } catch {
+          return '';
+        }
+      })(),
       videoDepsOk: videoDeps.ok,
-      missingVideoDeps: videoDeps.missing.join(', ')
+      missingVideoDeps: videoDeps.missing.join(', '),
+      ytdlVersion: (() => {
+        try {
+          return require('ytdl-core/package.json').version;
+        } catch {
+          return '';
+        }
+      })(),
+      playDlVersion: (() => {
+        try {
+          return require('play-dl/package.json').version;
+        } catch {
+          return '';
+        }
+      })(),
+      framePath
     };
   });
   // =========================== DEBUG-INFO END ===============================


### PR DESCRIPTION
## Summary
- extend `get-debug-info` with ffmpeg version, ytdl/play-dl versions and frame path
- expand `dev_info.js` with the same details
- document enhanced debug features in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc68842448327af037f423df6ed5b