### PR TITLE
Score-Farben und Vorschläge verbessern

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Eigenes Wörterbuch:** Ein neuer 📚-Knopf speichert englische Wörter zusammen mit deutscher Lautschrift.
 * **Hinweis-Symbol bei Übersetzungen:** Unter der Lupe erscheint ein kleines 📝, wenn der DE-Text ein Wort aus dem Wörterbuch enthält.
-* **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren zeigt ein Tooltip Kommentar und Vorschlag, ein Klick ersetzt den DE-Text und blinkt kurz blau auf
+* **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren zeigt ein Tooltip Kommentar und Vorschlag, ein Klick ersetzt den DE-Text und blinkt kurz blau auf. Der Vorschlag steht zusätzlich farbig über dem deutschen Textfeld.
 * **Debug-Ausgabe für GPT:** Ist der Debug-Modus aktiv, erscheinen gesendete Daten und Antworten der GPT-API in der Konsole
 * **GPT-Konsole:** Beim Klick auf "Bewerten (GPT)" öffnet sich ein Fenster mit einem Log aller gesendeten Prompts und Antworten
 * **Prompt-Vorschau:** Vor dem eigentlichen Versand zeigt ein Dialog den kompletten Prompt an. Erst nach Klick auf "Senden" wird die Anfrage gestellt und die Antwort im selben Fenster angezeigt
-* **Bewertung per Einfügen-Knopf:** Nach dem Versand erscheint ein zusätzlicher Knopf, der Score, Kommentar und Vorschlag in die Tabelle übernimmt
+* **Bewertung per Einfügen-Knopf:** Nach dem Versand erscheint ein zusätzlicher Knopf, der Score, Kommentar und Vorschlag in die Tabelle übernimmt und die farbige Vorschlagszeile aktualisiert
 * **Vorab-Dialog für GPT:** Vor dem Start zeigt ein Fenster, wie viele Zeilen und Sprecher enthalten sind
 * **Unbewertete Zeilen:** Noch nicht bewertete Zeilen zeigen eine graue 0
 * **Score-Spalte nach Version:** Die farbige Bewertung steht direkt vor dem EN-Text

--- a/tests/gptService.test.js
+++ b/tests/gptService.test.js
@@ -63,4 +63,5 @@ test('applyEvaluationResults überträgt Score und Kommentar', () => {
   expect(files[0].score).toBe(55);
   expect(files[0].comment).toBe('ok');
   expect(files[0].suggestion).toBe('neu');
+  expect(files[1].score).toBeUndefined();
 });

