### PR TITLE
Verbesserte Suggestion-Box

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Bugfix:** Scores werden korrekt eingefügt, auch wenn ID und Score als Zeichenketten geliefert werden
 * **Robustere Zuordnung:** GPT-Ergebnisse finden jetzt auch dann die richtige Zeile, wenn die ID leicht abweicht
 * **Eigenständige Score-Komponente:** Tooltip und Klick sind in `web/src/scoreColumn.js` gekapselt
+* **Einheitliche Score-Klassen:** Die Funktion `scoreClass` vergibt überall die gleichen Farbstufen
+* **Score in Prozent:** Die Bewertung wird in der Tabelle mit Prozentzeichen dargestellt
+* **Aktive Score-Events:** Nach jedem Rendern bindet `attachScoreHandlers` Tooltip und Klick
+* **Direkter Daten-Refresh:** Nach jeder Bewertung wird die Tabelle mit den aktualisierten Dateien neu gerendert
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
 * **Bereinigte Vorschau-Anzeige:** Leere GPT-Vorschläge lassen keinen zusätzlichen Abstand mehr
 * **Durchschnittlicher GPT-Score pro Projekt:** Die Projektübersicht zeigt nun den Mittelwert aller Bewertungen an

--- a/web/src/actions/projectEvaluate.js
+++ b/web/src/actions/projectEvaluate.js
@@ -2,10 +2,12 @@
 // GPT-Service importieren – je nach Umgebung
 let evaluateScene;
 let autoApplySuggestion = false;
+let attachScoreHandlers;
 if (typeof require !== 'undefined') {
     try {
         ({ evaluateScene } = require('../gptService.js'));
         ({ autoApplySuggestion } = require('../main.js'));
+        ({ attachScoreHandlers } = require('../scoreColumn.js'));
     } catch {}
 }
 if (typeof window !== 'undefined' && window.evaluateScene) {
@@ -13,6 +15,9 @@ if (typeof window !== 'undefined' && window.evaluateScene) {
 }
 if (typeof window !== 'undefined' && window.autoApplySuggestion !== undefined) {
     autoApplySuggestion = window.autoApplySuggestion;
+}
+if (typeof window !== 'undefined' && window.attachScoreHandlers) {
+    attachScoreHandlers = window.attachScoreHandlers;
 }
 
 // Überträgt die GPT-Ergebnisse in die Dateiliste
@@ -82,7 +87,15 @@ async function scoreVisibleLines(opts) {
         return;
     }
     applyEvaluationResults(results, files);
+    // Tabelle mit den aktualisierten Dateien neu aufbauen
     await renderTable(displayOrder.map(d => d.file));
+    if (typeof attachScoreHandlers === 'function' && typeof document !== 'undefined') {
+        const tbody = document.getElementById('fileTableBody');
+        if (tbody) {
+            // Nach dem Aufbau die Score-Klassen erneut binden
+            attachScoreHandlers(tbody, files);
+        }
+    }
     if (updateStatus) updateStatus('GPT-Bewertung abgeschlossen');
 }
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -200,7 +200,7 @@ let pathUtilsPromise;
 let evaluateScene;
 let applyEvaluationResults;
 let scoreVisibleLines;
-let scoreCellTemplate, attachScoreHandlers;
+let scoreCellTemplate, attachScoreHandlers, scoreClass;
 // Platzhalter für Dubbing-Funktionen
 let showDubbingSettings, createDubbingCSV, validateCsv, msToSeconds, isDubReady,
     startDubbing, redownloadDubbing, openDubbingPage, openLocalFile,
