### PR TITLE
Fix applyEvaluationResults loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@
 * Dateiwächter wartet auf stabile Dateigröße und löscht nur noch die importierte Datei.
 ## 🛠️ Patch in 1.40.35
 * Der Dateiwächter importiert Dateien jetzt nur automatisch, wenn eine passende Dubbing-ID vorhanden ist. Unbekannte Dateien öffnen stattdessen den manuellen Import-Dialog.
+## 🛠️ Patch in 1.40.36
+* Fehler behoben: Beim Einfügen von GPT-Ergebnissen erschien teilweise "applyEvaluationResults is not a function".
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Einfüge-Knopf versteht JSON:** Manuell in den GPT-Test kopierte Antworten können direkt übernommen werden
 * **Zuverlässiges Einfügen:** Der Einfüge-Knopf lädt fehlende Module nach, überträgt Score und Vorschlag in die Daten und zeichnet die Tabelle neu
 * **Kompatible Nachladung:** Beim Einfügen erkennt das Tool nun auch CommonJS-Exporte und verhindert so Fehler
+* **Fehlerbehebung beim Einfügen:** Der Button funktioniert nun auch, wenn `applyEvaluationResults` nur global definiert war
 * **Dritte Spalte im GPT-Test als Tabelle:** Rechts zeigt jetzt eine übersichtliche Tabelle mit ID, Dateiname, Ordner, Bewertung, Vorschlag und Kommentar alle Ergebnisse an
 * **Speicherfunktion für GPT-Test:** Jeder Versand erzeugt einen neuen Tab mit Prompt, Antwort und Tabelle. Tabs lassen sich wechseln und löschen.
 * **GPT-Tabs pro Projekt:** Geöffnete Tests bleiben gespeichert und erscheinen beim nächsten Öffnen wieder.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -239,10 +239,13 @@ if (typeof module !== 'undefined' && module.exports) {
         }
     }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; scoreClass = () => 'score-none'; });
     import('./actions/projectEvaluate.js').then(mod => {
+        // Funktionen entweder aus dem Modul oder von window uebernehmen
         applyEvaluationResults = mod.applyEvaluationResults ||
-                                (mod.default && mod.default.applyEvaluationResults);
+                                (mod.default && mod.default.applyEvaluationResults) ||
+                                window.applyEvaluationResults;
         scoreVisibleLines = mod.scoreVisibleLines ||
-                           (mod.default && mod.default.scoreVisibleLines);
+                           (mod.default && mod.default.scoreVisibleLines) ||
+                           window.scoreVisibleLines;
         moduleStatus.projectEvaluate = { loaded: true, source: 'Main' };
     }).catch(() => { moduleStatus.projectEvaluate = { loaded: false, source: 'Main' }; });
 } else {
@@ -287,10 +290,13 @@ if (typeof module !== 'undefined' && module.exports) {
         }
     }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; scoreClass = () => 'score-none'; });
     import('./actions/projectEvaluate.js').then(mod => {
+        // Fallback auf window, falls keine Exporte vorhanden sind
         applyEvaluationResults = mod.applyEvaluationResults ||
-                                (mod.default && mod.default.applyEvaluationResults);
+                                (mod.default && mod.default.applyEvaluationResults) ||
+                                window.applyEvaluationResults;
         scoreVisibleLines = mod.scoreVisibleLines ||
-                           (mod.default && mod.default.scoreVisibleLines);
+                           (mod.default && mod.default.scoreVisibleLines) ||
+                           window.scoreVisibleLines;
         moduleStatus.projectEvaluate = { loaded: true, source: 'Ausgelagert' };
     }).catch(() => { moduleStatus.projectEvaluate = { loaded: false, source: 'Ausgelagert' }; });
     moduleStatus.dubbing = { loaded: false, source: 'Ausgelagert' };
@@ -447,8 +453,10 @@ async function insertGptResults() {
         }
         if (typeof applyEvaluationResults !== 'function') {
             const mod = await import('./actions/projectEvaluate.js');
+            // Nach dem Laden auch window pruefen
             applyEvaluationResults = mod.applyEvaluationResults ||
-                                    (mod.default && mod.default.applyEvaluationResults);
+                                    (mod.default && mod.default.applyEvaluationResults) ||
+                                    window.applyEvaluationResults;
         }
     }
     btn.disabled = true;


### PR DESCRIPTION
## Summary
- sorge dafuer, dass beim dynamischen Import auch `window.applyEvaluationResults` und `window.scoreVisibleLines` beruecksichtigt werden
- aendere `insertGptResults`, damit der Button bei global definierter Funktion funktioniert
- ergaenze README und CHANGELOG

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68617c1596708327b51e350974e3ac23