### PR TITLE
Implement GPT model selection with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Eigenes Wörterbuch:** Ein neuer 📚-Knopf speichert englische Wörter zusammen mit deutscher Lautschrift.
 * **Hinweis-Symbol bei Übersetzungen:** Unter der Lupe erscheint ein kleines 📝, wenn der DE-Text ein Wort aus dem Wörterbuch enthält.
+* **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren zeigt ein Tooltip Kommentar und Vorschlag, ein Klick ersetzt den DE-Text und blinkt kurz blau auf
+* **Unbewertete Zeilen:** Noch nicht bewertete Zeilen zeigen eine graue 0
+* **Score-Spalte nach Version:** Die farbige Bewertung steht direkt vor dem EN-Text
+* **Anpassbarer Bewertungs-Prompt:** Der Text liegt in `prompts/gpt_score.txt`
+* **Auswahl des GPT-Modells:** Im ChatGPT-Dialog lässt sich das Modell wählen. Die Liste wird auf Wunsch vom Server geladen und für 24&nbsp;Stunden gespeichert
+* **Eigenständige Score-Komponente:** Tooltip und Klick sind in `web/src/scoreColumn.js` gekapselt
 * **Schlanker Video-Bereich:** Gespeicherte Links öffnen sich im Browser. Interner Player und OCR wurden entfernt.
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.
 * **Löschen per Desktop-API:** Einzelne Bookmarks lassen sich über einen IPC-Kanal entfernen.
@@ -70,7 +76,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Video & OCR Workbench:** Liste und Player teilen sich die obere Zeile, das OCR-Ergebnis belegt den gesamten Bereich darunter.
 * **Dreispaltiges Dialog-Layout:** Das OCR-Fenster sitzt jetzt rechts oben und die Steuerleiste belegt eine eigene Zeile.
 * **Verbesserte Thumbnail-Ladefunktion:** Vorschaubilder werden über `i.ytimg.com` geladen und die gesamte Zeile ist zum Öffnen des Videos anklickbar.
-* **Angepasste Content Security Policy:** `connect-src` erlaubt nun zusätzlich `i.ytimg.com`, damit Storyboards geladen werden können.
+* **Angepasste Content Security Policy:** `connect-src` erlaubt nun zusätzlich `i.ytimg.com` und `api.openai.com`, damit Storyboards und die GPT-API funktionieren.
 * **Fehlerhinweis bei fehlender YouTube-API:** Lädt der Player nicht, erscheint eine Meldung statt eines schwarzen Fensters.
 * **Fallback ohne YouTube-API:** Kann das Script nicht geladen werden, öffnet sich der Link automatisch im Browser.
 * **Toast bei gesperrten Videos:** Tritt ein YouTube-Fehler auf, informiert ein roter Hinweis über mögliche Proxy-Pflicht.
@@ -459,6 +465,7 @@ Seit Patch 1.40.96 meldet die Untertitel-Suche nun fehlende Text-Utilities.
 Seit Patch 1.40.97 greift ein Fallback auf die globale Funktion, falls die Text-Utilities nicht geladen werden können.
 Seit Patch 1.40.98 erlaubt die Content Security Policy nun auch Verbindungen zu `youtube.com`, damit Videotitel per oEmbed geladen werden können.
 Seit Patch 1.40.99 befindet sich der Hinweis zu oEmbed nicht mehr im Meta-Tag selbst. Dadurch zeigt der Browser keine CSP-Warnung mehr an.
+Seit Patch 1.40.100 erlaubt die Content Security Policy nun Verbindungen zu `api.openai.com`, damit der GPT-Key-Test im Einstellungsdialog funktioniert.
 
 Beispiel einer gültigen CSV:
 
@@ -642,6 +649,7 @@ Ab sofort zeigt diese Auswahl zusätzlich die vorhandenen EN- und DE-Texte des j
 * **🔧 Ordner reparieren:** Aktualisiert Ordnernamen in allen Projekten
 
 Diese Wartungsfunktionen findest du nun gesammelt im neuen **⚙️ Einstellungen**‑Knopf oben rechts.
