### PR TITLE
Add GPT suggestion preview with auto-apply option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Bugfix:** Scores werden korrekt eingefügt, auch wenn ID und Score als Zeichenketten geliefert werden
 * **Eigenständige Score-Komponente:** Tooltip und Klick sind in `web/src/scoreColumn.js` gekapselt
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
+* **Automatische Übernahme von GPT-Vorschlägen:** Eine neue Option setzt empfohlene Texte sofort in das DE-Feld
 * **Einfüge-Knopf versteht JSON:** Manuell in den GPT-Test kopierte Antworten können direkt übernommen werden
 * **Schlanker Video-Bereich:** Gespeicherte Links öffnen sich im Browser. Interner Player und OCR wurden entfernt.
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.

--- a/web/src/actions/projectEvaluate.js
+++ b/web/src/actions/projectEvaluate.js
@@ -1,13 +1,18 @@
 // Sammele sichtbare Zeilen, rufe den GPT-Service auf und aktualisiere die Tabelle
 // GPT-Service importieren – je nach Umgebung
 let evaluateScene;
+let autoApplySuggestion = false;
 if (typeof require !== 'undefined') {
     try {
         ({ evaluateScene } = require('../gptService.js'));
+        ({ autoApplySuggestion } = require('../main.js'));
     } catch {}
 }
 if (typeof window !== 'undefined' && window.evaluateScene) {
     evaluateScene = window.evaluateScene;
+}
+if (typeof window !== 'undefined' && window.autoApplySuggestion !== undefined) {
+    autoApplySuggestion = window.autoApplySuggestion;
 }
 
 // Überträgt die GPT-Ergebnisse in die Dateiliste
@@ -23,6 +28,9 @@ function applyEvaluationResults(results, files) {
             f.comment = r.comment || '';
             // Vorschlag separat speichern
             f.suggestion = r.suggestion || '';
+            if (autoApplySuggestion) {
+                f.deText = f.suggestion;
+            }
         }
     }
 }
@@ -64,7 +72,7 @@ async function scoreVisibleLines(opts) {
         results = await evaluateScene({ scene, lines, key: apiKey, model: gptModel });
     } catch (e) {
         if (showErrorBanner) {
-            showErrorBanner(String(e), () => scoreVisibleLines(opts));
+            showErrorBanner(String(e), () => scoreVisibleLines({ ...opts, autoApplySuggestion }));
         }
         return;
     }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2802,6 +2802,17 @@ th:nth-child(10) {
     color: #fff;
 }
 
+/* Vorschau des GPT-Vorschlags oberhalb des Textfelds */
+.suggestion-preview {
+    font-style: italic;
+    color: #999;
+    margin-bottom: 4px;
+    cursor: pointer;
+}
+.suggestion-preview:hover {
+    text-decoration: underline;
+}
+
 /* Blauer Blinkeffekt bei übernommener Übersetzung */
 .blink-blue {
     animation: blinkBlue 0.6s;


### PR DESCRIPTION
## Summary
- add global `autoApplySuggestion` setting
- insert checkbox for automatically applying GPT suggestions
- export and use the setting inside project evaluation
- show suggestion preview above DE text and allow clicking to copy
- style suggestion preview in italics
- document the new feature

## Testing
- `npm test` *(fails: ENOENT unlink temp.mp3)*

------
https://chatgpt.com/codex/tasks/task_e_686131b4f5e88327b2d2821009320fc5