### PR TITLE
Implementiert Prompt-Vorschau für GPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren zeigt ein Tooltip Kommentar und Vorschlag, ein Klick ersetzt den DE-Text und blinkt kurz blau auf
 * **Debug-Ausgabe für GPT:** Ist der Debug-Modus aktiv, erscheinen gesendete Daten und Antworten der GPT-API in der Konsole
 * **GPT-Konsole:** Beim Klick auf "Bewerten (GPT)" öffnet sich ein Fenster mit einem Log aller gesendeten Prompts und Antworten
+* **Prompt-Vorschau:** Vor dem eigentlichen Versand zeigt ein Dialog den kompletten Prompt an. Erst nach Klick auf "Senden" wird die Anfrage gestellt und die Antwort im selben Fenster angezeigt
 * **Vorab-Dialog für GPT:** Vor dem Start zeigt ein Fenster, wie viele Zeilen und Sprecher enthalten sind
 * **Unbewertete Zeilen:** Noch nicht bewertete Zeilen zeigen eine graue 0
 * **Score-Spalte nach Version:** Die farbige Bewertung steht direkt vor dem EN-Text

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -459,6 +459,22 @@
         </div>
     </div>
 
+    <!-- GPT Prompt Dialog -->
+    <div class="dialog-overlay hidden" id="gptPromptDialog">
+        <div class="dialog gpt-test-dialog">
+            <button class="dialog-close-btn" onclick="closeGptPromptDialog()">×</button>
+            <h3>GPT-Test</h3>
+            <div class="prompt-result-container">
+                <textarea id="gptPromptArea" readonly></textarea>
+                <textarea id="gptResultArea" readonly></textarea>
+            </div>
+            <div class="dialog-buttons">
+                <button class="btn btn-secondary" onclick="closeGptPromptDialog()">Schließen</button>
+                <button class="btn btn-success" id="gptPromptSend" onclick="sendGptPrompt()">Senden</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Neue Stimme Dialog -->
     <div class="dialog-overlay hidden" id="addVoiceDialog">
         <div class="dialog">

--- a/web/src/gptService.js
+++ b/web/src/gptService.js
@@ -1,6 +1,11 @@
 let systemPrompt = '';
 let promptReady;
 