+Dort gibt es jetzt auch einen Bereich **ChatGPT API**. Der Schlüssel wird lokal AES‑verschlüsselt im Nutzerordner gespeichert und lässt sich über einen Test-Knopf prüfen. Nach erfolgreichem Test kannst du die Liste der verfügbaren Modelle abrufen (↻) und eines auswählen. Die Modell-Liste wird 24&nbsp;Stunden zwischengespeichert. Vor dem Senden wird die geschätzte Tokenzahl angezeigt, ab 75k folgt ein Warnhinweis. Der Prompt für die Bewertung liegt in `prompts/gpt_score.txt`.
 
 ---
 
@@ -657,6 +665,8 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **web/src/fileUtils.js** – Text-Funktionen wie `calculateTextSimilarity`
 * **web/src/colorUtils.js** – Farb-Hilfsfunktionen wie `getVersionColor`
 * **web/src/fileUtils.mjs** – Wrapper, der die Textfunktionen sowohl im Browser als auch unter Node bereitstellt
+* **web/src/gptService.js** – Anbindung an die ChatGPT-API
+* **web/src/actions/projectEvaluate.js** – Bewertet sichtbare Zeilen und aktualisiert die Tabelle
 
 ---
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -23,6 +23,7 @@ const historyUtils = require('../historyUtils');
 const { watchDownloadFolder, clearDownloadFolder, pruefeAudiodatei } = require('../watcher.js');
 const { isDubReady } = require('../elevenlabs.js');
 const { createSoundBackup, listSoundBackups, deleteSoundBackup } = require('../soundBackupUtils');
+const { saveSettings, loadSettings } = require('../settingsStore.ts');
 // Fortschrittsbalken und FFmpeg für MP3->WAV-Konvertierung
 const ProgressBar = require('progress');
 const ffmpeg = require('ffmpeg-static');
@@ -53,6 +54,9 @@ fs.mkdirSync(audioBackupPath, { recursive: true });
 // Ordner für ZIP-Sicherungen der Sounds anlegen
 const soundZipBackupPath = path.join(backupPath, 'sounds');
 fs.mkdirSync(soundZipBackupPath, { recursive: true });
