### PR TITLE
Score-Klick zeigt Kommentar

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Eigenes Wörterbuch:** Ein neuer 📚-Knopf speichert englische Wörter zusammen mit deutscher Lautschrift.
 * **Aktives Projekt hervorgehoben:** Das aktuell geöffnete Projekt ist in der Seitenleiste deutlich markiert.
 * **Hinweis-Symbol bei Übersetzungen:** Unter der Lupe erscheint ein kleines 📝, wenn der DE-Text ein Wort aus dem Wörterbuch enthält.
-* **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren zeigt ein Tooltip nur noch den Kommentar, ein Klick ersetzt den DE-Text und blinkt kurz blau auf
+* **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren oder Anklicken des Scores erscheint nur der Kommentar. Den vorgeschlagenen Text übernimmst du jetzt durch Klick auf die farbige Box über dem DE-Feld
 * **Debug-Ausgabe für GPT:** Ist der Debug-Modus aktiv, erscheinen gesendete Daten und Antworten der GPT-API in der Konsole
 * **GPT-Konsole:** Beim Klick auf "Bewerten (GPT)" öffnet sich ein Fenster mit einem Log aller gesendeten Prompts und Antworten
 * **Prompt-Vorschau:** Vor dem eigentlichen Versand zeigt ein Dialog den kompletten Prompt an. Erst nach Klick auf "Senden" wird die Anfrage gestellt und die Antwort im selben Fenster angezeigt

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -43,15 +43,13 @@ export function scoreCellTemplate(file, escapeHtml) {
 export function attachScoreHandlers(tbody, files) {
     tbody.querySelectorAll('.score-cell').forEach(cell => {
         const id = Number(cell.parentElement?.dataset.id);
-        const suggestion = cell.dataset.suggestion;
         const comment = cell.dataset.comment;
-        // Beim Überfahren soll nur der Kommentar erscheinen
+        // Beim Überfahren erscheint der Kommentar
         const tooltipText = comment;
         cell.addEventListener('mouseenter', ev => openScoreTooltip(ev, tooltipText));
         cell.addEventListener('mouseleave', closeScoreTooltip);
-        if (suggestion) {
-            cell.addEventListener('click', () => applySuggestion(id, files));
-        }
+        // Klick zeigt nur noch den Kommentar
+        cell.addEventListener('click', ev => openScoreTooltip(ev, tooltipText));
     });
 }
 


### PR DESCRIPTION
## Summary
- reduziere Klick-Funktion auf Score-Zellen
- passe Doku zu GPT-Bewertungen an

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861b08046a88327b4205028e86a68a3