### PR TITLE
Zeige GPT-Score je Projekt

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Robustere Zuordnung:** GPT-Ergebnisse finden jetzt auch dann die richtige Zeile, wenn die ID leicht abweicht
 * **Eigenständige Score-Komponente:** Tooltip und Klick sind in `web/src/scoreColumn.js` gekapselt
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
+* **Durchschnittlicher GPT-Score pro Projekt:** Die Projektübersicht zeigt nun den Mittelwert aller Bewertungen an
 * **Automatische Übernahme von GPT-Vorschlägen:** Eine neue Option setzt empfohlene Texte sofort in das DE-Feld
 * **Einfüge-Knopf versteht JSON:** Manuell in den GPT-Test kopierte Antworten können direkt übernommen werden
 * **Dritte Spalte im GPT-Test als Tabelle:** Rechts zeigt jetzt eine übersichtliche Tabelle mit ID, Dateiname, Ordner, Bewertung, Vorschlag und Kommentar alle Ergebnisse an

--- a/calculateProjectStats.js
+++ b/calculateProjectStats.js
@@ -9,7 +9,8 @@ function calculateProjectStats(project) {
             dePercent: 0,
             deAudioPercent: 0,
             completedPercent: 0,
-            totalFiles: 0
+            totalFiles: 0,
+            scoreAvg: 0
         };
     }
 
@@ -17,13 +18,21 @@ function calculateProjectStats(project) {
     const filesWithDE = files.filter(f => f.deText && f.deText.trim().length > 0).length;
     const filesCompleted = files.filter(isFileCompleted).length;
     const filesWithDeAudio = files.filter(f => getDeFilePath(f)).length;
+    // Durchschnittliche GPT-Bewertung ermitteln
+    const validScores = files
+        .map(f => Number(f.score))
+        .filter(n => Number.isFinite(n));
+    const avgScore = validScores.length
+        ? Math.round(validScores.reduce((a, b) => a + b, 0) / validScores.length)
+        : 0;
 
     return {
         enPercent: Math.round((filesWithEN / totalFiles) * 100),
         dePercent: Math.round((filesWithDE / totalFiles) * 100),
         deAudioPercent: Math.round((filesWithDeAudio / totalFiles) * 100),
         completedPercent: Math.round((filesCompleted / totalFiles) * 100),
-        totalFiles: totalFiles
+        totalFiles: totalFiles,
+        scoreAvg: avgScore
     };
 }
 

--- a/tests/calculateProjectStats.test.js
+++ b/tests/calculateProjectStats.test.js
@@ -11,7 +11,8 @@ describe('calculateProjectStats', () => {
             dePercent: 0,
             deAudioPercent: 0,
             completedPercent: 0,
-            totalFiles: 0
+            totalFiles: 0,
+            scoreAvg: 0
         });
     });
 
@@ -23,7 +24,8 @@ describe('calculateProjectStats', () => {
             dePercent: 0,
             deAudioPercent: 0,
             completedPercent: 0,
-            totalFiles: 0
+            totalFiles: 0,
+            scoreAvg: 0
         });
     });
 
@@ -37,7 +39,8 @@ describe('calculateProjectStats', () => {
             dePercent: 100,
             deAudioPercent: 100,
             completedPercent: 100,
-            totalFiles: 1
+            totalFiles: 1,
+            scoreAvg: 0
         });
     });
 
@@ -55,7 +58,8 @@ describe('calculateProjectStats', () => {
             dePercent: 0,
             deAudioPercent: 0,
             completedPercent: 0,
-            totalFiles: 3
+            totalFiles: 3,
+            scoreAvg: 0
         });
     });
 
@@ -72,7 +76,8 @@ describe('calculateProjectStats', () => {
             dePercent: 100,
             deAudioPercent: 0,
             completedPercent: 0,
-            totalFiles: 2
+            totalFiles: 2,
+            scoreAvg: 0
         });
     });
 
@@ -89,7 +94,8 @@ describe('calculateProjectStats', () => {
             dePercent: 50,
             deAudioPercent: 0,
             completedPercent: 0,
-            totalFiles: 2
+            totalFiles: 2,
+            scoreAvg: 0
         });
     });
 
@@ -106,7 +112,19 @@ describe('calculateProjectStats', () => {
             dePercent: 100,
             deAudioPercent: 50,
             completedPercent: 50,
-            totalFiles: 2
+            totalFiles: 2,
+            scoreAvg: 0
         });
+    });
+
+    test('average gpt score is calculated', () => {
+        const result = calculateProjectStats({
+            files: [
+                { score: 20 },
+                { score: 40 },
+                { score: 60 }
+            ]
+        });
+        expect(result.scoreAvg).toBe(40);
     });
 });

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1156,7 +1156,8 @@ function calculateProjectStats(project) {
             dePercent: 0,
             deAudioPercent: 0,
             completedPercent: 0,
-            totalFiles: 0
+            totalFiles: 0,
+            scoreAvg: 0
         };
     }
     
@@ -1164,13 +1165,21 @@ function calculateProjectStats(project) {
     const filesWithDE = files.filter(f => f.deText && f.deText.trim().length > 0).length;
     const filesCompleted = files.filter(isFileCompleted).length;
     const filesWithDeAudio = files.filter(f => getDeFilePath(f)).length;
+    // Durchschnittliche GPT-Bewertung ermitteln
+    const validScores = files
+        .map(f => Number(f.score))
+        .filter(n => Number.isFinite(n));
+    const avgScore = validScores.length
+        ? Math.round(validScores.reduce((a, b) => a + b, 0) / validScores.length)
+        : 0;
     
     return {
         enPercent: Math.round((filesWithEN / totalFiles) * 100),
         dePercent: Math.round((filesWithDE / totalFiles) * 100),
         deAudioPercent: Math.round((filesWithDeAudio / totalFiles) * 100),
         completedPercent: Math.round((filesCompleted / totalFiles) * 100),
-        totalFiles: totalFiles
+        totalFiles: totalFiles,
+        scoreAvg: avgScore
     };
 }
 
@@ -1448,6 +1457,7 @@ function renderProjects() {
                             <span title="DE-Text">DE: ${stats.dePercent}%</span>
                             <span title="DE-Audio">🔊 ${stats.deAudioPercent}%</span>
                             <span title="Fertig">✓ ${stats.completedPercent}%</span>
+                            <span title="GPT-Score">★ ${stats.scoreAvg}</span>
                         </div>
                         <div style="font-size:9px;color:rgba(255,255,255,0.6);">
                             ${stats.totalFiles} Dateien
@@ -1466,7 +1476,7 @@ function renderProjects() {
                 `Teil:  ${p.levelPart}\n\n` +
                 `• EN: ${stats.enPercent}%  • DE: ${stats.dePercent}%\n` +
                 `• DE-Audio: ${stats.deAudioPercent}%  • Fertig: ${stats.completedPercent}%${done ? ' ✅' : ''}\n` +
-                `• Dateien: ${stats.totalFiles}`;
+                `• GPT: ${stats.scoreAvg}  • Dateien: ${stats.totalFiles}`;
 
             card.onclick = e => {
                 if (!e.target.classList.contains('delete-btn') &&


### PR DESCRIPTION
## Zusammenfassung
- durchschnittlichen GPT-Score in der Projektliste anzeigen
- neue Kennzahl `scoreAvg` in `calculateProjectStats`
- Tooltip und Titel der Projektkarten angepasst
- README um neues Feature erweitert
- Tests für `calculateProjectStats` aktualisiert und ergänzt

## Testplan
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686146c7b1e08327b8583c6bce072a62