+// Gespeicherte ChatGPT-Einstellungen laden
+let { openaiKey: openaiApiKey = '', selectedModel: openaiModel = '', cachedModels: cached = null } = loadSettings(userDataPath);
+let modelCache = cached || { data: [], time: 0 };
 // Hilfsfunktion: sicheres Verschieben ueber Dateisystemgrenzen hinweg
 function safeMove(src, dest) {
   try {
@@ -414,6 +418,30 @@ app.whenReady().then(() => {
       list.splice(idx, 1);
       saveBookmarks(list);
     }
+    return true;
+  });
+
+  // ChatGPT-Einstellungen laden und speichern
+  ipcMain.handle('load-openai-settings', () => ({ key: openaiApiKey, model: openaiModel }));
+  ipcMain.handle('save-openai-settings', (event, data) => {
+    openaiApiKey = data.key || '';
+    openaiModel = data.model || '';
+    saveSettings(userDataPath, {
+      openaiKey: openaiApiKey,
+      selectedModel: openaiModel,
+      cachedModels: modelCache
+    });
+    return true;
+  });
+
+  ipcMain.handle('load-openai-models', () => modelCache);
+  ipcMain.handle('save-openai-models', (event, list) => {
+    modelCache = { data: Array.isArray(list) ? list : [], time: Date.now() };
+    saveSettings(userDataPath, {
+      openaiKey: openaiApiKey,
+      selectedModel: openaiModel,
+      cachedModels: modelCache
+    });
     return true;
   });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -74,6 +74,10 @@ if (typeof require !== 'function') {
     startHla: (mode, lang, map) => ipcRenderer.invoke('start-hla', { mode, lang, map }),
     openExternal: (url) => ipcRenderer.invoke('open-external', url),
     openPath: (p) => ipcRenderer.invoke('open-path', p),
+    loadOpenaiSettings: () => ipcRenderer.invoke('load-openai-settings'),
+    saveOpenaiSettings: data => ipcRenderer.invoke('save-openai-settings', data),
+    loadOpenaiModels: () => ipcRenderer.invoke('load-openai-models'),
+    saveOpenaiModels: data => ipcRenderer.invoke('save-openai-models', data),
     // Automatische Steuerung der Dubbing-Seite
     autoDub: data => ipcRenderer.invoke('auto-dub', data),
     captureFrame: bounds => ipcRenderer.invoke('capture-frame', bounds),

--- a/prompts/gpt_score.txt
+++ b/prompts/gpt_score.txt
@@ -1,0 +1,5 @@
+Du bist ein kritischer Lektor. Bewerte die deutsche \
+Übersetzung jeder Zeile aus Half-Life: Alyx auf einer \
+Skala von 0 bis 100. Gib ein JSON-Array zurück, in dem \
+je Eintrag wie folgt aussieht:
+{ "id": <ID>, "score": <0-100>, "comment": "<kurzer Kommentar>", "suggestion": "<kurzer Vorschlag>" }

--- a/settingsStore.ts
+++ b/settingsStore.ts
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const algorithm = 'aes-256-cbc';
+const KEY = crypto.createHash('sha256').update('hla_translation_tool').digest();
+const IV = Buffer.alloc(16, 0);
+
+function encrypt(text) {
+    const cipher = crypto.createCipheriv(algorithm, KEY, IV);
+    return Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]).toString('base64');
+}
+
+function decrypt(enc) {
+    try {
+        const decipher = crypto.createDecipheriv(algorithm, KEY, IV);
+        return Buffer.concat([decipher.update(Buffer.from(enc, 'base64')), decipher.final()]).toString('utf8');
+    } catch {
+        return '';
+    }
+}
+
+function getFile(dir) {
+    return path.join(dir, 'settings.json');
+}
+
+function saveSettings(dir, data) {
+    const file = getFile(dir);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    let current = {};
+    if (fs.existsSync(file)) {
+        try {
+            current = JSON.parse(fs.readFileSync(file, 'utf8'));
+        } catch {}
+    }
+    const toSave = {
+        openaiKey: 'openaiKey' in data
+            ? encrypt(data.openaiKey || '')
+            : current.openaiKey || '',
+        selectedModel: 'selectedModel' in data
+            ? data.selectedModel || ''
+            : current.selectedModel || '',
+        cachedModels: 'cachedModels' in data
+            ? data.cachedModels
+            : current.cachedModels || null
+    };
+    fs.writeFileSync(file, JSON.stringify(toSave, null, 2));
+}
+
+function loadSettings(dir) {
+    const file = getFile(dir);
+    if (fs.existsSync(file)) {
+        try {
+            const obj = JSON.parse(fs.readFileSync(file, 'utf8'));
+            return {
+                openaiKey: obj.openaiKey ? decrypt(obj.openaiKey) : '',
+                selectedModel: obj.selectedModel || '',
+                cachedModels: obj.cachedModels || null
+            };
+        } catch {}
+    }
+    return { openaiKey: '', selectedModel: '', cachedModels: null };
+}
+
+module.exports = { saveSettings, loadSettings };

