### PR TITLE
Fix Score Tooltip area

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Feineres Bewertungsschema:** Ab 95 % wird der Score grün, zwischen 85 % und 94 % gelb
 * **Score in Prozent:** Die Bewertung wird in der Tabelle mit Prozentzeichen dargestellt
 * **Aktive Score-Events:** Nach jedem Rendern bindet `attachScoreHandlers` Tooltip und Klick
+* **Kommentar-Anzeige auf ganzer Fläche:** Der Tooltip reagiert jetzt auf das gesamte Score-Feld
 * **Direkter Daten-Refresh:** Nach jeder Bewertung wird die Tabelle mit den aktualisierten Dateien neu gerendert
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
 * **Feste Schriftfarben:** Gelber Score nutzt schwarze Schrift, rot und gruen weiss

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -37,7 +37,8 @@ export function scoreCellTemplate(file, escapeHtml) {
     const com = escapeHtml(file.comment || '');
     // Score immer als Prozentwert anzeigen
     const scoreText = noScore ? '0' : file.score;
-    return `<td class="score-cell ${cls}" style="color:${color}" data-suggestion="${sug}" data-comment="${com}">${scoreText}%</td>`;
+    // Tooltip auch per title-Attribut hinterlegen, damit das gesamte Feld reagiert
+    return `<td class="score-cell ${cls}" title="${com}" style="color:${color}" data-suggestion="${sug}" data-comment="${com}">${scoreText}%</td>`;
 }
 
 export function attachScoreHandlers(tbody, files) {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2776,6 +2776,7 @@ th:nth-child(10) {
 /* Score-Bewertungen */
 .score-cell {
     text-align: center;
+    cursor: pointer; /* gesamtes Feld ist anklickbar */
 }
 
 .score-none {


### PR DESCRIPTION
## Summary
- Tooltip über title-Attribut auf ganze Score-Zelle erweitert
- Cursor auf Score-Feld zeigt jetzt anklickbaren Bereich an
- Dokumentation im README zur verbesserten Kommentar-Anzeige ergänzt

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6861b1a602f08327aa6de2b960c207b0