### PR TITLE
Add GPT score pipeline test and bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.
 * **Löschen per Desktop-API:** Einzelne Bookmarks lassen sich über einen IPC-Kanal entfernen.
 * **Tests für Video-Bookmarks:** Überprüfen Laden, Sortierung sowie Hinzufügen und Entfernen von Einträgen.
+* **Tests für GPT-Bewertungen:** Prüfen, ob empfangene Scores korrekt übernommen und dargestellt werden.
 * **Prüfung von Video-Links:** Eingaben müssen mit `https://` beginnen und dürfen keine Leerzeichen enthalten.
 * **Duplikat-Prüfung & dauerhafte Speicherung im Nutzerordner**
 * **Automatische YouTube-Titel:** Beim Hinzufügen lädt das Tool den Videotitel per oEmbed und sortiert die Liste alphabetisch. Schlägt dies fehl, wird die eingegebene URL als Titel gespeichert.

--- a/tests/scorePipeline.test.js
+++ b/tests/scorePipeline.test.js
@@ -1,0 +1,26 @@
+const { applyEvaluationResults } = require('../web/src/actions/projectEvaluate.js');
+const { scoreCellTemplate } = require('../web/src/scoreColumn.js');
+
+function escapeHtml(text) {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+describe('GPT-Score-Pipeline', () => {
+    test('applyEvaluationResults überträgt Score und Kommentare', () => {
+        const files = [{ id: 1 }, { id: 2 }];
+        const results = [{ id: 2, score: '80', comment: 'gut', suggestion: 'foo' }];
+        applyEvaluationResults(results, files);
+        expect(files[1]).toEqual({ id: 2, score: 80, comment: 'gut', suggestion: 'foo' });
+    });
+
+    test('scoreCellTemplate erzeugt HTML mit richtiger Klasse', () => {
+        const html = scoreCellTemplate({ score: 85, comment: 'ok', suggestion: '' }, escapeHtml);
+        expect(html).toContain('score-high');
+        expect(html).toContain('>85<');
+    });
+});

--- a/web/src/actions/projectEvaluate.js
+++ b/web/src/actions/projectEvaluate.js
@@ -1,14 +1,20 @@
 // Sammele sichtbare Zeilen, rufe den GPT-Service auf und aktualisiere die Tabelle
 // GPT-Service importieren
-import { evaluateScene } from '../gptService.js';
+let evaluateScene;
+if (typeof module !== 'undefined' && module.exports) {
+    ({ evaluateScene } = require('../gptService.js'));
+} else if (typeof window !== 'undefined') {
+    evaluateScene = window.evaluateScene;
+}
 
 // Überträgt die GPT-Ergebnisse in die Dateiliste
-export function applyEvaluationResults(results, files) {
+function applyEvaluationResults(results, files) {
     if (!Array.isArray(results)) return;
     for (const r of results) {
         const f = files.find(fl => fl.id === r.id);
         if (f) {
-            f.score = r.score;
+            const parsedScore = Number(r.score);
+            f.score = Number.isFinite(parsedScore) ? parsedScore : null;
             f.comment = r.comment;
             // Vorschlag separat speichern
             f.suggestion = r.suggestion;
@@ -16,7 +22,7 @@ export function applyEvaluationResults(results, files) {
     }
 }
 
-export async function scoreVisibleLines(opts) {
+async function scoreVisibleLines(opts) {
     const { displayOrder, files, currentProject, apiKey, gptModel, renderTable,
             updateStatus, showErrorBanner, showToast } = opts;
     if (!apiKey) {

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -1,5 +1,5 @@
 // Erzeugt den HTML-Code für eine Score-Zelle und bindet Tooltip sowie Klick
-export function scoreCellTemplate(file, escapeHtml) {
+function scoreCellTemplate(file, escapeHtml) {
     const noScore = file.score === undefined || file.score === null;
     const cls = noScore
         ? 'score-none'
@@ -15,7 +15,7 @@ export function scoreCellTemplate(file, escapeHtml) {
     return `<td class="score-cell ${cls}" data-suggestion="${sug}" data-comment="${com}" title="${title}">${scoreText}</td>`;
 }
 
-export function attachScoreHandlers(tbody, files) {
+function attachScoreHandlers(tbody, files) {
     tbody.querySelectorAll('.score-cell').forEach(cell => {
         const id = Number(cell.parentElement?.dataset.id);
         const suggestion = cell.dataset.suggestion;
@@ -30,7 +30,7 @@ export function attachScoreHandlers(tbody, files) {
 }
 
 // Tooltip anzeigen
-export function openScoreTooltip(ev, text) {
+function openScoreTooltip(ev, text) {
     closeScoreTooltip();
     if (!text) return;
     const box = document.createElement('div');
@@ -42,9 +42,18 @@ export function openScoreTooltip(ev, text) {
     document.body.appendChild(box);
 }
 
-export function closeScoreTooltip() {
+function closeScoreTooltip() {
     const box = document.getElementById('scoreTooltip');
     if (box) box.remove();
+}
+
+// Kompatibilität für CommonJS und Browser
+if (typeof module !== 'undefined') {
+    module.exports = { scoreCellTemplate, attachScoreHandlers, openScoreTooltip, closeScoreTooltip };
+}
+if (typeof window !== 'undefined') {
+    window.scoreCellTemplate = scoreCellTemplate;
+    window.attachScoreHandlers = attachScoreHandlers;
 }
 
 function applySuggestion(id, files) {


### PR DESCRIPTION
## Summary
- parse numeric score values in `applyEvaluationResults`
- adapt `projectEvaluate.js` and `scoreColumn.js` for CommonJS usage
- add test `scorePipeline.test.js` for GPT score workflow
- document the new tests in the README

## Testing
- `npx jest tests/scorePipeline.test.js --runInBand`
- `npx jest --runInBand --json --silent`

------
https://chatgpt.com/codex/tasks/task_e_686073d609b08327ad819849efc1a3bb