### PR TITLE
Implement gespeicherte GPT-Tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Einfüge-Knopf versteht JSON:** Manuell in den GPT-Test kopierte Antworten können direkt übernommen werden
 * **Dritte Spalte im GPT-Test als Tabelle:** Rechts zeigt jetzt eine übersichtliche Tabelle mit ID, Dateiname, Ordner, Bewertung, Vorschlag und Kommentar alle Ergebnisse an
 * **Speicherfunktion für GPT-Test:** Jeder Versand erzeugt einen neuen Tab mit Prompt, Antwort und Tabelle. Tabs lassen sich wechseln und löschen.
+* **GPT-Tabs pro Projekt:** Geöffnete Tests bleiben gespeichert und erscheinen beim nächsten Öffnen wieder.
 * **Schlanker Video-Bereich:** Gespeicherte Links öffnen sich im Browser. Interner Player und OCR wurden entfernt.
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.
 * **Löschen per Desktop-API:** Einzelne Bookmarks lassen sich über einen IPC-Kanal entfernen.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -396,6 +396,7 @@ async function sendGptPrompt() {
                 summary: results
             });
             currentProject.gptTabIndex = currentProject.gptTests.length - 1;
+            isDirty = true; // Änderungen merken, damit Tabs gespeichert werden
             saveCurrentProject();
             renderGptTestTabs();
         }
@@ -481,6 +482,8 @@ function selectGptTestTab(index) {
     const test = currentProject.gptTests[index];
     if (!test) return;
     currentProject.gptTabIndex = index;
+    isDirty = true; // Aktive Tab-Position speichern
+    saveCurrentProject();
     const area = document.getElementById('gptPromptArea');
     const res  = document.getElementById('gptResultArea');
     if (area) area.value = test.prompt || '';
@@ -497,6 +500,7 @@ function deleteGptTestTab(index) {
     if (currentProject.gptTabIndex >= currentProject.gptTests.length) {
         currentProject.gptTabIndex = currentProject.gptTests.length - 1;
     }
+    isDirty = true; // Tab-Liste wurde geändert
     saveCurrentProject();
     renderGptTestTabs();
     if (currentProject.gptTabIndex >= 0) {


### PR DESCRIPTION
## Summary
- Tabs im GPT-Test werden nun bei jeder Änderung als projektspezifische Daten gespeichert
- Auswahl eines Tabs merkt sich den aktiven Index
- README um Hinweis auf dauerhaft gespeicherte GPT-Tabs erweitert

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68613f9619c883279dda15c57e344430