### PR TITLE
Fix GPT score insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Robuste GPT-Antworten:** Entfernt ```json-Blöcke``` automatisch und verhindert so Parsefehler
 * **Charaktername im GPT-Prompt:** Das Feld `character` nutzt nun den Ordnernamen
 * **Bugfix:** Scores werden korrekt eingefügt, auch wenn ID und Score als Zeichenketten geliefert werden
+* **Bugfix:** GPT-Bewertungen funktionieren jetzt auch bei Dezimal-IDs
 * **Eigenständige Score-Komponente:** Tooltip und Klick sind in `web/src/scoreColumn.js` gekapselt
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
 * **Automatische Übernahme von GPT-Vorschlägen:** Eine neue Option setzt empfohlene Texte sofort in das DE-Feld

--- a/tests/gptService.test.js
+++ b/tests/gptService.test.js
@@ -65,6 +65,14 @@ test('applyEvaluationResults überträgt Score und Kommentar', () => {
   expect(files[0].suggestion).toBe('neu');
 });
 
+test('applyEvaluationResults findet dezimale IDs', () => {
+  const { applyEvaluationResults } = require('../web/src/actions/projectEvaluate.js');
+  const files = [{ id: 1234.56 }];
+  const results = [{ id: '1234.56', score: 99, comment: 'gut', suggestion: 'ja' }];
+  applyEvaluationResults(results, files);
+  expect(files[0].score).toBe(99);
+});
+
 test('parseEvaluationResults liefert Array oder null', () => {
   const { parseEvaluationResults } = require('../web/src/actions/projectEvaluate.js');
   const valid = '[{"id":1}]';

--- a/web/src/actions/projectEvaluate.js
+++ b/web/src/actions/projectEvaluate.js
@@ -19,8 +19,8 @@ if (typeof window !== 'undefined' && window.autoApplySuggestion !== undefined) {
 function applyEvaluationResults(results, files) {
     if (!Array.isArray(results)) return;
     for (const r of results) {
-        const id = Number(r.id);
-        const f = files.find(fl => fl.id === id);
+        const id = String(r.id);
+        const f = files.find(fl => String(fl.id) === id);
         if (f) {
             // Score in Zahl umwandeln, sonst 0
             const sc = Number(r.score);


### PR DESCRIPTION
## Summary
- compare IDs as strings when applying GPT scores
- add regression test for decimal IDs
- mention fix in README

## Testing
- `npm test` *(fails: ENOENT or truncated)*

------
https://chatgpt.com/codex/tasks/task_e_68613571ae9c83278862b76ffb7b9926