### PR TITLE
Add summary column to GPT test dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
 * **Automatische Übernahme von GPT-Vorschlägen:** Eine neue Option setzt empfohlene Texte sofort in das DE-Feld
 * **Einfüge-Knopf versteht JSON:** Manuell in den GPT-Test kopierte Antworten können direkt übernommen werden
+* **Dritte Spalte im GPT-Test:** Rechts erscheint eine Übersicht mit Dateiname, Ordner, Bewertung, Vorschlag und Kommentar
 * **Schlanker Video-Bereich:** Gespeicherte Links öffnen sich im Browser. Interner Player und OCR wurden entfernt.
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.
 * **Löschen per Desktop-API:** Einzelne Bookmarks lassen sich über einen IPC-Kanal entfernen.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -467,6 +467,7 @@
             <div class="prompt-result-container">
                 <textarea id="gptPromptArea" readonly></textarea>
                 <textarea id="gptResultArea" readonly></textarea>
+                <textarea id="gptSummaryArea" readonly></textarea>
             </div>
             <div class="dialog-buttons">
                 <button class="btn btn-secondary" onclick="closeGptPromptDialog()">Schließen</button>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -354,6 +354,8 @@ function showGptPromptDialog() {
     area.value = promptText;
     const resultArea = document.getElementById('gptResultArea');
     if (resultArea) resultArea.value = '';
+    const summaryArea = document.getElementById('gptSummaryArea');
+    if (summaryArea) summaryArea.value = '';
     // Einfüge-Knopf deaktivieren und alte Ergebnisse löschen
     gptEvaluationResults = null;
     const insertBtn = document.getElementById('gptPromptInsert');
@@ -381,6 +383,7 @@ async function sendGptPrompt() {
         });
         resultArea.value = JSON.stringify(results, null, 2);
         gptEvaluationResults = results;
+        updateGptSummary(results);
         const insertBtn = document.getElementById('gptPromptInsert');
         if (insertBtn) insertBtn.disabled = false;
     } catch (e) {
@@ -409,6 +412,24 @@ async function insertGptResults() {
         saveCurrentProject();
     }
     closeGptPromptDialog();
+}
+
+// Erstellt eine Übersicht der GPT-Ergebnisse
+function updateGptSummary(results) {
+    const area = document.getElementById('gptSummaryArea');
+    if (!area || !Array.isArray(results)) { if (area) area.value = ''; return; }
+    const lines = results.map(r => {
+        const idNum = Number(r.id);
+        let f = files.find(fl => fl.id === idNum);
+        if (!f) f = files.find(fl => String(fl.id) === String(r.id));
+        const name = f?.name || '';
+        const folder = f?.folder || '';
+        const score = r.score ?? '';
+        const suggestion = (r.suggestion || '').replace(/\n/g, ' ');
+        const comment = (r.comment || '').replace(/\n/g, ' ');
+        return `${name}\t${folder}\t${score}\t${suggestion}\t${comment}`;
+    });
+    area.value = lines.join('\n');
 }
 
 // Bewertet aktuell sichtbare Zeilen über ChatGPT

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2852,8 +2852,11 @@ th:nth-child(10) {
     gap: 10px;
 }
 .gpt-test-dialog textarea {
-    width: 50%;
+    flex: 1;
     min-height: 300px;
+}
+#gptSummaryArea {
+    font-family: monospace;
 }
 
 /* Fehlerbanner bei API-Problemen */


### PR DESCRIPTION
## Summary
- show third textarea in GPT-Test dialog
- style GPT dialog for three equal columns
- display formatted GPT results in the new column
- document the new feature in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861399e33dc83279a09b3e4c941c0ab