### PR TITLE
Fix doppelte Vorschau

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
 * **Kontrastreicher Score:** Bei hellen Hintergrundfarben wechselt die Schrift automatisch auf schwarz
 * **Bereinigte Vorschau-Anzeige:** Leere GPT-Vorschläge lassen keinen zusätzlichen Abstand mehr
+* **Einheitliche GPT-Vorschau:** Der farbige Vorschlagsbalken ist nun direkt klickbar und es gibt nur noch einen Tooltip
 * **Durchschnittlicher GPT-Score pro Projekt:** Die Projektübersicht zeigt nun den Mittelwert aller Bewertungen an
 * **Automatische Übernahme von GPT-Vorschlägen:** Eine neue Option setzt empfohlene Texte sofort in das DE-Feld
 * **Einfüge-Knopf versteht JSON:** Manuell in den GPT-Test kopierte Antworten können direkt übernommen werden

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2773,9 +2773,6 @@ return `
         </div></td>
         <td>
         <div class="suggestion-box ${scoreClass(file.score)}" style="color:${getContrastingTextColor(SCORE_COLORS[scoreClass(file.score)])}" data-file-id="${file.id}">${escapeHtml(file.suggestion || '')}</div>
-        <div class="suggestion-preview" data-id="${file.id}">
-          ${escapeHtml(file.suggestion || '')}
-        </div>
         <div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
             <textarea class="text-input"
                  onchange="updateText(${file.id}, 'de', this.value)"
@@ -2836,17 +2833,21 @@ return `
             updateTranslationDisplay(f.id);
             updateSuggestionDisplay(f.id);
         });
-        document.querySelectorAll('.suggestion-preview').forEach(div => {
-            const id = Number(div.dataset.id);
+        // GPT-Vorschlag per Klick übernehmen
+        document.querySelectorAll('.suggestion-box').forEach(div => {
+            const id = Number(div.dataset.fileId);
             const file = files.find(f => f.id === id);
             div.textContent = file.suggestion || '';
             div.onclick = () => {
                 file.deText = file.suggestion;
                 window.isDirty = true;
-                const textarea = div.nextElementSibling;
-                textarea.value = file.deText;
-                textarea.classList.add('blink-blue');
-                setTimeout(() => textarea.classList.remove('blink-blue'), 600);
+                const container = div.nextElementSibling;
+                const textarea = container?.querySelector('textarea.text-input');
+                if (textarea) {
+                    textarea.value = file.deText;
+                    textarea.classList.add('blink-blue');
+                    setTimeout(() => textarea.classList.remove('blink-blue'), 600);
+                }
             };
         });
     }, 50);
@@ -3987,9 +3988,9 @@ function updateTranslationDisplay(fileId) {
 }
 
 // Zeigt den GPT-Vorschlag oberhalb des DE-Textes an
+// Aktualisiert die farbige Vorschlagsbox
 function updateSuggestionDisplay(fileId) {
     const box = document.querySelector(`.suggestion-box[data-file-id="${fileId}"]`);
-    const preview = document.querySelector(`.suggestion-preview[data-id="${fileId}"]`);
     const file = files.find(f => f.id === fileId);
     if (box && file) {
         box.textContent = file.suggestion || '';
@@ -3997,10 +3998,6 @@ function updateSuggestionDisplay(fileId) {
         box.className = `suggestion-box ${cls}`;
         box.style.color = getContrastingTextColor(SCORE_COLORS[cls] || '#666');
         box.style.display = file.suggestion ? 'block' : 'none';
-    }
-    if (preview && file) {
-        preview.textContent = file.suggestion || '';
-        preview.style.display = file.suggestion ? 'block' : 'none';
     }
 }
 

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -32,10 +32,9 @@ export function scoreCellTemplate(file, escapeHtml) {
     const noScore = file.score === undefined || file.score === null;
     const sug = escapeHtml(file.suggestion || '');
     const com = escapeHtml(file.comment || '');
-    const title = escapeHtml([file.comment, file.suggestion].filter(Boolean).join(' - '));
     // Score immer als Prozentwert anzeigen
     const scoreText = noScore ? '0' : file.score;
-    return `<td class="score-cell ${cls}" style="color:${color}" data-suggestion="${sug}" data-comment="${com}" title="${title}">${scoreText}%</td>`;
+    return `<td class="score-cell ${cls}" style="color:${color}" data-suggestion="${sug}" data-comment="${com}">${scoreText}%</td>`;
 }
 
 export function attachScoreHandlers(tbody, files) {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2803,6 +2803,7 @@ th:nth-child(10) {
     margin-bottom: 2px;
     padding: 2px 4px;
     border-radius: 3px;
+    cursor: pointer; /* Box ist jetzt direkt anklickbar */
 }
 .suggestion-box.score-low,
 .suggestion-box.score-high {
@@ -2815,20 +2816,8 @@ th:nth-child(10) {
 }
 .suggestion-box.score-high { background: #1e4620; }
 .suggestion-box.score-low  { background: #391212; }
-.suggestion-box:empty,
-.suggestion-preview:empty {
+.suggestion-box:empty {
     display: none;
-}
-
-/* Vorschau des GPT-Vorschlags oberhalb des Textfelds */
-.suggestion-preview {
-    font-style: italic;
-    color: #999;
-    margin-bottom: 4px;
-    cursor: pointer;
-}
-.suggestion-preview:hover {
-    text-decoration: underline;
 }
 
 /* Blauer Blinkeffekt bei übernommener Übersetzung */


### PR DESCRIPTION
## Summary
- entferne doppelte Vorschau-Box und Tooltip
- Vorschlagsbox ist nun klickbar und mit Cursor versehen
- Tooltip im Score nutzt nur noch eigene Logik
- README um Hinweis zur neuen Anzeige erweitert

## Testing
- `npx jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861a2eb531883279867181f4f4258e9