### PR TITLE
Add YouTube storyboard previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Überarbeitete Video-Manager-Oberfläche:** Neue Farbakzente und deutliche Aktions-Icons erleichtern die Bedienung.
 * **Stabiles Sortieren:** Nach Filterung oder Sortierung funktionieren die Video-Buttons dank Originalindex weiterhin korrekt.
 * **Thumbnail-Ansicht:** Die Tabelle zeigt Vorschaubilder, ein Klick auf Titel oder Bild öffnet das Video im Browser.
-* **Zeitspezifische Screenshots:** Beim ersten Laden erzeugt `ffmpeg` automatisch ein Bild an der hinterlegten Zeit und speichert es im Nutzerordner.
+* **Schnelles Vorschaubild per Storyboard:** Das Tool wählt zunächst die passende Kachel aus dem YouTube‑Storyboard. Scheitert dies, wird wie bisher ein Bild über `ffmpeg` erzeugt.
+* **Gepufferte Sprite-Sheets:** Einmal geladene Storyboard-Bilder bleiben im Cache und verkürzen die Ladezeit.
 * **Fortschrittsanzeige beim Screenshot:** Solange das Bild erstellt wird, zeigt ein Ladebalken den Vorgang an. Schlägt die Erstellung fehl, erscheint ein rotes Ausrufezeichen.
 * **Direkt geladene Screenshots:** Jedes Video zeigt sofort das Vorschaubild und ersetzt es automatisch durch den aktuellen Frame, sobald dieser verfügbar ist.
 * **Prüft Screenshot-Abhängigkeiten:** Konsole und Debug-Menü melden, ob `ffmpeg` und `ytdl-core` vorhanden sind und warum kein Bild erzeugt werden konnte.

--- a/utils/videoFrameUtils.js
+++ b/utils/videoFrameUtils.js
@@ -1,0 +1,74 @@
+export function extractTime(url) {
+    const m1 = url.match(/[?&#]t=([^&#]+)/);
+    if (m1) {
+        if (/^\d+$/.test(m1[1])) return Number(m1[1]);
+        let sec = 0;
+        m1[1].replace(/(\d+)(h|m|s)/g, (_, num, unit) => {
+            num = Number(num);
+            if (unit === 'h') sec += num * 3600;
+            else if (unit === 'm') sec += num * 60;
+            else if (unit === 's') sec += num;
+        });
+        return sec;
+    }
+    const m2 = url.match(/[?&#]start=(\d+)/);
+    return m2 ? Number(m2[1]) : 0;
+}
+
+const sheetCache = new Map();
+
+function loadImage(url) {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.onload = () => resolve(img);
+        img.onerror = () => reject(new Error('Bild konnte nicht geladen werden'));
+        img.src = url;
+    });
+}
+
+export async function fetchStoryboardFrame(url, sec) {
+    try {
+        const idMatch = url.match(/[?&]v=([^&#]+)/) || url.match(/youtu\.be\/([^?&#]+)/);
+        if (!idMatch) return null;
+        const id = idMatch[1];
+        const res = await fetch(`https://i.ytimg.com/sb/${id}/storyboard3.json`);
+        if (!res.ok) return null;
+        const text = await res.text();
+        const line = text.split('\n')[0].trim();
+        const parts = line.split('|');
+        if (parts.length < 2) return null;
+        const tracks = parts.slice(1).map(t => t.split('#'));
+        if (!tracks.length) return null;
+        let best = tracks[0];
+        for (const t of tracks) {
+            if (Number(t[6]) < Number(best[6])) best = t;
+        }
+        const width = Number(best[0]);
+        const height = Number(best[1]);
+        const cols = Number(best[3]);
+        const rows = Number(best[2]);
+        const interval = Number(best[6]);
+        const frameIndex = Math.floor(sec * 1000 / interval);
+        const sheet = Math.floor(frameIndex / (cols * rows));
+        const tile = frameIndex % (cols * rows);
+        const base = parts[0];
+        const src = base.replace('L$L', `L${sheet}`).replace('$M', `M${tile}`) + '&sigh=' + parts.at(-1);
+        const cacheKey = `${id}-${sheet}`;
+        let img = sheetCache.get(cacheKey);
+        if (!img) {
+            img = await loadImage(src);
+            sheetCache.set(cacheKey, img);
+        }
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext('2d');
+        const sx = (tile % cols) * width;
+        const sy = Math.floor(tile / cols) * height;
+        ctx.drawImage(img, sx, sy, width, height, 0, 0, width, height);
+        return canvas.toDataURL('image/png');
+    } catch {
+        return null;
+    }
+}

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -10,6 +10,9 @@ const closeDlgSmall = document.getElementById('closeVideoDlgSmall');
 const videoGrid = document.getElementById('videoGrid');
 const videoFilter    = document.getElementById('videoFilter');
 
+// Modul für Storyboard-Vorschauen laden
+const storyboardPromise = import('../utils/videoFrameUtils.js');
+
 // Fallback wenn keine externe API vorhanden ist
 if (!window.videoApi) {
     window.videoApi = {
@@ -71,8 +74,13 @@ async function refreshTable(sortKey='title', dir=true) {
 
         const overlay = div.querySelector('.thumb-overlay');
         const imgElem = div.querySelector('img.video-thumb');
-        if (window.videoApi && window.videoApi.getFrame) {
-            // Nur in der Desktop-Version steht eine API bereit, um Screenshots zu laden
+        const { fetchStoryboardFrame } = await storyboardPromise;
+        const preview = await fetchStoryboardFrame(b.url, b.time);
+        if (preview) {
+            imgElem.src = preview;
+            overlay.remove();
+        } else if (window.videoApi && window.videoApi.getFrame) {
+            // Fallback über ffmpeg
             overlay.classList.add('active');
             window.videoApi.getFrame({ url: b.url, time: b.time })
                 .then(data => {
@@ -89,7 +97,6 @@ async function refreshTable(sortKey='title', dir=true) {
                     overlay.classList.add('error');
                 });
         } else {
-            // In der reinen Web-Version gibt es keine Video-API – Ladeanzeige entfernen
             overlay.remove();
         }
     }


### PR DESCRIPTION
## Summary
- introduce a new browser helper `fetchStoryboardFrame` that loads storyboard tiles and caches sprite sheets
- show storyboard preview in the video bookmark list before falling back to `ffmpeg`
- document the new storyboard behaviour and caching in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fcf690000832783681388add78448