### PR TITLE
Fix dynamic import for projectEvaluate

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Automatische Übernahme von GPT-Vorschlägen:** Eine neue Option setzt empfohlene Texte sofort in das DE-Feld
 * **Einfüge-Knopf versteht JSON:** Manuell in den GPT-Test kopierte Antworten können direkt übernommen werden
 * **Zuverlässiges Einfügen:** Der Einfüge-Knopf lädt fehlende Module nach, überträgt Score und Vorschlag in die Daten und zeichnet die Tabelle neu
+* **Kompatible Nachladung:** Beim Einfügen erkennt das Tool nun auch CommonJS-Exporte und verhindert so Fehler
 * **Dritte Spalte im GPT-Test als Tabelle:** Rechts zeigt jetzt eine übersichtliche Tabelle mit ID, Dateiname, Ordner, Bewertung, Vorschlag und Kommentar alle Ergebnisse an
 * **Speicherfunktion für GPT-Test:** Jeder Versand erzeugt einen neuen Tab mit Prompt, Antwort und Tabelle. Tabs lassen sich wechseln und löschen.
 * **GPT-Tabs pro Projekt:** Geöffnete Tests bleiben gespeichert und erscheinen beim nächsten Öffnen wieder.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -239,8 +239,10 @@ if (typeof module !== 'undefined' && module.exports) {
         }
     }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; scoreClass = () => 'score-none'; });
     import('./actions/projectEvaluate.js').then(mod => {
-        applyEvaluationResults = mod.applyEvaluationResults;
-        scoreVisibleLines = mod.scoreVisibleLines;
+        applyEvaluationResults = mod.applyEvaluationResults ||
+                                (mod.default && mod.default.applyEvaluationResults);
+        scoreVisibleLines = mod.scoreVisibleLines ||
+                           (mod.default && mod.default.scoreVisibleLines);
         moduleStatus.projectEvaluate = { loaded: true, source: 'Main' };
     }).catch(() => { moduleStatus.projectEvaluate = { loaded: false, source: 'Main' }; });
 } else {
@@ -285,8 +287,10 @@ if (typeof module !== 'undefined' && module.exports) {
         }
     }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; scoreClass = () => 'score-none'; });
     import('./actions/projectEvaluate.js').then(mod => {
-        applyEvaluationResults = mod.applyEvaluationResults;
-        scoreVisibleLines = mod.scoreVisibleLines;
+        applyEvaluationResults = mod.applyEvaluationResults ||
+                                (mod.default && mod.default.applyEvaluationResults);
+        scoreVisibleLines = mod.scoreVisibleLines ||
+                           (mod.default && mod.default.scoreVisibleLines);
         moduleStatus.projectEvaluate = { loaded: true, source: 'Ausgelagert' };
     }).catch(() => { moduleStatus.projectEvaluate = { loaded: false, source: 'Ausgelagert' }; });
     moduleStatus.dubbing = { loaded: false, source: 'Ausgelagert' };
@@ -443,7 +447,8 @@ async function insertGptResults() {
         }
         if (typeof applyEvaluationResults !== 'function') {
             const mod = await import('./actions/projectEvaluate.js');
-            applyEvaluationResults = mod.applyEvaluationResults;
+            applyEvaluationResults = mod.applyEvaluationResults ||
+                                    (mod.default && mod.default.applyEvaluationResults);
         }
     }
     btn.disabled = true;


### PR DESCRIPTION
## Summary
- handle default exports when loading projectEvaluate.js
- mention compatibility improvement in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68616be02f34832794650e2ec5731194