--- a/tests/gptService.test.js
+++ b/tests/gptService.test.js
@@ -1,0 +1,50 @@
+const jestFetch = jest.fn();
+
+beforeEach(() => {
+  jest.resetModules();
+  global.fetch = jestFetch;
+});
+
+afterEach(() => {
+  delete global.fetch;
+});
+
+test('teilt lange Anfragen in Blöcke', async () => {
+  const { evaluateScene } = require('../web/src/gptService.js');
+  const lines = Array.from({ length: 300 }, (_, i) => ({ id: i, character: '', en: 'a', de: 'b' }));
+  jestFetch.mockResolvedValue({ ok: true, json: async () => ({ choices: [{ message: { content: '[]' } }] }) });
+  await evaluateScene({ scene: 'scene', lines, key: 'key', model: 'gpt-3.5-turbo' });
+  expect(jestFetch).toHaveBeenCalledTimes(2);
+});
+
+test('wirft bei API-Fehler', async () => {
+  const { evaluateScene } = require('../web/src/gptService.js');
+  const lines = [{ id: 1, character: '', en: 'a', de: 'b' }];
+  jestFetch.mockResolvedValue({ ok: false, status: 429, json: async () => ({ error: { message: 'limit' } }) });
+  await expect(evaluateScene({ scene: 's', lines, key: 'key', model: 'gpt-3.5-turbo' })).rejects.toThrow('API-Fehler');
+});
+
+test('testKey prüft API-Schlüssel', async () => {
+  const { testKey } = require('../web/src/gptService.js');
+  jestFetch.mockResolvedValue({ ok: true });
+  const ok = await testKey('abc');
+  expect(jestFetch).toHaveBeenCalledWith('https://api.openai.com/v1/models', { headers: { Authorization: 'Bearer abc' } });
+  expect(ok).toBe(true);
+});
+
+test('fetchModels filtert GPT-Modelle', async () => {
+  const { fetchModels } = require('../web/src/gptService.js');
+  jestFetch.mockResolvedValue({ ok: true, json: async () => ({ data: [
+    { id: 'gpt-3.5-turbo', owned_by: 'openai' },
+    { id: 'foo', owned_by: 'openai' }
+  ] }) });
+  const models = await fetchModels('key', true);
+  expect(jestFetch).toHaveBeenCalledWith('https://api.openai.com/v1/models', { headers: { Authorization: 'Bearer key' } });
+  expect(models).toEqual([{ id: 'gpt-3.5-turbo', owned_by: 'openai' }]);
+});
+
+test('fetchModels wirft bei Fehler', async () => {
+  const { fetchModels } = require('../web/src/gptService.js');
+  jestFetch.mockResolvedValue({ ok: false, text: async () => 'nope' });
+  await expect(fetchModels('k', true)).rejects.toThrow('nope');
+});

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -12,7 +12,7 @@
                    script-src 'self' https://www.youtube.com 'unsafe-inline';
                    style-src-elem 'self';
                    style-src-attr 'self' 'unsafe-inline';
-                   connect-src 'self' https://api.elevenlabs.io https://www.youtube.com https://i.ytimg.com;
+                   connect-src 'self' https://api.elevenlabs.io https://api.openai.com https://www.youtube.com https://i.ytimg.com;
                    frame-src https://www.youtube.com blob:;
                    img-src 'self' data: https://i.ytimg.com;
                    worker-src 'self' blob:;
@@ -21,6 +21,10 @@
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>
+    <div id="errorBanner" class="error-banner hidden">
+        <span id="errorBannerMessage"></span>
+        <button id="errorBannerRetry">Erneut versuchen</button>
+    </div>
     <div class="container">
         <!-- Sidebar -->
         <aside class="sidebar">
@@ -53,6 +57,7 @@
                             <div class="settings-item" onclick="scanAudioDuplicates()">🎵 Audio-Duplikate</div>
                             <div class="settings-item" onclick="showBackupDialog()">💾 Backup</div>
                             <div class="settings-item" onclick="showApiDialog()">🔊 ElevenLabs API</div>
+                            <div class="settings-item" onclick="showGptApiDialog()">💬 ChatGPT API</div>
                             <div class="settings-item" onclick="resetFileDatabase()">🔄 Reset DB</div>
                             <div class="settings-item" onclick="updateAllFilePaths()">🔄 Projekte bereinigen</div>
                             <div class="settings-item" onclick="repairProjectFolders()">🔧 Ordner reparieren</div>
@@ -81,6 +86,7 @@
                     </label>
                     <input type="text" id="mapSelect" placeholder="Level" style="width:140px">
                     <button id="startButton" class="btn btn-secondary" onclick="startHla()">Starten</button>
+                    <button id="gptScoreButton">Bewerten (GPT)</button>
                 </div>
             </div>
 			
@@ -161,6 +167,7 @@
         <th class="sortable">Dateiname</th>
         <th class="sortable">Ordner</th>
         <th>Version</th>
+        <th>Score</th>
         <th>EN Text</th>
         <th>DE Text</th>
         <th width="40">UT-Suche</th>
@@ -410,6 +417,30 @@
                 <button class="btn" onclick="addCustomVoice()">Neue Stimme</button>
                 <button class="btn btn-secondary" onclick="closeApiDialog()">Abbrechen</button>
                 <button class="btn btn-success" onclick="saveApiSettings()">Speichern</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- ChatGPT API Dialog -->
