### PR TITLE
Storyboard über Info-JSON laden

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Überarbeitete Video-Manager-Oberfläche:** Neue Farbakzente und deutliche Aktions-Icons erleichtern die Bedienung.
 * **Stabiles Sortieren:** Nach Filterung oder Sortierung funktionieren die Video-Buttons dank Originalindex weiterhin korrekt.
 * **Thumbnail-Ansicht:** Die Tabelle zeigt Vorschaubilder, ein Klick auf Titel oder Bild öffnet das Video im Browser.
-* **Schnelles Vorschaubild per Storyboard:** Das Tool versucht nacheinander `storyboard3.json`, `storyboard2.json`, `storyboard1.json`, `storyboard0.json` und `storyboard.json`. Bleibt das Bild aus, wird das Standard-Thumbnail verwendet.
+* **Schnelles Vorschaubild per Storyboard:** Das Tool lädt nur noch `storyboard_info.json` und ermittelt daraus direkt den passenden Sprite-Link.
 * **Gepufferte Sprite-Sheets:** Einmal geladene Storyboard-Bilder bleiben im Cache und verkürzen die Ladezeit.
 * **Gepufferte Storyboard-Daten:** Fehlt ein Storyboard, merkt sich das Tool die Video-ID und versucht es nicht erneut.
-* **Hilfsfunktion `fetchStoryboardFrame()`** greift auf die genannten JSON-Dateien zu und liefert die Storyboard-Kachel als Base64-PNG oder `null`.
+* **Hilfsfunktion `fetchStoryboardFrame()`** nutzt jetzt `storyboard_info.json` und liefert die Storyboard-Kachel als Base64-PNG oder `null`.
 * **Moderne Rasteransicht:** Gespeicherte Videos erscheinen jetzt in einem übersichtlichen Grid mit großem Thumbnail und direktem "Aktualisieren"-Knopf.
 * **Intuitiver Hinzufügen-Button:** Der +‑Button sitzt nun direkt neben dem URL-Feld und speichert den Link auf Knopfdruck.
 * **Fixer Dialog-Abstand:** Der Video-Manager steht nun stets mit 10 % Rand im Fenster. Die Funktion `adjustVideoDialogHeight` wurde entfernt.

--- a/utils/videoFrameUtils.js
+++ b/utils/videoFrameUtils.js
@@ -38,15 +38,10 @@ export async function fetchStoryboardFrame(url, sec) {
         // Bereits geladene Storyboard-Daten wiederverwenden
         let spec = specCache.get(id);
         if (spec === undefined) {
-            // Mehrstufiger Fallback: storyboard3.json ➜ 2 ➜ 1 ➜ 0 ➜ storyboard.json
-            const variants = [3, 2, 1, 0, ''];
-            let text = null;
-            for (const v of variants) {
-                const sb = v === '' ? 'storyboard.json' : `storyboard${v}.json`;
-                const res = await fetch(`https://i.ytimg.com/sb/${id}/${sb}`);
-                if (res.ok) { text = await res.text(); break; }
-            }
-            if (!text) { specCache.set(id, null); return null; }
+            // Versuch, alle nötigen Infos über storyboard_info.json zu laden
+            const res = await fetch(`https://i.ytimg.com/sb/${id}/storyboard_info.json`);
+            if (!res.ok) { specCache.set(id, null); return null; }
+            const text = await res.text();
             const line = text.split('\n')[0].trim();
             const parts = line.split('|');
             if (parts.length < 2) { specCache.set(id, null); return null; }


### PR DESCRIPTION
## Zusammenfassung
- `fetchStoryboardFrame` nutzt nun `storyboard_info.json`
- README an die neue Vorgehensweise angepasst

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fe1b0897483279c26efa4c8230985