### PR TITLE
Score-Farben

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Aktive Score-Events:** Nach jedem Rendern bindet `attachScoreHandlers` Tooltip und Klick
 * **Direkter Daten-Refresh:** Nach jeder Bewertung wird die Tabelle mit den aktualisierten Dateien neu gerendert
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
-* **Kontrastreicher Score:** Bei hellen Hintergrundfarben wechselt die Schrift automatisch auf schwarz
+* **Feste Schriftfarben:** Gelber Score nutzt schwarze Schrift, rot und gruen weiss
 * **Bereinigte Vorschau-Anzeige:** Leere GPT-Vorschläge lassen keinen zusätzlichen Abstand mehr
 * **Einheitliche GPT-Vorschau:** Der farbige Vorschlagsbalken ist nun direkt klickbar und es gibt nur noch einen Tooltip
 * **Durchschnittlicher GPT-Score pro Projekt:** Die Projektübersicht zeigt nun den Mittelwert aller Bewertungen an

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -15,8 +15,11 @@ export const SCORE_COLORS = {
     'score-high': '#3A3'
 };
 
-// Ermittelt bei heller Hintergrundfarbe automatisch schwarze Schrift
+// Gibt die zur Score-Farbe passende Schriftfarbe zurück
 export function getContrastingTextColor(hex) {
+    const c = hex.toLowerCase();
+    if (c === '#bb8') return '#000'; // gelb -> schwarze Schrift
+    if (c === '#3a3' || c === '#a33') return '#fff'; // grün/rot -> weiße Schrift
     if (hex.length === 4) hex = '#' + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3];
     const r = parseInt(hex.substr(1, 2), 16);
     const g = parseInt(hex.substr(3, 2), 16);

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2285,6 +2285,7 @@ th:nth-child(10) {
 
 .similarity-score.medium {
     background: #ff9800;
+    color: #000;
 }
 
 .similarity-score.low {


### PR DESCRIPTION
## Summary
- Schriftfarbe bei gelbem Score auf schwarz setzen, sonst weiß
- `getContrastingTextColor` passt sich nun an festgelegte Score-Farben an
- Ändere README entsprechend

## Testing
- `node --unhandled-rejections=warn node_modules/jest/bin/jest.js --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861a5a4e164832799b9e9a69950b9bd