### PR TITLE
Fix Storyboard detection for new YouTube format

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Schnelles Vorschaubild per Storyboard:** Das Tool liest nun `storyboard_spec` aus der Videoseite und ermittelt daraus die signierte Sprite-URL.
 * **Gepufferte Sprite-Sheets:** Einmal geladene Storyboard-Bilder bleiben im Cache und verkürzen die Ladezeit.
 * **Gepufferte Storyboard-Daten:** Fehlt ein Storyboard, merkt sich das Tool die Video-ID und versucht es nicht erneut.
+* **Kompatibel mit `playerStoryboardSpecRenderer`:** Falls das ältere `storyboard_spec` fehlt, erkennt das Tool nun das neue JSON-Format.
 * **Neue Funktionen `fetchStoryboardSpec`, `buildTileURL` und `fetchStoryboardFrame()`** liefern die Storyboard-Kachel direkt als Base64-PNG oder `null`.
 * **Moderne Rasteransicht:** Gespeicherte Videos erscheinen jetzt in einem übersichtlichen Grid mit großem Thumbnail und direktem "Aktualisieren"-Knopf.
 * **Neues ⟳-Symbol:** Ein Klick auf das kleine Icon oben links lädt das Storyboard neu und aktualisiert das Vorschaubild.

--- a/utils/videoFrameUtils.js
+++ b/utils/videoFrameUtils.js
@@ -29,7 +29,11 @@ export async function fetchStoryboardSpec(videoId) {
         const res = await fetch(`https://www.youtube.com/watch?v=${videoId}&hl=en`);
         if (!res.ok) throw new Error('Antwort war nicht OK');
         const text = await res.text();
-        const m = text.match(/"storyboard_spec":"([^"]+)"/);
+        let m = text.match(/"storyboard_spec":"([^"]+)"/);
+        if (!m) {
+            // Neues Format mit playerStoryboardSpecRenderer abfangen
+            m = text.match(/"playerStoryboardSpecRenderer":\{"spec":"([^"]+)"/);
+        }
         if (!m) throw new Error('Kein storyboard_spec gefunden');
         const spec = m[1].replace(/\\u0026/g, '&');
         specCache.set(videoId, spec);


### PR DESCRIPTION
## Summary
- catch the newer `playerStoryboardSpecRenderer` JSON format in `fetchStoryboardSpec`
- document the new compatibility in `README.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ff1420d248327abaa49526cceeb18