### PR TITLE
Überarbeite Storyboard Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Überarbeitete Storyboard-Funktionen:** `parseTracks` trennt den Basis-Link ab und `buildTileURL` nutzt den kleinsten `step`, um daraus die endgültige URL zu bilden.
 * **Automatischer 403-Retry:** Bei einem 403-Fehler wird das Token neu geladen; erst danach greift der `getFrame`-Fallback.
 * **Fallback über ffmpeg:** Kann kein Storyboard geladen werden, erzeugt die Desktop-App per `get-video-frame` ein Bild im Ordner `videoFrames`.
+* **Hilfsfunktion `previewFor`:** Ermittelt Vorschaubilder bevorzugt über das Storyboard, greift andernfalls auf `get-video-frame` zurück und zeigt bei Fehlern ein Platzhalterbild.
 * **Moderne Rasteransicht:** Gespeicherte Videos erscheinen jetzt in einem übersichtlichen Grid mit großem Thumbnail und direktem "Aktualisieren"-Knopf.
 * **Neues ⟳-Symbol:** Ein Klick auf das kleine Icon oben links lädt das Storyboard neu und aktualisiert das Vorschaubild.
 * **Intuitiver Hinzufügen-Button:** Der +‑Button sitzt nun direkt neben dem URL-Feld und speichert den Link auf Knopfdruck.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Kompatibel mit `playerStoryboardSpecRenderer`:** Falls das ältere `storyboard_spec` fehlt, erkennt das Tool nun das neue JSON-Format.
 * **Überarbeitete Storyboard-Funktionen:** `parseTracks` trennt den Basis-Link ab und `buildTileURL` nutzt den kleinsten `step`, um daraus die endgültige URL zu bilden.
 * **Automatischer 403-Retry:** Bei einem 403-Fehler wird das Token neu geladen; erst danach greift der `getFrame`-Fallback.
+* **Fallback über ffmpeg:** Kann kein Storyboard geladen werden, erzeugt die Desktop-App per `get-video-frame` ein Bild im Ordner `videoFrames`.
 * **Moderne Rasteransicht:** Gespeicherte Videos erscheinen jetzt in einem übersichtlichen Grid mit großem Thumbnail und direktem "Aktualisieren"-Knopf.
 * **Neues ⟳-Symbol:** Ein Klick auf das kleine Icon oben links lädt das Storyboard neu und aktualisiert das Vorschaubild.
 * **Intuitiver Hinzufügen-Button:** Der +‑Button sitzt nun direkt neben dem URL-Feld und speichert den Link auf Knopfdruck.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Gepufferte Sprite-Sheets:** Einmal geladene Storyboard-Bilder bleiben im Cache und verkürzen die Ladezeit.
 * **Gepufferte Storyboard-Daten:** Fehlt ein Storyboard, merkt sich das Tool die Video-ID und versucht es nicht erneut.
 * **Kompatibel mit `playerStoryboardSpecRenderer`:** Falls das ältere `storyboard_spec` fehlt, erkennt das Tool nun das neue JSON-Format.
-* **Überarbeitete Storyboard-Funktionen:** `fetchStoryboardSpec`, `parseTracks`, `chooseBestTrack` und `buildTileURL` erzeugen immer signierte URLs.
+* **Überarbeitete Storyboard-Funktionen:** `parseTracks` trennt den Basis-Link ab und `buildTileURL` nutzt den kleinsten `step`, um daraus die endgültige URL zu bilden.
 * **Automatischer 403-Retry:** Bei einem 403-Fehler wird das Token neu geladen; erst danach greift der `getFrame`-Fallback.
 * **Moderne Rasteransicht:** Gespeicherte Videos erscheinen jetzt in einem übersichtlichen Grid mit großem Thumbnail und direktem "Aktualisieren"-Knopf.
 * **Neues ⟳-Symbol:** Ein Klick auf das kleine Icon oben links lädt das Storyboard neu und aktualisiert das Vorschaubild.

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -98,6 +98,8 @@ if (typeof require !== 'function') {
     saveBookmarks: list => ipcRenderer.invoke('save-bookmarks', list),
     // einzelnen Bookmark per Index löschen
     deleteBookmark: idx => ipcRenderer.invoke('delete-bookmark', idx),
+    // Holt ein Vorschaubild über den Hauptprozess
+    getFrame: info => ipcRenderer.invoke('get-video-frame', info)
   });
   console.log('[Preload] erfolgreich geladen');
 }

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -13,6 +13,20 @@ const videoFilter    = document.getElementById('videoFilter');
 // Funktionen für YouTube-Storyboards
 import { fetchStoryboardFrame, extractTime } from '../utils/videoFrameUtils.js';
 
+// Liefert das passende Vorschaubild für einen Bookmark
+// Zunächst wird das Storyboard abgefragt. Scheitert dies,
+// greift die Desktop-App über get-video-frame auf ffmpeg zurück.
+// Schlägt auch das fehl, gibt es ein Standardbild zurück.
+async function previewFor(b) {
+    const png = await fetchStoryboardFrame(b.url, b.time);
+    if (png) return png;
+    if (window.videoApi?.getFrame) {
+        const data = await window.videoApi.getFrame({ url: b.url, time: b.time });
+        if (data) return /^data:/.test(data) ? data : `data:image/jpeg;base64,${data}`;
+    }
+    return `https://i.ytimg.com/vi/${extractYoutubeId(b.url)}/hqdefault.jpg`;
+}
+
 // Fallback wenn keine externe API vorhanden ist
 if (!window.videoApi) {
     window.videoApi = {
@@ -72,13 +86,7 @@ async function refreshTable(sortKey='title', dir=true) {
         const overlay = div.querySelector('.thumb-overlay');
         const imgElem = div.querySelector('img.video-thumb');
         overlay.classList.add('active');
-        const preview = await fetchStoryboardFrame(b.url, b.time);
-        if (preview) {
-            imgElem.src = preview;
-        } else {
-            imgElem.src = await window.videoApi.getFrame({ url: b.url,
-                                                         time: b.time });
-        }
+        imgElem.src = await previewFor(b);
         imgElem.referrerPolicy = 'no-referrer';
         imgElem.crossOrigin    = 'anonymous';
         overlay.remove();
@@ -101,13 +109,7 @@ videoGrid.addEventListener('click', async e=>{
         overlay.innerHTML = '<div class="progress-bar"><div class="progress-fill"></div></div>';
         wrapper.appendChild(overlay);
         const imgElem = wrapper.querySelector('img.video-thumb');
-        const preview = await fetchStoryboardFrame(bm.url, bm.time);
-        if (preview) {
-            imgElem.src = preview;
-        } else {
-            imgElem.src = await window.videoApi.getFrame({ url: bm.url,
-                                                         time: bm.time });
-        }
+        imgElem.src = await previewFor(bm);
         imgElem.referrerPolicy = 'no-referrer';
         imgElem.crossOrigin    = 'anonymous';
         overlay.remove();


### PR DESCRIPTION
## Zusammenfassung
- parseTracks trennt wieder den Basisteil ab und speichert ihn in jedem Track
- buildTileURL wählt die kleinste Schrittweite und setzt URL mit dem Basisteil zusammen
- fetchStoryboardFrame nutzt die neuen Track-Daten
- README um Hinweise auf die neuen Funktionen ergänzt

## Testanweisungen
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ffd4203c4832780a3b729bcd55652