### PR TITLE
Implement GPT review dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,14 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Automatische Prüfung geänderter Endungen** passt Datenbank und Projekte an
 * **Live‑Statistiken:** EN‑%, DE‑%, Completion‑%, Globale Textzahlen (EN/DE/BEIDE/∑)
 * **Vollständig offline** – keine Server, keine externen Abhängigkeiten
-* **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
+* **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt. Der GPT-Knopf sitzt jetzt rechts neben dieser Leiste.
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Eigenes Wörterbuch:** Ein neuer 📚-Knopf speichert englische Wörter zusammen mit deutscher Lautschrift.
 * **Hinweis-Symbol bei Übersetzungen:** Unter der Lupe erscheint ein kleines 📝, wenn der DE-Text ein Wort aus dem Wörterbuch enthält.
 * **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren zeigt ein Tooltip Kommentar und Vorschlag, ein Klick ersetzt den DE-Text und blinkt kurz blau auf
 * **Debug-Ausgabe für GPT:** Ist der Debug-Modus aktiv, erscheinen gesendete Daten und Antworten der GPT-API in der Konsole
 * **GPT-Konsole:** Beim Klick auf "Bewerten (GPT)" öffnet sich ein Fenster mit einem Log aller gesendeten Prompts und Antworten
+* **Vorab-Dialog für GPT:** Vor dem Start zeigt ein Fenster, wie viele Zeilen und Sprecher enthalten sind
 * **Unbewertete Zeilen:** Noch nicht bewertete Zeilen zeigen eine graue 0
 * **Score-Spalte nach Version:** Die farbige Bewertung steht direkt vor dem EN-Text
 * **Anpassbarer Bewertungs-Prompt:** Der Text liegt in `prompts/gpt_score.txt`

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -445,6 +445,20 @@
         </div>
     </div>
 
+    <!-- GPT Start Dialog -->
+    <div class="dialog-overlay hidden" id="gptStartDialog">
+        <div class="dialog">
+<button class="dialog-close-btn" onclick="closeGptStartDialog()">×</button>
+            <h3>Bewerten (GPT)</h3>
+            <p id="gptStartInfo"></p>
+            <ul id="gptStartSpeakers" class="debug-info-list"></ul>
+            <div class="dialog-buttons">
+                <button class="btn btn-secondary" onclick="closeGptStartDialog()">Abbrechen</button>
+                <button class="btn btn-success" onclick="startGptScoring()">Start</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Neue Stimme Dialog -->
     <div class="dialog-overlay hidden" id="addVoiceDialog">
         <div class="dialog">

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -281,20 +281,42 @@ function cleanupDubCache() {
 if (typeof document !== "undefined" && typeof document.getElementById === "function") {
     const gptBtn = document.getElementById("gptScoreButton");
     if (gptBtn) {
-        gptBtn.addEventListener("click", () => {
-            if (typeof scoreVisibleLines === 'function') {
-                scoreVisibleLines({
-                    displayOrder,
-                    files,
-                    currentProject,
-                    apiKey: openaiApiKey,
-                    gptModel: openaiModel,
-                    renderTable: renderFileTableWithOrder,
-                    updateStatus,
-                    showErrorBanner,
-                    showToast
-                });
-            }
+        gptBtn.addEventListener("click", showGptStartDialog);
+    }
+}
+
+// Öffnet einen Dialog mit Zeilenzahl und Sprechern
+function showGptStartDialog() {
+    const visible = displayOrder.filter(item => {
+        const row = document.querySelector(`tr[data-id='${item.file.id}']`);
+        return row && row.offsetParent !== null;
+    });
+    const info = document.getElementById('gptStartInfo');
+    const list = document.getElementById('gptStartSpeakers');
+    const speakers = [...new Set(visible.map(v => v.file.folder))].sort();
+    if (info) info.textContent = `${visible.length} Zeilen werden gesendet.`;
+    if (list) list.innerHTML = speakers.map(s => `<li>${s}</li>`).join('');
+    document.getElementById('gptStartDialog').classList.remove('hidden');
+}
+
+function closeGptStartDialog() {
+    document.getElementById('gptStartDialog').classList.add('hidden');
+}
+
+// Startet die eigentliche Bewertung nach Bestätigung
+function startGptScoring() {
+    closeGptStartDialog();
+    if (typeof scoreVisibleLines === 'function') {
+        scoreVisibleLines({
+            displayOrder,
+            files,
+            currentProject,
+            apiKey: openaiApiKey,
+            gptModel: openaiModel,
+            renderTable: renderFileTableWithOrder,
+            updateStatus,
+            showErrorBanner,
+            showToast
         });
     }
 }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -461,6 +461,11 @@ th:nth-child(10) {
             align-items: center;
         }
 
+        /* GPT-Knopf weiter rechts platzieren */
+        #gptScoreButton {
+            margin-left: auto;
+        }
+
 .video-launch {
     margin-left: auto;
     display: flex;


### PR DESCRIPTION
## Summary
- show GPT button on the right
- open a preview dialog before sending lines to GPT
- start GPT evaluation from the dialog
- document the new dialog in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6860710656c0832786165ac8163837d8