+// Liefert den geladenen System-Prompt
+function getSystemPrompt() {
+    return systemPrompt;
+}
+
 if (typeof window !== 'undefined' && typeof fetch === 'function') {
     // Im Browser: Prompt per Fetch laden
     const url = '../prompts/gpt_score.txt';
@@ -13,7 +18,10 @@ if (typeof window !== 'undefined' && typeof fetch === 'function') {
     const fs = require('fs');
     const path = require('path');
     try {
-        systemPrompt = fs.readFileSync(path.join(__dirname, '..', 'prompts', 'gpt_score.txt'), 'utf8').trim();
+        const localPath = path.join(__dirname, '..', 'prompts', 'gpt_score.txt');
+        const rootPath  = path.join(__dirname, '..', '..', 'prompts', 'gpt_score.txt');
+        const filePath  = fs.existsSync(localPath) ? localPath : rootPath;
+        systemPrompt = fs.readFileSync(filePath, 'utf8').trim();
     } catch (e) {
         console.error('Prompt konnte nicht geladen werden', e);
     }
@@ -162,11 +170,13 @@ async function fetchModels(apiKey, ignoreCache = false) {
 }
 
 // Kompatibilität für CommonJS
+// Exporte für Node und Browser bereitstellen
 if (typeof module !== 'undefined') {
-    module.exports = { evaluateScene, testKey, fetchModels };
+    module.exports = { evaluateScene, testKey, fetchModels, getSystemPrompt };
 }
 if (typeof window !== 'undefined') {
     window.evaluateScene = evaluateScene;
     window.testGptKey = testKey;
     window.fetchGptModels = fetchModels;
+    window.getSystemPrompt = getSystemPrompt;
 }

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -79,6 +79,8 @@ let elevenLabsApiKey   = localStorage.getItem('hla_elevenLabsApiKey') || '';
 // Gespeicherter API-Key für ChatGPT (wird verschlüsselt auf der Festplatte gespeichert)
 let openaiApiKey       = '';
 let openaiModel        = '';
+// Merkt Szene und Zeilen für den GPT-Testdialog
+let gptPromptData      = null;
 // Liste der verfügbaren Stimmen der API
 let availableVoices    = [];
 // Manuell hinzugefügte Stimmen
@@ -306,19 +308,57 @@ function closeGptStartDialog() {
 // Startet die eigentliche Bewertung nach Bestätigung
 function startGptScoring() {
     closeGptStartDialog();
-    if (typeof scoreVisibleLines === 'function') {
-        scoreVisibleLines({
-            displayOrder,
-            files,
-            currentProject,
-            apiKey: openaiApiKey,
-            gptModel: openaiModel,
-            renderTable: renderFileTableWithOrder,
-            updateStatus,
-            showErrorBanner,
-            showToast
+    const visible = displayOrder.filter(item => {
+        const row = document.querySelector(`tr[data-id='${item.file.id}']`);
+        return row && row.offsetParent !== null;
+    });
+    const lines = visible.map(({ file }) => ({
+        id: file.id,
+        character: file.character || '',
+        en: file.enText || '',
+        de: file.deText || ''
+    }));
+    const scene = currentProject?.levelName || '';
+    gptPromptData = { scene, lines };
+    showGptPromptDialog();
+}
+
+// Zeigt den Testdialog mit dem kompletten Prompt
+function showGptPromptDialog() {
+    const area = document.getElementById('gptPromptArea');
+    if (!area || !gptPromptData) return;
+    const sys = typeof window.getSystemPrompt === 'function'
+        ? window.getSystemPrompt() : '';
+    const promptText = `System:\n${sys}\n\nUser:\n${JSON.stringify(gptPromptData, null, 2)}`;
+    area.value = promptText;
+    const resultArea = document.getElementById('gptResultArea');
+    if (resultArea) resultArea.value = '';
+    document.getElementById('gptPromptDialog').classList.remove('hidden');
+}
+
+function closeGptPromptDialog() {
+    document.getElementById('gptPromptDialog').classList.add('hidden');
+}
+
+// Sendet den Prompt an die API und zeigt die Antwort an
+async function sendGptPrompt() {
+    const btn = document.getElementById('gptPromptSend');
+    const resultArea = document.getElementById('gptResultArea');
+    if (!gptPromptData || !btn || !resultArea) return;
+    btn.disabled = true;
+    resultArea.value = 'Sende...';
+    try {
+        const results = await evaluateScene({
+            scene: gptPromptData.scene,
+            lines: gptPromptData.lines,
+            key: openaiApiKey,
+            model: openaiModel
         });
+        resultArea.value = JSON.stringify(results, null, 2);
+    } catch (e) {
+        resultArea.value = String(e);
     }
+    btn.disabled = false;
 }
 
 // Bewertet aktuell sichtbare Zeilen über ChatGPT

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2823,6 +2823,16 @@ th:nth-child(10) {
     margin-bottom: 10px;
 }
 
+/* Einfacher Dialog zum Testen des GPT-Prompts */
+.gpt-test-dialog .prompt-result-container {
+    display: flex;
+    gap: 10px;
+}
+.gpt-test-dialog textarea {
+    width: 50%;
+    min-height: 300px;
+}
+
 /* Fehlerbanner bei API-Problemen */
 .error-banner {
     position: fixed;


### PR DESCRIPTION
## Zusammenfassung
- erweitere `gptService` um `getSystemPrompt`
- neuer Dialog `gptPromptDialog` mit Eingabe und Antwortanzeige
- Funktionen zum Anzeigen und Senden des Prompts
- Style-Anpassungen für den neuen Dialog
- README um Prompt-Vorschau ergänzt
- sucht die Prompt-Datei nun auch im Hauptordner

## Testing
- `npm test -- tests/gptService.test.js tests/elevenlabs.test.js --silent --runInBand`
- `node node_modules/jest/bin/jest.js --runInBand --json --outputFile /tmp/test-summary.json`


------
https://chatgpt.com/codex/tasks/task_e_6860e6e78f548327b25024d1080f9376