### PR TITLE
Fix Scoreanzeige mit Tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Eigenes Wörterbuch:** Ein neuer 📚-Knopf speichert englische Wörter zusammen mit deutscher Lautschrift.
 * **Hinweis-Symbol bei Übersetzungen:** Unter der Lupe erscheint ein kleines 📝, wenn der DE-Text ein Wort aus dem Wörterbuch enthält.
 * **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren zeigt ein Tooltip Kommentar und Vorschlag, ein Klick ersetzt den DE-Text und blinkt kurz blau auf
+* **GPT-Vorschläge über dem DE-Text:** Nach einer Bewertung wird ein farbig hinterlegter Vorschlag oberhalb des deutschen Textes angezeigt
 * **Debug-Ausgabe für GPT:** Ist der Debug-Modus aktiv, erscheinen gesendete Daten und Antworten der GPT-API in der Konsole
 * **GPT-Konsole:** Beim Klick auf "Bewerten (GPT)" öffnet sich ein Fenster mit einem Log aller gesendeten Prompts und Antworten
 * **Prompt-Vorschau:** Vor dem eigentlichen Versand zeigt ein Dialog den kompletten Prompt an. Erst nach Klick auf "Senden" wird die Anfrage gestellt und die Antwort im selben Fenster angezeigt

