### PR TITLE
Lade gespeicherte GPT-Einstellungen automatisch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,17 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren zeigt ein Tooltip Kommentar und Vorschlag, ein Klick ersetzt den DE-Text und blinkt kurz blau auf
 * **Debug-Ausgabe für GPT:** Ist der Debug-Modus aktiv, erscheinen gesendete Daten und Antworten der GPT-API in der Konsole
 * **GPT-Konsole:** Beim Klick auf "Bewerten (GPT)" öffnet sich ein Fenster mit einem Log aller gesendeten Prompts und Antworten
+* **Prompt-Vorschau:** Vor dem eigentlichen Versand zeigt ein Dialog den kompletten Prompt an. Erst nach Klick auf "Senden" wird die Anfrage gestellt und die Antwort im selben Fenster angezeigt
+* **Bewertung per Einfügen-Knopf:** Nach dem Versand erscheint ein zusätzlicher Knopf, der Score, Kommentar und Vorschlag in die Tabelle übernimmt
 * **Vorab-Dialog für GPT:** Vor dem Start zeigt ein Fenster, wie viele Zeilen und Sprecher enthalten sind
 * **Unbewertete Zeilen:** Noch nicht bewertete Zeilen zeigen eine graue 0
 * **Score-Spalte nach Version:** Die farbige Bewertung steht direkt vor dem EN-Text
 * **Anpassbarer Bewertungs-Prompt:** Der Text liegt in `prompts/gpt_score.txt`
 * **Auswahl des GPT-Modells:** Im ChatGPT-Dialog lässt sich das Modell wählen. Die Liste wird auf Wunsch vom Server geladen und für 24&nbsp;Stunden gespeichert
+* **Automatisch geladene GPT-Einstellungen:** Gespeicherter Key und gewähltes Modell stehen nach dem Start sofort zur Verfügung
+* **Robuste GPT-Antworten:** Entfernt ```json-Blöcke``` automatisch und verhindert so Parsefehler
+* **Charaktername im GPT-Prompt:** Das Feld `character` nutzt nun den Ordnernamen
+* **Bugfix:** Scores werden korrekt eingefügt, auch wenn ID und Score als Zeichenketten geliefert werden
 * **Eigenständige Score-Komponente:** Tooltip und Klick sind in `web/src/scoreColumn.js` gekapselt
 * **Schlanker Video-Bereich:** Gespeicherte Links öffnen sich im Browser. Interner Player und OCR wurden entfernt.
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.

--- a/tests/gptService.test.js
+++ b/tests/gptService.test.js
@@ -48,3 +48,19 @@ test('fetchModels wirft bei Fehler', async () => {
   jestFetch.mockResolvedValue({ ok: false, text: async () => 'nope' });
   await expect(fetchModels('k', true)).rejects.toThrow('nope');
 });
+
+test('sanitizeJSONResponse entfernt ```json-Blöcke', () => {
+  const { sanitizeJSONResponse } = require('../web/src/gptService.js');
+  const input = '```json\n[{"a":1}]\n```';
+  expect(sanitizeJSONResponse(input)).toBe('[{"a":1}]');
+});
+
+test('applyEvaluationResults überträgt Score und Kommentar', () => {
+  const { applyEvaluationResults } = require('../web/src/actions/projectEvaluate.js');
+  const files = [{ id: 1 }, { id: 2 }];
+  const results = [{ id: '1', score: '55', comment: 'ok', suggestion: 'neu' }];
+  applyEvaluationResults(results, files);
+  expect(files[0].score).toBe(55);
+  expect(files[0].comment).toBe('ok');
+  expect(files[0].suggestion).toBe('neu');
+});

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -459,6 +459,23 @@
         </div>
     </div>
 
+    <!-- GPT Prompt Dialog -->
+    <div class="dialog-overlay hidden" id="gptPromptDialog">
+        <div class="dialog gpt-test-dialog">
+            <button class="dialog-close-btn" onclick="closeGptPromptDialog()">×</button>
+            <h3>GPT-Test</h3>
+            <div class="prompt-result-container">
+                <textarea id="gptPromptArea" readonly></textarea>
+                <textarea id="gptResultArea" readonly></textarea>
+            </div>
+            <div class="dialog-buttons">
+                <button class="btn btn-secondary" onclick="closeGptPromptDialog()">Schließen</button>
+                <button class="btn btn-success" id="gptPromptSend" onclick="sendGptPrompt()">Senden</button>
+                <button class="btn btn-blue" id="gptPromptInsert" onclick="insertGptResults()" disabled>Einfügen</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Neue Stimme Dialog -->
     <div class="dialog-overlay hidden" id="addVoiceDialog">
         <div class="dialog">

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2823,6 +2823,16 @@ th:nth-child(10) {
     margin-bottom: 10px;
 }
 
+/* Einfacher Dialog zum Testen des GPT-Prompts */
+.gpt-test-dialog .prompt-result-container {
+    display: flex;
+    gap: 10px;
+}
+.gpt-test-dialog textarea {
+    width: 50%;
+    min-height: 300px;
+}
+
 /* Fehlerbanner bei API-Problemen */
 .error-banner {
     position: fixed;


### PR DESCRIPTION
## Zusammenfassung
- füge `ladeGptEinstellungen` hinzu und rufe es beim Start auf
- README listet automatische GPT-Einstellungen
- entferne ```json-Blöcke``` in GPT-Antworten mit neuer `sanitizeJSONResponse`
- Charakter wird jetzt mit Ordnernamen befüllt
- Bewertungsergebnisse landen nach dem Versand direkt in die Tabelle
- GPT-Testdialog enthält jetzt einen Einfügen-Knopf
- Bugfix: Score-Übernahme funktioniert jetzt auch bei Zeichenketten-IDs

## Testing
- `npm test -- --runInBand --json --outputFile /tmp/test-summary.json`

------
https://chatgpt.com/codex/tasks/task_e_6860e6e78f548327b25024d1080f9376