--- a/tests/scoreColumn.test.js
+++ b/tests/scoreColumn.test.js
@@ -1,0 +1,17 @@
+const { scoreCellTemplate } = require('../web/src/scoreColumn.js');
+
+test('scoreCellTemplate erstellt farbige Zelle mit Tooltip', () => {
+  const file = { score: 80, comment: 'gut', suggestion: 'neu' };
+  const html = scoreCellTemplate(file, t => t);
+  expect(html).toContain('class="score-cell score-high"');
+  expect(html).toContain('data-suggestion="neu"');
+  expect(html).toContain('data-comment="gut"');
+  expect(html).toContain('title="gut - neu"');
+  expect(html).toContain('>80<');
+});
+
+test('scoreCellTemplate nutzt Defaultwerte', () => {
+  const html = scoreCellTemplate({}, t => t);
+  expect(html).toContain('class="score-cell score-none"');
+  expect(html).toContain('>0<');
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2555,7 +2555,9 @@ return `
             ${hasDeAudio ? `<span class="version-badge" style="background:${getVersionColor(file.version ?? 1)}" onclick="openVersionMenu(event, ${file.id})">${file.version ?? 1}</span>` : ''}
         </td>
         ${scoreCellTemplate(file, escapeHtml)}
-        <td><div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
+        <td>
+        <div class="de-suggestion ${getSuggestionClass(file)}" data-file-id="${file.id}">${escapeHtml(file.suggestion || '')}</div>
+        <div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
             <textarea class="text-input"
                  onchange="updateText(${file.id}, 'en', this.value)"
                  oninput="autoResizeInput(this)">${escapeHtml(file.enText)}</textarea>
@@ -2564,7 +2566,8 @@ return `
                 <button class="play-btn" onclick="playAudio(${file.id})">▶</button>
             </div>
         </div></td>
-        <td><div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
+        <td>
+        <div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
             <textarea class="text-input"
                  onchange="updateText(${file.id}, 'de', this.value)"
                  oninput="autoResizeInput(this)">${escapeHtml(file.deText)}</textarea>
@@ -11224,6 +11227,16 @@ function showChapterCustomization(chapterName, ev) {
         // Hilfsfunktion für RegExp-Erstellung
         function escapeRegExp(str) {
             return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        }
+
+        // Liefert eine CSS-Klasse für die Vorschlagsfarbe
+        function getSuggestionClass(file) {
+            const sc = Number(file.score);
+            if (!file.suggestion) return 'de-suggestion empty';
+            if (!Number.isFinite(sc)) return 'de-suggestion sug-none';
+            if (sc >= 70) return 'de-suggestion sug-high';
+            if (sc >= 40) return 'de-suggestion sug-medium';
+            return 'de-suggestion sug-low';
         }
 
         // Prüft, ob ein Wort aus dem Wörterbuch im angegebenen Text vorkommt

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -1,5 +1,5 @@
 // Erzeugt den HTML-Code für eine Score-Zelle und bindet Tooltip sowie Klick
-export function scoreCellTemplate(file, escapeHtml) {
+function scoreCellTemplate(file, escapeHtml) {
     const noScore = file.score === undefined || file.score === null;
     const cls = noScore
         ? 'score-none'
@@ -15,7 +15,7 @@ export function scoreCellTemplate(file, escapeHtml) {
     return `<td class="score-cell ${cls}" data-suggestion="${sug}" data-comment="${com}" title="${title}">${scoreText}</td>`;
 }
 
-export function attachScoreHandlers(tbody, files) {
+function attachScoreHandlers(tbody, files) {
     tbody.querySelectorAll('.score-cell').forEach(cell => {
         const id = Number(cell.parentElement?.dataset.id);
         const suggestion = cell.dataset.suggestion;
@@ -30,7 +30,7 @@ export function attachScoreHandlers(tbody, files) {
 }
 
 // Tooltip anzeigen
-export function openScoreTooltip(ev, text) {
+function openScoreTooltip(ev, text) {
     closeScoreTooltip();
     if (!text) return;
     const box = document.createElement('div');
@@ -42,7 +42,7 @@ export function openScoreTooltip(ev, text) {
     document.body.appendChild(box);
 }
 
-export function closeScoreTooltip() {
+function closeScoreTooltip() {
     const box = document.getElementById('scoreTooltip');
     if (box) box.remove();
 }
@@ -51,6 +51,7 @@ function applySuggestion(id, files) {
     const file = files.find(f => f.id === id);
     if (!file || !file.suggestion) return;
     file.deText = file.suggestion;
+    file.suggestion = '';
     window.isDirty = true;
     const row = document.querySelector(`tr[data-id='${id}']`);
     const deCell = row?.querySelectorAll('textarea.text-input')[1];
@@ -59,4 +60,18 @@ function applySuggestion(id, files) {
         deCell.classList.add('blink-blue');
         setTimeout(() => deCell.classList.remove('blink-blue'), 600);
     }
+    const sugBox = row?.querySelector('.de-suggestion');
+    if (sugBox) {
+        sugBox.textContent = '';
+        sugBox.className = 'de-suggestion empty';
+    }
+}
+
+// Exporte für Node und Browser
+if (typeof module !== 'undefined') {
+    module.exports = { scoreCellTemplate, attachScoreHandlers };
+}
+if (typeof window !== 'undefined') {
+    window.scoreCellTemplate = scoreCellTemplate;
+    window.attachScoreHandlers = attachScoreHandlers;
 }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2790,6 +2790,21 @@ th:nth-child(10) {
     background: #3A3;
 }
 
+/* Vorschläge über dem DE-Text */
+.de-suggestion {
+    font-size: 12px;
+    margin-bottom: 2px;
+    padding: 2px 4px;
+    border-radius: 4px;
+    display: inline-block;
+}
+
+.de-suggestion.empty { display: none; }
+.sug-none { background: #666; color: #ccc; }
+.sug-low { background: #A33; color: #fff; }
+.sug-medium { background: #BB8; color: #000; }
+.sug-high { background: #3A3; color: #fff; }
+
 /* Blauer Blinkeffekt bei übernommener Übersetzung */
 .blink-blue {
     animation: blinkBlue 0.6s;


### PR DESCRIPTION
## Summary
- erweitere GPT-Bewertung: Vorschläge erscheinen farbig über dem DE-Text
- neue Hilfsfunktion `getSuggestionClass`
- Score-Spalte erhält eine Testdatei und zusätzlicher Check
- kleine Anpassungen am README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68610e344ba483279760f4dcf9e4fc04