### PR TITLE
Score-Spalte entfernt

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Direkter Daten-Refresh:** Nach jeder Bewertung wird die Tabelle mit den aktualisierten Dateien neu gerendert
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
 * **Bereinigte Vorschau-Anzeige:** Leere GPT-Vorschläge lassen keinen zusätzlichen Abstand mehr
-* **Durchschnittlicher GPT-Score pro Projekt:** Die Projektübersicht zeigt nun den Mittelwert aller Bewertungen an
 * **Automatische Übernahme von GPT-Vorschlägen:** Eine neue Option setzt empfohlene Texte sofort in das DE-Feld
 * **Einfüge-Knopf versteht JSON:** Manuell in den GPT-Test kopierte Antworten können direkt übernommen werden
 * **Zuverlässiges Einfügen:** Der Einfüge-Knopf lädt fehlende Module nach, überträgt Score und Vorschlag in die Daten und zeichnet die Tabelle neu

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1485,7 +1485,6 @@ function renderProjects() {
                             <span title="DE-Text">DE: ${stats.dePercent}%</span>
                             <span title="DE-Audio">🔊 ${stats.deAudioPercent}%</span>
                             <span title="Fertig">✓ ${stats.completedPercent}%</span>
-                            <span title="GPT-Score">★ ${stats.scoreAvg}</span>
                         </div>
                         <div style="font-size:9px;color:rgba(255,255,255,0.6);">
                             ${stats.totalFiles} Dateien


### PR DESCRIPTION
## Summary
- entferne Anzeige des durchschnittlichen GPT-Scores in der Projektübersicht
- passe README entsprechend an

## Testing
- `npx jest --runInBand --silent` *(fehlschlägt: ENOENT in `elevenlabs.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68617950a9248327b699db3dcbdeeedb