### PR TITLE
Lesbare Scorefarben

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Aktive Score-Events:** Nach jedem Rendern bindet `attachScoreHandlers` Tooltip und Klick
 * **Direkter Daten-Refresh:** Nach jeder Bewertung wird die Tabelle mit den aktualisierten Dateien neu gerendert
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
+* **Kontrastreicher Score:** Bei hellen Hintergrundfarben wechselt die Schrift automatisch auf schwarz
 * **Bereinigte Vorschau-Anzeige:** Leere GPT-Vorschläge lassen keinen zusätzlichen Abstand mehr
 * **Durchschnittlicher GPT-Score pro Projekt:** Die Projektübersicht zeigt nun den Mittelwert aller Bewertungen an
 * **Automatische Übernahme von GPT-Vorschlägen:** Eine neue Option setzt empfohlene Texte sofort in das DE-Feld

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -200,7 +200,7 @@ let pathUtilsPromise;
 let evaluateScene;
 let applyEvaluationResults;
 let scoreVisibleLines;
-let scoreCellTemplate, attachScoreHandlers, scoreClass;
+let scoreCellTemplate, attachScoreHandlers, scoreClass, getContrastingTextColor, SCORE_COLORS;
 // Platzhalter für Dubbing-Funktionen
 let showDubbingSettings, createDubbingCSV, validateCsv, msToSeconds, isDubReady,
     startDubbing, redownloadDubbing, openDubbingPage, openLocalFile,
