### PR TITLE
Passe Score-Farben an Bewertungsschema an

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Robustere Zuordnung:** GPT-Ergebnisse finden jetzt auch dann die richtige Zeile, wenn die ID leicht abweicht
 * **Eigenständige Score-Komponente:** Tooltip und Klick sind in `web/src/scoreColumn.js` gekapselt
 * **Einheitliche Score-Klassen:** Die Funktion `scoreClass` vergibt überall die gleichen Farbstufen
+* **Feineres Bewertungsschema:** Ab 95 % wird der Score grün, zwischen 85 % und 94 % gelb
 * **Score in Prozent:** Die Bewertung wird in der Tabelle mit Prozentzeichen dargestellt
 * **Aktive Score-Events:** Nach jedem Rendern bindet `attachScoreHandlers` Tooltip und Klick
 * **Direkter Daten-Refresh:** Nach jeder Bewertung wird die Tabelle mit den aktualisierten Dateien neu gerendert

--- a/tests/scoreColumn.test.js
+++ b/tests/scoreColumn.test.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+// Lädt die Funktion scoreClass aus dem Modul ohne ES-Import
+const file = fs.readFileSync(path.join(__dirname, '../web/src/scoreColumn.js'), 'utf8');
+const match = file.match(/export function scoreClass\(score\) {[^}]+}/);
+// eslint-disable-next-line no-eval
+eval(match[0].replace('export ', ''));
+
+describe('scoreClass', () => {
+  test('liefert score-high ab 95', () => {
+    expect(scoreClass(100)).toBe('score-high');
+    expect(scoreClass(95)).toBe('score-high');
+  });
+
+  test('liefert score-medium zwischen 85 und 94', () => {
+    expect(scoreClass(94)).toBe('score-medium');
+    expect(scoreClass(85)).toBe('score-medium');
+  });
+
+  test('liefert score-low unter 85', () => {
+    expect(scoreClass(84)).toBe('score-low');
+    expect(scoreClass(0)).toBe('score-low');
+  });
+
+  test('liefert score-none ohne Wert', () => {
+    expect(scoreClass(null)).toBe('score-none');
+    expect(scoreClass(undefined)).toBe('score-none');
+  });
+});

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -1,8 +1,9 @@
 // Erzeugt den HTML-Code für eine Score-Zelle und bindet Tooltip sowie Klick
 // Ermittelt die passende CSS-Klasse basierend auf dem Score
+// Liefert die CSS-Klasse abhängig von der prozentualen Bewertung
 export function scoreClass(score) {
     if (score === undefined || score === null) return 'score-none';
-    return score >= 70 ? 'score-high' : score >= 40 ? 'score-medium' : 'score-low';
+    return score >= 95 ? 'score-high' : score >= 85 ? 'score-medium' : 'score-low';
 }
 
 // Erzeugt den HTML-Code für eine Score-Zelle und bindet Tooltip sowie Klick
@@ -61,4 +62,15 @@ function applySuggestion(id, files) {
         deCell.classList.add('blink-blue');
         setTimeout(() => deCell.classList.remove('blink-blue'), 600);
     }
+}
+
+// Export für Node-Tests
+if (typeof module !== 'undefined') {
+    module.exports = {
+        scoreClass,
+        scoreCellTemplate,
+        attachScoreHandlers,
+        openScoreTooltip,
+        closeScoreTooltip
+    };
 }


### PR DESCRIPTION
## Summary
- Farbschwellen in `scoreClass` auf 95/85 angepasst
- Hinweis auf neues Bewertungsschema in der README
- `scoreColumn.js` mit CommonJS-Export versehen
- neuer Test `scoreColumn.test.js` sichert Farblogik

## Testing
- `npx jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_68618166182483278b94875681ddefb7