+    <div class="dialog-overlay hidden" id="gptApiDialog">
+        <div class="dialog">
+            <button class="dialog-close-btn" onclick="closeGptApiDialog()">×</button>
+            <h3>💬 ChatGPT API</h3>
+            <div class="customize-field api-key-field">
+                <label>API-Key:</label>
+                <input type="password" id="openaiKeyInput" style="width:55%;">
+                <button class="btn eye-btn" onclick="toggleOpenaiKey()">👁</button>
+                <button class="btn" id="testOpenaiKeyBtn" onclick="testGptApiKey()">Key testen</button>
+                <span id="openaiKeyStatus" class="status-indicator"></span>
+            </div>
+            <div class="customize-field">
+                <label>GPT-Modell:</label>
+                <select id="gptModelSelect" style="width:55%;" disabled></select>
+                <button class="btn" id="refreshModelsBtn" title="Verfügbare Modelle vom Server laden">↻</button>
+            </div>
+            <div class="dialog-buttons">
+                <button class="btn btn-secondary" onclick="closeGptApiDialog()">Abbrechen</button>
+                <button class="btn btn-success" onclick="saveGptApiSettings()">Speichern</button>
             </div>
         </div>
     </div>

--- a/web/src/actions/projectEvaluate.js
+++ b/web/src/actions/projectEvaluate.js
@@ -1,0 +1,55 @@
+// Sammele sichtbare Zeilen, rufe den GPT-Service auf und aktualisiere die Tabelle
+// GPT-Service importieren
+import { evaluateScene } from '../gptService.js';
+
+// Überträgt die GPT-Ergebnisse in die Dateiliste
+export function applyEvaluationResults(results, files) {
+    if (!Array.isArray(results)) return;
+    for (const r of results) {
+        const f = files.find(fl => fl.id === r.id);
+        if (f) {
+            f.score = r.score;
+            f.comment = r.comment;
+            // Vorschlag separat speichern
+            f.suggestion = r.suggestion;
+        }
+    }
+}
+
+export async function scoreVisibleLines(opts) {
+    const { displayOrder, files, currentProject, apiKey, gptModel, renderTable,
+            updateStatus, showErrorBanner, showToast } = opts;
+    if (!apiKey) {
+        if (showToast) showToast('Kein GPT-Key gespeichert', 'error');
+        return;
+    }
+
+    const visible = displayOrder.filter(item => {
+        const row = document.querySelector(`tr[data-id='${item.file.id}']`);
+        return row && row.offsetParent !== null;
+    });
+    const lines = visible.map(({ file }) => ({
+        id: file.id,
+        character: file.character || '',
+        en: file.enText || '',
+        de: file.deText || ''
+    }));
+    const scene = currentProject?.levelName || '';
+    let results = [];
+    try {
+        results = await evaluateScene({ scene, lines, key: apiKey, model: gptModel });
+    } catch (e) {
+        if (showErrorBanner) {
+            showErrorBanner(String(e), () => scoreVisibleLines(opts));
+        }
+        return;
+    }
+    applyEvaluationResults(results, files);
+    await renderTable(displayOrder.map(d => d.file));
+    if (updateStatus) updateStatus('GPT-Bewertung abgeschlossen');
+}
+
+// Kompatibilität für CommonJS
+if (typeof module !== 'undefined') {
+    module.exports = { scoreVisibleLines, applyEvaluationResults };
+}

