### PR TITLE
Verbesserte GPT-Test Tabelle

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
 * **Automatische Übernahme von GPT-Vorschlägen:** Eine neue Option setzt empfohlene Texte sofort in das DE-Feld
 * **Einfüge-Knopf versteht JSON:** Manuell in den GPT-Test kopierte Antworten können direkt übernommen werden
-* **Dritte Spalte im GPT-Test:** Rechts erscheint eine Übersicht mit Dateiname, Ordner, Bewertung, Vorschlag und Kommentar
+* **Dritte Spalte im GPT-Test als Tabelle:** Rechts zeigt jetzt eine übersichtliche Tabelle mit ID, Dateiname, Ordner, Bewertung, Vorschlag und Kommentar alle Ergebnisse an
 * **Schlanker Video-Bereich:** Gespeicherte Links öffnen sich im Browser. Interner Player und OCR wurden entfernt.
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.
 * **Löschen per Desktop-API:** Einzelne Bookmarks lassen sich über einen IPC-Kanal entfernen.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -467,7 +467,21 @@
             <div class="prompt-result-container">
                 <textarea id="gptPromptArea" readonly></textarea>
                 <textarea id="gptResultArea" readonly></textarea>
-                <textarea id="gptSummaryArea" readonly></textarea>
+                <div class="summary-table-wrapper">
+                    <table id="gptSummaryTable">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Datei</th>
+                                <th>Ordner</th>
+                                <th>Bewertung</th>
+                                <th>Vorschlag</th>
+                                <th>Kommentar</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
             </div>
             <div class="dialog-buttons">
                 <button class="btn btn-secondary" onclick="closeGptPromptDialog()">Schließen</button>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -354,8 +354,8 @@ function showGptPromptDialog() {
     area.value = promptText;
     const resultArea = document.getElementById('gptResultArea');
     if (resultArea) resultArea.value = '';
-    const summaryArea = document.getElementById('gptSummaryArea');
-    if (summaryArea) summaryArea.value = '';
+    const summaryBody = document.querySelector('#gptSummaryTable tbody');
+    if (summaryBody) summaryBody.innerHTML = '';
     // Einfüge-Knopf deaktivieren und alte Ergebnisse löschen
     gptEvaluationResults = null;
     const insertBtn = document.getElementById('gptPromptInsert');
@@ -416,9 +416,11 @@ async function insertGptResults() {
 
 // Erstellt eine Übersicht der GPT-Ergebnisse
 function updateGptSummary(results) {
-    const area = document.getElementById('gptSummaryArea');
-    if (!area || !Array.isArray(results)) { if (area) area.value = ''; return; }
-    const lines = results.map(r => {
+    const body = document.querySelector('#gptSummaryTable tbody');
+    if (!body || !Array.isArray(results)) { if (body) body.innerHTML = ''; return; }
+    // Tabelle leeren
+    body.innerHTML = '';
+    for (const r of results) {
         const idNum = Number(r.id);
         let f = files.find(fl => fl.id === idNum);
         if (!f) f = files.find(fl => String(fl.id) === String(r.id));
@@ -427,9 +429,16 @@ function updateGptSummary(results) {
         const score = r.score ?? '';
         const suggestion = (r.suggestion || '').replace(/\n/g, ' ');
         const comment = (r.comment || '').replace(/\n/g, ' ');
-        return `${name}\t${folder}\t${score}\t${suggestion}\t${comment}`;
-    });
-    area.value = lines.join('\n');
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>${r.id}</td>
+            <td>${name}</td>
+            <td>${folder}</td>
+            <td>${score}</td>
+            <td>${suggestion}</td>
+            <td>${comment}</td>`;
+        body.appendChild(tr);
+    }
 }
 
 // Bewertet aktuell sichtbare Zeilen über ChatGPT

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2855,8 +2855,25 @@ th:nth-child(10) {
     flex: 1;
     min-height: 300px;
 }
-#gptSummaryArea {
+.summary-table-wrapper {
+    flex: 1;
+    overflow: auto;
+}
+#gptSummaryTable {
+    width: 100%;
+    border-collapse: collapse;
     font-family: monospace;
+}
+#gptSummaryTable th,
+#gptSummaryTable td {
+    border: 1px solid #444;
+    padding: 4px;
+}
+#gptSummaryTable th {
+    background: #2a2a2a;
+    color: #ff6b1a;
+    position: sticky;
+    top: 0;
 }
 
 /* Fehlerbanner bei API-Problemen */


### PR DESCRIPTION
## Zusammenfassung
- GPT-Testergebnisse werden rechts nun in einer echten Tabelle angezeigt
- Tabellendarstellung in HTML, JS und CSS integriert
- README aktualisiert

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68613b783a548327b3c8e16f001ab326