### PR TITLE
Implement gespeicherte GPT-Tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Einfüge-Knopf versteht JSON:** Manuell in den GPT-Test kopierte Antworten können direkt übernommen werden
 * **Dritte Spalte im GPT-Test als Tabelle:** Rechts zeigt jetzt eine übersichtliche Tabelle mit ID, Dateiname, Ordner, Bewertung, Vorschlag und Kommentar alle Ergebnisse an
 * **Speicherfunktion für GPT-Test:** Jeder Versand erzeugt einen neuen Tab mit Prompt, Antwort und Tabelle. Tabs lassen sich wechseln und löschen.
+* **GPT-Tabs pro Projekt:** Geöffnete Tests bleiben gespeichert und erscheinen beim nächsten Öffnen wieder.
+* **GPT-Knopf direkt neben der Suche:** Ein Klick öffnet die gespeicherten GPT-Tabs des aktuellen Projekts.
 * **Schlanker Video-Bereich:** Gespeicherte Links öffnen sich im Browser. Interner Player und OCR wurden entfernt.
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.
 * **Löschen per Desktop-API:** Einzelne Bookmarks lassen sich über einen IPC-Kanal entfernen.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -86,7 +86,6 @@
                     </label>
                     <input type="text" id="mapSelect" placeholder="Level" style="width:140px">
                     <button id="startButton" class="btn btn-secondary" onclick="startHla()">Starten</button>
-                    <button id="gptScoreButton" class="btn btn-secondary">Bewerten (GPT)</button>
                 </div>
             </div>
 			
@@ -108,6 +107,7 @@
                 <div class="search-container">
                     <input type="text" class="search-input" placeholder="Live-Suche: Dateiname oder Text... (Groß-/Kleinschreibung, Punkte ignoriert)" id="searchInput">
                     <div class="search-results" id="searchResults"></div>
+                    <button id="gptScoreButton" class="btn btn-secondary">Bewerten (GPT)</button>
                 </div>
                 <div class="sort-controls">
                     <span style="color: #999;">Sortierung:</span>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -303,8 +303,24 @@ function cleanupDubCache() {
 if (typeof document !== "undefined" && typeof document.getElementById === "function") {
     const gptBtn = document.getElementById("gptScoreButton");
     if (gptBtn) {
-        gptBtn.addEventListener("click", showGptStartDialog);
+        gptBtn.addEventListener("click", () => {
+            if (currentProject?.gptTests?.length) {
+                openSavedGptTests();
+            } else {
+                showGptStartDialog();
+            }
+        });
     }
+}
+
+// Öffnet die gespeicherten GPT-Tabs ohne neue Bewertung
+function openSavedGptTests() {
+    renderGptTestTabs();
+    if (currentProject && currentProject.gptTests?.length) {
+        const idx = currentProject.gptTabIndex ?? 0;
+        selectGptTestTab(Math.min(idx, currentProject.gptTests.length - 1));
+    }
+    document.getElementById('gptPromptDialog').classList.remove('hidden');
 }
 
 // Öffnet einen Dialog mit Zeilenzahl und Sprechern
@@ -396,6 +412,7 @@ async function sendGptPrompt() {
                 summary: results
             });
             currentProject.gptTabIndex = currentProject.gptTests.length - 1;
+            isDirty = true; // Änderungen merken, damit Tabs gespeichert werden
             saveCurrentProject();
             renderGptTestTabs();
         }
@@ -481,6 +498,8 @@ function selectGptTestTab(index) {
     const test = currentProject.gptTests[index];
     if (!test) return;
     currentProject.gptTabIndex = index;
+    isDirty = true; // Aktive Tab-Position speichern
+    saveCurrentProject();
     const area = document.getElementById('gptPromptArea');
     const res  = document.getElementById('gptResultArea');
     if (area) area.value = test.prompt || '';
@@ -497,6 +516,7 @@ function deleteGptTestTab(index) {
     if (currentProject.gptTabIndex >= currentProject.gptTests.length) {
         currentProject.gptTabIndex = currentProject.gptTests.length - 1;
     }
+    isDirty = true; // Tab-Liste wurde geändert
     saveCurrentProject();
     renderGptTestTabs();
     if (currentProject.gptTabIndex >= 0) {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -461,9 +461,9 @@ th:nth-child(10) {
             align-items: center;
         }
 
-        /* GPT-Knopf weiter rechts platzieren */
+        /* GPT-Knopf neben der Suche */
         #gptScoreButton {
-            margin-left: auto;
+            margin-left: 10px;
         }
 
 .video-launch {


### PR DESCRIPTION
## Summary
- GPT-Button wandert neben die Live-Suche und öffnet vorhandene Bewertungstabs
- Neuer Helfer `openSavedGptTests()` zeigt gespeicherte GPT-Ergebnisse sofort an
- CSS angepasst, damit der Knopf neben der Suche steht
- README um Hinweis auf den neuen Button ergänzt

## Testing
- `node --unhandled-rejections=warn node_modules/jest/bin/jest.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68613f9619c883279dda15c57e344430