--- a/web/src/gptService.js
+++ b/web/src/gptService.js
@@ -1,0 +1,151 @@
+let systemPrompt = '';
+let promptReady;
+
+if (typeof window !== 'undefined' && typeof fetch === 'function') {
+    // Im Browser: Prompt per Fetch laden
+    const url = '../prompts/gpt_score.txt';
+    promptReady = fetch(url)
+        .then(r => r.ok ? r.text() : '')
+        .then(t => { systemPrompt = t.trim(); })
+        .catch(() => { systemPrompt = ''; });
+} else {
+    // Unter Node: Prompt direkt von der Festplatte lesen
+    const fs = require('fs');
+    const path = require('path');
+    try {
+        systemPrompt = fs.readFileSync(path.join(__dirname, '..', 'prompts', 'gpt_score.txt'), 'utf8').trim();
+    } catch (e) {
+        console.error('Prompt konnte nicht geladen werden', e);
+    }
+    promptReady = Promise.resolve();
+}
+
+// Bewertet eine Szene mit GPT und liefert ein Array
+// [{id, score, comment, suggestion}]
+async function evaluateScene({ scene, lines, key, model = 'gpt-4o-mini' }) {
+    await promptReady;
+
+    // Kosten grob abschaetzen (3 Tokens je Zeichen)
+    const charCount = lines.reduce((s, l) =>
+        s + (l.character || '').length + (l.en || '').length + (l.de || '').length, 0);
+    const estimatedTokens = charCount * 3;
+    if (estimatedTokens > 75000) {
+        if (typeof window !== 'undefined' && window.showToast) {
+            window.showToast(`Warnung: etwa ${estimatedTokens} Tokens`, 'error');
+        } else {
+            console.warn(`Warnung: etwa ${estimatedTokens} Tokens`);
+        }
+    }
+
+    const results = [];
+    const chunkSize = 250;
+    let canceled = false;
+    let ui = null;
+
+    // Fortschrittsdialog nur im Browser anzeigen
+    if (typeof document !== 'undefined' && lines.length > chunkSize) {
+        ui = createProgressDialog(lines.length);
+        ui.cancelBtn.onclick = () => { canceled = true; ui.overlay.remove(); };
+    }
+
+    for (let i = 0; i < lines.length && !canceled; i += chunkSize) {
+        const chunk = lines.slice(i, i + chunkSize);
+        if (ui) updateProgressDialog(ui, i, lines.length);
+        const messages = [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: JSON.stringify({ scene, lines: chunk }) }
+        ];
+        try {
+            const res = await fetch('https://api.openai.com/v1/chat/completions', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': 'Bearer ' + key
+                },
+                body: JSON.stringify({ model, messages, temperature: 0 })
+            });
+            if (!res.ok) {
+                throw new Error(`HTTP ${res.status}`);
+            }
+            const data = await res.json();
+            const arr = JSON.parse(data.choices[0].message.content);
+            results.push(...arr);
+        } catch (e) {
+            if (ui) ui.overlay.remove();
+            throw new Error('API-Fehler: ' + (e && e.message ? e.message : e));
+        }
+    }
+
+    if (ui) ui.overlay.remove();
+    if (canceled) throw new Error('Abgebrochen');
+    return results;
+}
+
+function createProgressDialog(total) {
+    const overlay = document.createElement('div');
+    overlay.className = 'dialog-overlay';
+    overlay.innerHTML = `<div class="dialog gpt-progress">
+        <div class="gpt-status" id="gptStatus">0 / ${total}</div>
+        <div class="progress-bar"><div class="progress-fill" id="gptFill"></div></div>
+        <button id="gptCancelBtn">Abbrechen</button>
+    </div>`;
+    document.body.appendChild(overlay);
+    const fill = overlay.querySelector('#gptFill');
+    const status = overlay.querySelector('#gptStatus');
+    const cancelBtn = overlay.querySelector('#gptCancelBtn');
+    return { overlay, fill, status, cancelBtn };
+}
+
+function updateProgressDialog(ui, done, total) {
+    ui.status.textContent = `${done} / ${total}`;
+    ui.fill.style.width = `${Math.round((done / total) * 100)}%`;
+}
+
+// Prueft, ob der uebergebene API-Key gueltig ist
+async function testKey(key) {
+    try {
+        const res = await fetch('https://api.openai.com/v1/models', {
+            headers: { 'Authorization': 'Bearer ' + key }
+        });
+        return res.ok;
+    } catch {
+        return false;
+    }
+}
+
+// Verfügbare Modelle vom Server laden, optional Cache verwenden
+async function fetchModels(apiKey, ignoreCache = false) {
+    if (!apiKey) throw new Error('API-Key fehlt');
+    if (typeof window !== 'undefined' && window.electronAPI?.loadOpenaiModels && !ignoreCache) {
+        try {
+            const cache = await window.electronAPI.loadOpenaiModels();
+            if (cache && Array.isArray(cache.data) && cache.time && Date.now() - cache.time < 86400000) {
+                return cache.data;
+            }
+        } catch {}
+    }
+    const res = await fetch('https://api.openai.com/v1/models', {
+        headers: { 'Authorization': 'Bearer ' + apiKey }
+    });
+    if (!res.ok) {
+        throw new Error(await res.text());
+    }
+    const json = await res.json();
+    const models = json.data
+        .filter(m => m.id && m.id.startsWith('gpt'))
+        .map(m => ({ id: m.id, owned_by: m.owned_by }));
+    if (typeof window !== 'undefined' && window.electronAPI?.saveOpenaiModels) {
+        try { await window.electronAPI.saveOpenaiModels(models); } catch {}
+    }
+    return models;
+}
+
+// Kompatibilität für CommonJS
+if (typeof module !== 'undefined') {
+    module.exports = { evaluateScene, testKey, fetchModels };
+}
+if (typeof window !== 'undefined') {
+    window.evaluateScene = evaluateScene;
+    window.testGptKey = testKey;
+    window.fetchGptModels = fetchModels;
+}

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -1,0 +1,62 @@
+// Erzeugt den HTML-Code für eine Score-Zelle und bindet Tooltip sowie Klick
+export function scoreCellTemplate(file, escapeHtml) {
+    const noScore = file.score === undefined || file.score === null;
+    const cls = noScore
+        ? 'score-none'
+        : file.score >= 70
+            ? 'score-high'
+            : file.score >= 40
+                ? 'score-medium'
+                : 'score-low';
+    const sug = escapeHtml(file.suggestion || '');
+    const com = escapeHtml(file.comment || '');
+    const title = escapeHtml([file.comment, file.suggestion].filter(Boolean).join(' - '));
+    const scoreText = noScore ? '0' : file.score;
+    return `<td class="score-cell ${cls}" data-suggestion="${sug}" data-comment="${com}" title="${title}">${scoreText}</td>`;
+}
+
+export function attachScoreHandlers(tbody, files) {
+    tbody.querySelectorAll('.score-cell').forEach(cell => {
+        const id = Number(cell.parentElement?.dataset.id);
+        const suggestion = cell.dataset.suggestion;
+        const comment = cell.dataset.comment;
+        const tooltipText = [comment, suggestion].filter(Boolean).join(' - ');
+        cell.addEventListener('mouseenter', ev => openScoreTooltip(ev, tooltipText));
+        cell.addEventListener('mouseleave', closeScoreTooltip);
+        if (suggestion) {
+            cell.addEventListener('click', () => applySuggestion(id, files));
+        }
+    });
+}
+
+// Tooltip anzeigen
+export function openScoreTooltip(ev, text) {
+    closeScoreTooltip();
+    if (!text) return;
+    const box = document.createElement('div');
+    box.className = 'info-tooltip';
+    box.id = 'scoreTooltip';
+    box.textContent = text;
+    box.style.left = ev.clientX + 'px';
+    box.style.top = ev.clientY + 'px';
+    document.body.appendChild(box);
+}
+
+export function closeScoreTooltip() {
+    const box = document.getElementById('scoreTooltip');
+    if (box) box.remove();
+}
+
+function applySuggestion(id, files) {
+    const file = files.find(f => f.id === id);
+    if (!file || !file.suggestion) return;
+    file.deText = file.suggestion;
+    window.isDirty = true;
+    const row = document.querySelector(`tr[data-id='${id}']`);
+    const deCell = row?.querySelectorAll('textarea.text-input')[1];
+    if (deCell) {
+        deCell.value = file.deText;
+        deCell.classList.add('blink-blue');
+        setTimeout(() => deCell.classList.remove('blink-blue'), 600);
+    }
+}

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -54,7 +54,8 @@
         }
 		
 		/* Debug column styling */
