### PR TITLE
Add 'Alle hinzufügen' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **🛡️ HTML-Schutz:** Suchbegriffe werden vor Ausfuehrung von Code gesichert
 * **Bugfix:** Das Live-Suchfeld zeigt Hervorhebungen jetzt korrekt an und blendet HTML-Tags nicht mehr ein
 * **Bugfix:** Ordnerauswahl erscheint wieder korrekt, wenn eine Datei in mehreren Ordnern gefunden wird
+* **Neu:** Im Auswahlfenster gibt es nun den Button "Alle hinzufügen", der sämtliche gefundenen Pfade auf einmal zum Projekt hinzufügt
 
 ### Intelligente Features
 


### PR DESCRIPTION
## Summary
- add button to add all duplicate files at once
- support this new option in search dialog
- document new button in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fec61d6708327be12c6150a5e373f