@@ -233,7 +233,11 @@ if (typeof module !== 'undefined' && module.exports) {
     import('./scoreColumn.js').then(mod => {
         scoreCellTemplate = mod.scoreCellTemplate;
         attachScoreHandlers = mod.attachScoreHandlers;
-    }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; });
+        scoreClass = mod.scoreClass;
+        if (typeof window !== 'undefined') {
+            window.attachScoreHandlers = attachScoreHandlers;
+        }
+    }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; scoreClass = () => 'score-none'; });
     import('./actions/projectEvaluate.js').then(mod => {
         applyEvaluationResults = mod.applyEvaluationResults;
         scoreVisibleLines = mod.scoreVisibleLines;
@@ -275,7 +279,11 @@ if (typeof module !== 'undefined' && module.exports) {
     import('./scoreColumn.js').then(mod => {
         scoreCellTemplate = mod.scoreCellTemplate;
         attachScoreHandlers = mod.attachScoreHandlers;
-    }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; });
+        scoreClass = mod.scoreClass;
+        if (typeof window !== 'undefined') {
+            window.attachScoreHandlers = attachScoreHandlers;
+        }
+    }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; scoreClass = () => 'score-none'; });
     import('./actions/projectEvaluate.js').then(mod => {
         applyEvaluationResults = mod.applyEvaluationResults;
         scoreVisibleLines = mod.scoreVisibleLines;
@@ -2732,7 +2740,7 @@ return `
             </div>
         </div></td>
         <td>
-        <div class="suggestion-box ${file.score === undefined || file.score === null ? 'score-none' : file.score >= 70 ? 'score-high' : file.score >= 40 ? 'score-medium' : 'score-low'}" data-file-id="${file.id}">${escapeHtml(file.suggestion || '')}</div>
+        <div class="suggestion-box ${scoreClass(file.score)}" data-file-id="${file.id}">${escapeHtml(file.suggestion || '')}</div>
         <div class="suggestion-preview" data-id="${file.id}">
           ${escapeHtml(file.suggestion || '')}
         </div>
@@ -2781,6 +2789,7 @@ return `
     tbody.innerHTML = rows.join('');
 
     // Tooltip- und Klicklogik auslagern
+    // Bindet Tooltip und Klick auf die Score-Zellen und stellt die CSS-Klassen sicher
     attachScoreHandlers(tbody, files);
     
     addDragAndDropHandlers();
@@ -3923,11 +3932,7 @@ function updateSuggestionDisplay(fileId) {
     const file = files.find(f => f.id === fileId);
     if (box && file) {
         box.textContent = file.suggestion || '';
-        const cls = file.score === undefined || file.score === null
-            ? 'score-none'
-            : file.score >= 70 ? 'score-high'
-                : file.score >= 40 ? 'score-medium'
-                    : 'score-low';
+        const cls = scoreClass(file.score);
         box.className = `suggestion-box ${cls}`;
         box.style.display = file.suggestion ? 'block' : 'none';
     }

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -1,18 +1,20 @@
 // Erzeugt den HTML-Code für eine Score-Zelle und bindet Tooltip sowie Klick
+// Ermittelt die passende CSS-Klasse basierend auf dem Score
+export function scoreClass(score) {
+    if (score === undefined || score === null) return 'score-none';
+    return score >= 70 ? 'score-high' : score >= 40 ? 'score-medium' : 'score-low';
+}
+
+// Erzeugt den HTML-Code für eine Score-Zelle und bindet Tooltip sowie Klick
 export function scoreCellTemplate(file, escapeHtml) {
+    const cls = scoreClass(file.score);
     const noScore = file.score === undefined || file.score === null;
-    const cls = noScore
-        ? 'score-none'
-        : file.score >= 70
-            ? 'score-high'
-            : file.score >= 40
-                ? 'score-medium'
-                : 'score-low';
     const sug = escapeHtml(file.suggestion || '');
     const com = escapeHtml(file.comment || '');
     const title = escapeHtml([file.comment, file.suggestion].filter(Boolean).join(' - '));
+    // Score immer als Prozentwert anzeigen
     const scoreText = noScore ? '0' : file.score;
-    return `<td class="score-cell ${cls}" data-suggestion="${sug}" data-comment="${com}" title="${title}">${scoreText}</td>`;
+    return `<td class="score-cell ${cls}" data-suggestion="${sug}" data-comment="${com}" title="${title}">${scoreText}%</td>`;
 }
 
 export function attachScoreHandlers(tbody, files) {


### PR DESCRIPTION
## Zusammenfassung
- Score-Events werden nun nach jedem Rendern gebunden
- `attachScoreHandlers` wird im Projekt-Dialog importiert und nach dem Rendern aufgerufen
- README vermerkt das automatische Binden der Event-Handler
- Direkter Daten-Refresh wird dokumentiert und im Code kommentiert

## Test
- `npm test --silent -- --runInBand --json --outputFile=jest_results.json`


------
https://chatgpt.com/codex/tasks/task_e_686157e8da38832791af0549484fc605