-td:nth-child(7) {
+/* Stil der Pfad-Spalte */
+td:nth-child(10) {
     max-width: 200px;
     font-size: 11px;
     color: #666;
@@ -62,7 +63,7 @@ td:nth-child(7) {
     line-height: 1.2;
 }
 
-th:nth-child(7) {
+th:nth-child(10) {
     max-width: 200px;
     font-size: 12px;
 }
@@ -647,13 +648,14 @@ th:nth-child(7) {
         }
 
         /* Flexible Spaltenbreite für EN und DE */
-        td:nth-child(6), td:nth-child(7) {
+        /* Spaltenbreite für EN- und DE-Text nach neuer Score-Spalte */
+        td:nth-child(7), td:nth-child(8) {
             width: 25%;
             min-width: 200px;
             vertical-align: top;
         }
 
-        th:nth-child(6), th:nth-child(7) {
+        th:nth-child(7), th:nth-child(8) {
             width: 25%;
             min-width: 200px;
         }
@@ -666,30 +668,30 @@ th:nth-child(7) {
 
 /* Make table responsive - aktualisierte Spalten-Nummern */
 @media (max-width: 1200px) {
-    td:nth-child(6), td:nth-child(7) {
+    td:nth-child(7), td:nth-child(8) {
         width: 25%;
         min-width: 180px;
     }
-    th:nth-child(6), th:nth-child(7) {
+    th:nth-child(7), th:nth-child(8) {
         width: 25%;
         min-width: 180px;
     }
-    /* Debug-Spalte bei kleinen Bildschirmen ausblenden */
-    td:nth-child(8), th:nth-child(8) {
+    /* Debug-Spalte (UT-Suche) bei kleinen Bildschirmen ausblenden */
+    td:nth-child(9), th:nth-child(9) {
         display: none;
     }
 }
 
 @media (max-width: 900px) {
-    td:nth-child(6), td:nth-child(7) {
+    td:nth-child(7), td:nth-child(8) {
         width: 30%;
         min-width: 160px;
     }
-    th:nth-child(6), th:nth-child(7) {
+    th:nth-child(7), th:nth-child(8) {
         width: 30%;
         min-width: 160px;
     }
-    td:nth-child(8), th:nth-child(8) {
+    td:nth-child(9), th:nth-child(9) {
         display: none;
     }
 }
@@ -2759,6 +2761,67 @@ th:nth-child(7) {
 .word-list-table input{
     width: 100%;
 }
+
+/* Score-Bewertungen */
+.score-cell {
+    text-align: center;
+    color: #fff;
+}
+
+.score-none {
+    background: #666;
+    color: #ccc;
+}
+
+.score-low {
+    background: #A33;
+}
+
+.score-medium {
+    background: #BB8;
+}
+
+.score-high {
+    background: #3A3;
+}
+
+/* Blauer Blinkeffekt bei übernommener Übersetzung */
+.blink-blue {
+    animation: blinkBlue 0.6s;
+}
+
+@keyframes blinkBlue {
+    from { background-color: #4a80ff; }
+    to   { background-color: transparent; }
+}
+
+/* Dialog für GPT-Bewertung */
+.gpt-progress {
+    display: none;
+    padding: 20px;
+    background: #1a1a1a;
+    border: 1px solid #444;
+    border-radius: 6px;
+    margin: 20px;
+    z-index: 3000;
+}
+.gpt-progress.active { display: block; }
+.gpt-status { font-size: 14px; color: #999; margin-bottom: 8px; }
+
+/* Fehlerbanner bei API-Problemen */
+.error-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    background: #e74c3c;
+    color: #fff;
+    text-align: center;
+    padding: 10px;
+    z-index: 4000;
+}
+.error-banner.hidden { display: none; }
+.error-banner button { margin-left: 15px; }
 
 /* ===== Mobil-Fallback ===== */
 @media (max-width:900px){


### PR DESCRIPTION
## Summary
- erweitere ChatGPT-Einstellungen um dynamische Modell-Liste
- cache verfügbare Modelle für 24 h in den Settings
- `gptService.js` bietet nun `fetchModels` und nutzt "gpt-4o-mini" als Fallback
- Tests decken `fetchModels` ab
- README beschreibt die neue Funktion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68604cb240f08327b63a7778b7b313cc