### PR TITLE
Fix Live-Suche folder selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,6 +673,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **📋 Live‑Highlighting:** Suchbegriffe werden in Ergebnissen hervorgehoben
 * **🛡️ HTML-Schutz:** Suchbegriffe werden vor Ausfuehrung von Code gesichert
 * **Bugfix:** Das Live-Suchfeld zeigt Hervorhebungen jetzt korrekt an und blendet HTML-Tags nicht mehr ein
+* **Bugfix:** Ordnerauswahl erscheint wieder korrekt, wenn eine Datei in mehreren Ordnern gefunden wird
 
 ### Intelligente Features
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -9562,7 +9562,7 @@ function showFolderSelectionDialog(ambiguousFiles) {
         
         overlay.appendChild(dialog);
         document.body.appendChild(overlay);
-        overlay.classList.remove('hidden');
+        // Overlay sichtbar machen
         overlay.classList.remove('hidden');
         
         // Cleanup functions when dialog closes
@@ -9840,7 +9840,9 @@ function showSingleFileSelectionDialog(filename, paths, originalResult) {
         
         overlay.appendChild(dialog);
         document.body.appendChild(overlay);
-        
+        // Overlay sichtbar machen
+        overlay.classList.remove('hidden');
+
         // Klick außerhalb abfangen und abbrechen
         overlay.addEventListener('click', (e) => {
             if (e.target === overlay) {


### PR DESCRIPTION
## Summary
- set dialog overlay visible in single-file selection
- document the bugfix in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fe975c57c832791e987bc327694bc