### PR TITLE
Fix GPT suggestion box display

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Robustere Zuordnung:** GPT-Ergebnisse finden jetzt auch dann die richtige Zeile, wenn die ID leicht abweicht
 * **Eigenständige Score-Komponente:** Tooltip und Klick sind in `web/src/scoreColumn.js` gekapselt
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
+* **Bereinigte Vorschau-Anzeige:** Leere GPT-Vorschläge lassen keinen zusätzlichen Abstand mehr
 * **Durchschnittlicher GPT-Score pro Projekt:** Die Projektübersicht zeigt nun den Mittelwert aller Bewertungen an
 * **Automatische Übernahme von GPT-Vorschlägen:** Eine neue Option setzt empfohlene Texte sofort in das DE-Feld
 * **Einfüge-Knopf versteht JSON:** Manuell in den GPT-Test kopierte Antworten können direkt übernommen werden

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -3918,16 +3918,22 @@ function updateTranslationDisplay(fileId) {
 
 // Zeigt den GPT-Vorschlag oberhalb des DE-Textes an
 function updateSuggestionDisplay(fileId) {
-    const div = document.querySelector(`.suggestion-box[data-file-id="${fileId}"]`);
+    const box = document.querySelector(`.suggestion-box[data-file-id="${fileId}"]`);
+    const preview = document.querySelector(`.suggestion-preview[data-id="${fileId}"]`);
     const file = files.find(f => f.id === fileId);
-    if (div && file) {
-        div.textContent = file.suggestion || '';
+    if (box && file) {
+        box.textContent = file.suggestion || '';
         const cls = file.score === undefined || file.score === null
             ? 'score-none'
             : file.score >= 70 ? 'score-high'
                 : file.score >= 40 ? 'score-medium'
                     : 'score-low';
-        div.className = `suggestion-box ${cls}`;
+        box.className = `suggestion-box ${cls}`;
+        box.style.display = file.suggestion ? 'block' : 'none';
+    }
+    if (preview && file) {
+        preview.textContent = file.suggestion || '';
+        preview.style.display = file.suggestion ? 'block' : 'none';
     }
 }
 

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2804,6 +2804,10 @@ th:nth-child(10) {
 .suggestion-box.score-high {
     color: #fff;
 }
+.suggestion-box:empty,
+.suggestion-preview:empty {
+    display: none;
+}
 
 /* Vorschau des GPT-Vorschlags oberhalb des Textfelds */
 .suggestion-preview {


### PR DESCRIPTION
## Summary
- hide empty GPT-Vorschläge via CSS
- updateSuggestionDisplay toggles visibility of suggestion box and preview
- note cleaned-up preview display in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686152234e30832789fefbcb7fa03448