@@ -234,10 +234,12 @@ if (typeof module !== 'undefined' && module.exports) {
         scoreCellTemplate = mod.scoreCellTemplate;
         attachScoreHandlers = mod.attachScoreHandlers;
         scoreClass = mod.scoreClass;
+        getContrastingTextColor = mod.getContrastingTextColor;
+        SCORE_COLORS = mod.SCORE_COLORS;
         if (typeof window !== 'undefined') {
             window.attachScoreHandlers = attachScoreHandlers;
         }
-    }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; scoreClass = () => 'score-none'; });
+    }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; scoreClass = () => 'score-none'; getContrastingTextColor = () => '#fff'; SCORE_COLORS = {}; });
     import('./actions/projectEvaluate.js').then(mod => {
         // Funktionen entweder aus dem Modul oder von window uebernehmen
         applyEvaluationResults = mod.applyEvaluationResults ||
@@ -285,10 +287,12 @@ if (typeof module !== 'undefined' && module.exports) {
         scoreCellTemplate = mod.scoreCellTemplate;
         attachScoreHandlers = mod.attachScoreHandlers;
         scoreClass = mod.scoreClass;
+        getContrastingTextColor = mod.getContrastingTextColor;
+        SCORE_COLORS = mod.SCORE_COLORS;
         if (typeof window !== 'undefined') {
             window.attachScoreHandlers = attachScoreHandlers;
         }
-    }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; scoreClass = () => 'score-none'; });
+    }).catch(() => { scoreCellTemplate = () => ''; attachScoreHandlers = () => {}; scoreClass = () => 'score-none'; getContrastingTextColor = () => '#fff'; SCORE_COLORS = {}; });
     import('./actions/projectEvaluate.js').then(mod => {
         // Fallback auf window, falls keine Exporte vorhanden sind
         applyEvaluationResults = mod.applyEvaluationResults ||
@@ -2768,7 +2772,7 @@ return `
             </div>
         </div></td>
         <td>
-        <div class="suggestion-box ${scoreClass(file.score)}" data-file-id="${file.id}">${escapeHtml(file.suggestion || '')}</div>
+        <div class="suggestion-box ${scoreClass(file.score)}" style="color:${getContrastingTextColor(SCORE_COLORS[scoreClass(file.score)])}" data-file-id="${file.id}">${escapeHtml(file.suggestion || '')}</div>
         <div class="suggestion-preview" data-id="${file.id}">
           ${escapeHtml(file.suggestion || '')}
         </div>
@@ -3991,6 +3995,7 @@ function updateSuggestionDisplay(fileId) {
         box.textContent = file.suggestion || '';
         const cls = scoreClass(file.score);
         box.className = `suggestion-box ${cls}`;
+        box.style.color = getContrastingTextColor(SCORE_COLORS[cls] || '#666');
         box.style.display = file.suggestion ? 'block' : 'none';
     }
     if (preview && file) {

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -1,21 +1,41 @@
 // Erzeugt den HTML-Code für eine Score-Zelle und bindet Tooltip sowie Klick
 // Ermittelt die passende CSS-Klasse basierend auf dem Score
 // Liefert die CSS-Klasse abhängig von der prozentualen Bewertung
+// Liefert die CSS-Klasse abhängig von der prozentualen Bewertung
 export function scoreClass(score) {
     if (score === undefined || score === null) return 'score-none';
     return score >= 95 ? 'score-high' : score >= 85 ? 'score-medium' : 'score-low';
 }
 
+// Farbwerte passend zu den Score-Klassen
+export const SCORE_COLORS = {
+    'score-none': '#666',
+    'score-low': '#A33',
+    'score-medium': '#BB8',
+    'score-high': '#3A3'
+};
+
+// Ermittelt bei heller Hintergrundfarbe automatisch schwarze Schrift
+export function getContrastingTextColor(hex) {
+    if (hex.length === 4) hex = '#' + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3];
+    const r = parseInt(hex.substr(1, 2), 16);
+    const g = parseInt(hex.substr(3, 2), 16);
+    const b = parseInt(hex.substr(5, 2), 16);
+    const brightness = 0.299 * r + 0.587 * g + 0.114 * b;
+    return brightness > 186 ? '#000' : '#fff';
+}
+
 // Erzeugt den HTML-Code für eine Score-Zelle und bindet Tooltip sowie Klick
 export function scoreCellTemplate(file, escapeHtml) {
     const cls = scoreClass(file.score);
+    const color = getContrastingTextColor(SCORE_COLORS[cls]);
     const noScore = file.score === undefined || file.score === null;
     const sug = escapeHtml(file.suggestion || '');
     const com = escapeHtml(file.comment || '');
     const title = escapeHtml([file.comment, file.suggestion].filter(Boolean).join(' - '));
     // Score immer als Prozentwert anzeigen
     const scoreText = noScore ? '0' : file.score;
-    return `<td class="score-cell ${cls}" data-suggestion="${sug}" data-comment="${com}" title="${title}">${scoreText}%</td>`;
+    return `<td class="score-cell ${cls}" style="color:${color}" data-suggestion="${sug}" data-comment="${com}" title="${title}">${scoreText}%</td>`;
 }
 
 export function attachScoreHandlers(tbody, files) {
@@ -70,6 +90,8 @@ if (typeof module !== 'undefined') {
         scoreClass,
         scoreCellTemplate,
         attachScoreHandlers,
+        getContrastingTextColor,
+        SCORE_COLORS,
         openScoreTooltip,
         closeScoreTooltip
     };

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2773,7 +2773,6 @@ th:nth-child(10) {
 /* Score-Bewertungen */
 .score-cell {
     text-align: center;
-    color: #fff;
 }
 
 .score-none {
@@ -2783,14 +2782,17 @@ th:nth-child(10) {
 
 .score-low {
     background: #A33;
+    color: #fff;
 }
 
 .score-medium {
     background: #BB8;
+    color: #000;
 }
 
 .score-high {
     background: #3A3;
+    color: #fff;
 }
 
 /* Anzeige des GPT-Vorschlags oberhalb des DE-Textes */
@@ -2803,6 +2805,11 @@ th:nth-child(10) {
 .suggestion-box.score-low,
 .suggestion-box.score-high {
     color: #fff;
+}
+
+/* Bei heller Scorefarbe dunkle Schrift verwenden */
+.suggestion-box.score-medium {
+    color: #000;
 }
 .suggestion-box.score-high { background: #1e4620; }
 .suggestion-box.score-low  { background: #391212; }


### PR DESCRIPTION
## Zusammenfassung
- automatische Schriftfarbe abhängig vom Score-Hintergrund
- Style-Anpassungen für bessere Lesbarkeit
- neue Funktionen `getContrastingTextColor` und `SCORE_COLORS`
- README um neues Feature ergänzt

## Tests
- `npx jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_686183c83c98832794ee38bcbaf92886