### PR TITLE
Score-Tooltip nur Kommentar

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Eigenes Wörterbuch:** Ein neuer 📚-Knopf speichert englische Wörter zusammen mit deutscher Lautschrift.
 * **Aktives Projekt hervorgehoben:** Das aktuell geöffnete Projekt ist in der Seitenleiste deutlich markiert.
 * **Hinweis-Symbol bei Übersetzungen:** Unter der Lupe erscheint ein kleines 📝, wenn der DE-Text ein Wort aus dem Wörterbuch enthält.
-* **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren zeigt ein Tooltip Kommentar und Vorschlag, ein Klick ersetzt den DE-Text und blinkt kurz blau auf
+* **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren zeigt ein Tooltip nur noch den Kommentar, ein Klick ersetzt den DE-Text und blinkt kurz blau auf
 * **Debug-Ausgabe für GPT:** Ist der Debug-Modus aktiv, erscheinen gesendete Daten und Antworten der GPT-API in der Konsole
 * **GPT-Konsole:** Beim Klick auf "Bewerten (GPT)" öffnet sich ein Fenster mit einem Log aller gesendeten Prompts und Antworten
 * **Prompt-Vorschau:** Vor dem eigentlichen Versand zeigt ein Dialog den kompletten Prompt an. Erst nach Klick auf "Senden" wird die Anfrage gestellt und die Antwort im selben Fenster angezeigt
@@ -53,7 +53,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Vorab-Dialog für GPT:** Vor dem Start zeigt ein Fenster, wie viele Zeilen und Sprecher enthalten sind
 * **Unbewertete Zeilen:** Noch nicht bewertete Zeilen zeigen eine graue 0
 * **Score-Spalte nach Version:** Die farbige Bewertung steht direkt vor dem EN-Text
-* **Anpassbarer Bewertungs-Prompt:** Der Text liegt in `prompts/gpt_score.txt`
+* **Anpassbarer Bewertungs-Prompt:** Der Text liegt in `prompts/gpt_score.txt`; jede Bewertung liefert nun immer auch einen Verbesserungsvorschlag
 * **Auswahl des GPT-Modells:** Im ChatGPT-Dialog lässt sich das Modell wählen. Die Liste wird auf Wunsch vom Server geladen und für 24&nbsp;Stunden gespeichert
 * **Automatisch geladene GPT-Einstellungen:** Gespeicherter Key und gewähltes Modell stehen nach dem Start sofort zur Verfügung
 * **Robuste GPT-Antworten:** Entfernt ```json-Blöcke``` automatisch und verhindert so Parsefehler

--- a/prompts/gpt_score.txt
+++ b/prompts/gpt_score.txt
@@ -15,14 +15,13 @@ Du erhältst einen **Block von Dialogzeilen** mit englischem Original, deutscher
      • 95–100 = perfekt/ sehr gut → grün  
      • 85–94  = akzeptabel, kleinere Schwächen → gelb  
      • < 85   = problematisch oder bedeutungsverkürzt → rot  
-   - Formuliere einen **knappen Kommentar** (max. 120 Zeichen), der den Score erklärt.
+   - Formuliere einen **knappen Kommentar** (max. 120 Zeichen), der Score und eventuelle Änderungen begründet.
 
-3. **Stiloptimierung**  
-   - Für alle Zeilen **mit Score < 95**:  
-     • Erstelle eine **alternative, idiomatische Fassung**, die  
-       – **vollständig** alle Originalbedeutungen enthält  
-       – **natürlich** gesprochen klingt  
-       – **charakter- und kontextgerecht** ist  
+3. **Stiloptimierung**
+   - Erstelle **für jede Zeile** eine **alternative, idiomatische Fassung**, die
+       – **vollständig** alle Originalbedeutungen enthält
+       – **natürlich** gesprochen klingt
+       – **charakter- und kontextgerecht** ist
      • Kürze nur, wenn **keine** Information verloren geht.
 
 Antworte **ausschließlich** im folgenden JSON-Array-Format:

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -45,7 +45,8 @@ export function attachScoreHandlers(tbody, files) {
         const id = Number(cell.parentElement?.dataset.id);
         const suggestion = cell.dataset.suggestion;
         const comment = cell.dataset.comment;
-        const tooltipText = [comment, suggestion].filter(Boolean).join(' - ');
+        // Beim Überfahren soll nur der Kommentar erscheinen
+        const tooltipText = comment;
         cell.addEventListener('mouseenter', ev => openScoreTooltip(ev, tooltipText));
         cell.addEventListener('mouseleave', closeScoreTooltip);
         if (suggestion) {


### PR DESCRIPTION
## Summary
- nur Kommentar im Score-Tooltip anzeigen
- Bewertungsprompt so anpassen, dass jede Zeile einen Vorschlag erhält
- README entsprechend aktualisieren

## Testing
- `npm test --runInBand` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6861ab86a9688327b5a2ba5b62d2b80a