--- a/tests/scoreColumn.test.js
+++ b/tests/scoreColumn.test.js
@@ -1,0 +1,16 @@
+const { scoreCellTemplate, getScoreClass } = require('../web/src/scoreColumn.js');
+
+test('getScoreClass liefert richtige Klassen', () => {
+  expect(getScoreClass(80)).toBe('score-high');
+  expect(getScoreClass(50)).toBe('score-medium');
+  expect(getScoreClass(20)).toBe('score-low');
+  expect(getScoreClass(undefined)).toBe('score-none');
+});
+
+test('scoreCellTemplate erzeugt korrekte HTML-Attribute', () => {
+  const html = scoreCellTemplate({ score: 75, comment: 'gut', suggestion: 'neu' }, s => s);
+  expect(html).toContain('score-high');
+  expect(html).toContain('data-comment="gut"');
+  expect(html).toContain('data-suggestion="neu"');
+  expect(html).toContain('>75<');
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -195,7 +195,7 @@ let pathUtilsPromise;
 let evaluateScene;
 let applyEvaluationResults;
 let scoreVisibleLines;
-let scoreCellTemplate, attachScoreHandlers;
+let scoreCellTemplate, attachScoreHandlers, getScoreClass;
 // Platzhalter für Dubbing-Funktionen
 let showDubbingSettings, createDubbingCSV, validateCsv, msToSeconds, isDubReady,
     startDubbing, redownloadDubbing, openDubbingPage, openLocalFile,
@@ -228,6 +228,7 @@ if (typeof module !== 'undefined' && module.exports) {
     import('./scoreColumn.js').then(mod => {
         scoreCellTemplate = mod.scoreCellTemplate;
         attachScoreHandlers = mod.attachScoreHandlers;
+        getScoreClass = mod.getScoreClass;
     }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; });
     import('./actions/projectEvaluate.js').then(mod => {
         applyEvaluationResults = mod.applyEvaluationResults;
@@ -270,6 +271,7 @@ if (typeof module !== 'undefined' && module.exports) {
     import('./scoreColumn.js').then(mod => {
         scoreCellTemplate = mod.scoreCellTemplate;
         attachScoreHandlers = mod.attachScoreHandlers;
+        getScoreClass = mod.getScoreClass;
     }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; });
     import('./actions/projectEvaluate.js').then(mod => {
         applyEvaluationResults = mod.applyEvaluationResults;
@@ -2564,7 +2566,8 @@ return `
                 <button class="play-btn" onclick="playAudio(${file.id})">▶</button>
             </div>
         </div></td>
-        <td><div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
+        <td><div class="gpt-suggestion ${getScoreClass ? getScoreClass(file.score).replace('score-', 'suggestion-') : ''}" data-file-id="${file.id}">${escapeHtml(file.suggestion || '')}</div>
+        <div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
             <textarea class="text-input"
                  onchange="updateText(${file.id}, 'de', this.value)"
                  oninput="autoResizeInput(this)">${escapeHtml(file.deText)}</textarea>
@@ -2618,7 +2621,10 @@ return `
     // Nach dem Rendern Textfelder und Übersetzungsanzeige anpassen
     setTimeout(() => {
         resizeTextFields();
-        sortedFiles.forEach(f => updateTranslationDisplay(f.id));
+        sortedFiles.forEach(f => {
+            updateTranslationDisplay(f.id);
+            updateSuggestionDisplay(f.id);
+        });
     }, 50);
 }
 // =========================== RENDER FILE TABLE WITH ORDER END ===========================
@@ -3724,6 +3730,16 @@ function updateTranslationDisplay(fileId) {
     const file = files.find(f => f.id === fileId);
     if (div && file) {
         div.textContent = file.autoTranslation || '';
+    }
+}
+
+function updateSuggestionDisplay(fileId) {
+    const div = document.querySelector(`.gpt-suggestion[data-file-id="${fileId}"]`);
+    const file = files.find(f => f.id === fileId);
+    if (div && file && typeof getScoreClass === 'function') {
+        const base = getScoreClass(file.score).replace('score-', 'suggestion-');
+        div.className = `gpt-suggestion ${base}`;
+        div.textContent = file.suggestion || '';
     }
 }
 

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -1,21 +1,22 @@
 // Erzeugt den HTML-Code für eine Score-Zelle und bindet Tooltip sowie Klick
-export function scoreCellTemplate(file, escapeHtml) {
-    const noScore = file.score === undefined || file.score === null;
-    const cls = noScore
-        ? 'score-none'
-        : file.score >= 70
-            ? 'score-high'
-            : file.score >= 40
-                ? 'score-medium'
-                : 'score-low';
+// Gibt die passende CSS-Klasse anhand des Scores zurück
+function getScoreClass(score) {
+    if (score === undefined || score === null) return 'score-none';
+    if (score >= 70) return 'score-high';
+    if (score >= 40) return 'score-medium';
+    return 'score-low';
+}
+
+function scoreCellTemplate(file, escapeHtml) {
+    const cls = getScoreClass(file.score);
     const sug = escapeHtml(file.suggestion || '');
     const com = escapeHtml(file.comment || '');
     const title = escapeHtml([file.comment, file.suggestion].filter(Boolean).join(' - '));
-    const scoreText = noScore ? '0' : file.score;
+    const scoreText = file.score === undefined || file.score === null ? '0' : file.score;
     return `<td class="score-cell ${cls}" data-suggestion="${sug}" data-comment="${com}" title="${title}">${scoreText}</td>`;
 }
 
-export function attachScoreHandlers(tbody, files) {
+function attachScoreHandlers(tbody, files) {
     tbody.querySelectorAll('.score-cell').forEach(cell => {
         const id = Number(cell.parentElement?.dataset.id);
         const suggestion = cell.dataset.suggestion;
@@ -30,7 +31,7 @@ export function attachScoreHandlers(tbody, files) {
 }
 
 // Tooltip anzeigen
-export function openScoreTooltip(ev, text) {
+function openScoreTooltip(ev, text) {
     closeScoreTooltip();
     if (!text) return;
     const box = document.createElement('div');
@@ -42,7 +43,7 @@ export function openScoreTooltip(ev, text) {
     document.body.appendChild(box);
 }
 
-export function closeScoreTooltip() {
+function closeScoreTooltip() {
     const box = document.getElementById('scoreTooltip');
     if (box) box.remove();
 }
@@ -51,6 +52,8 @@ function applySuggestion(id, files) {
     const file = files.find(f => f.id === id);
     if (!file || !file.suggestion) return;
     file.deText = file.suggestion;
+    // Vorschlag nach Übernahme entfernen
+    file.suggestion = '';
     window.isDirty = true;
     const row = document.querySelector(`tr[data-id='${id}']`);
     const deCell = row?.querySelectorAll('textarea.text-input')[1];
@@ -59,4 +62,20 @@ function applySuggestion(id, files) {
         deCell.classList.add('blink-blue');
         setTimeout(() => deCell.classList.remove('blink-blue'), 600);
     }
+    const sugDiv = row?.querySelector('.gpt-suggestion');
+    if (sugDiv) sugDiv.textContent = '';
+}
+
+// Kompatibilität für CommonJS und Browser
+if (typeof module !== 'undefined') {
+    module.exports = {
+        scoreCellTemplate,
+        attachScoreHandlers,
+        getScoreClass
+    };
+}
+if (typeof window !== 'undefined') {
+    window.scoreCellTemplate = scoreCellTemplate;
+    window.attachScoreHandlers = attachScoreHandlers;
+    window.getScoreClass = getScoreClass;
 }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2790,6 +2790,19 @@ th:nth-child(10) {
     background: #3A3;
 }
 
+/* GPT-Vorschläge über dem DE-Text */
+.gpt-suggestion {
+    font-size: 12px;
+    margin-bottom: 2px;
+    padding: 2px 4px;
+    border-radius: 3px;
+    color: #fff;
+}
+.suggestion-none { background: #666; color: #ccc; }
+.suggestion-low { background: #A33; }
+.suggestion-medium { background: #BB8; color: #000; }
+.suggestion-high { background: #3A3; }
+
 /* Blauer Blinkeffekt bei übernommener Übersetzung */
 .blink-blue {
     animation: blinkBlue 0.6s;


### PR DESCRIPTION
## Summary
- implementiere getScoreClass und verbessere Scorecell-Rendere
- zeige GPT-Vorschläge farbig über dem DE-Text an
- füge CSS für Vorschläge hinzu
- erweitere Tests für scoreColumn
- README um neue Funktion ergänzt

## Testing
- `npm test --silent 2>&1 | grep -E "PASS|FAIL" | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6861117e2bac8327b84feac78e467745