### PR TITLE
Add comment display over suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
 * **Feste Schriftfarben:** Gelber Score nutzt schwarze Schrift, rot und gruen weiss
 * **Bereinigte Vorschau-Anzeige:** Leere GPT-Vorschläge lassen keinen zusätzlichen Abstand mehr
+* **Kommentar über dem Vorschlag:** Ist ein Kommentar vorhanden, erscheint er in weißer Schrift direkt über der farbigen Box
 * **Einheitliche GPT-Vorschau:** Der farbige Vorschlagsbalken ist nun direkt klickbar und es gibt nur noch einen Tooltip
 * **Durchschnittlicher GPT-Score pro Projekt:** Die Projektübersicht zeigt nun den Mittelwert aller Bewertungen an
 * **Automatische Übernahme von GPT-Vorschlägen:** Eine neue Option setzt empfohlene Texte sofort in das DE-Feld

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2772,6 +2772,7 @@ return `
             </div>
         </div></td>
         <td>
+        <div class="comment-box" data-file-id="${file.id}">${escapeHtml(file.comment || '')}</div>
         <div class="suggestion-box ${scoreClass(file.score)}" style="color:${getContrastingTextColor(SCORE_COLORS[scoreClass(file.score)])}" data-file-id="${file.id}">${escapeHtml(file.suggestion || '')}</div>
         <div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
             <textarea class="text-input"
@@ -2831,6 +2832,7 @@ return `
         resizeTextFields();
         sortedFiles.forEach(f => {
             updateTranslationDisplay(f.id);
+            updateCommentDisplay(f.id);
             updateSuggestionDisplay(f.id);
         });
         // GPT-Vorschlag per Klick übernehmen
@@ -3998,6 +4000,16 @@ function updateSuggestionDisplay(fileId) {
         box.className = `suggestion-box ${cls}`;
         box.style.color = getContrastingTextColor(SCORE_COLORS[cls] || '#666');
         box.style.display = file.suggestion ? 'block' : 'none';
+    }
+}
+
+// Zeigt den GPT-Kommentar oberhalb des Vorschlags an
+function updateCommentDisplay(fileId) {
+    const box = document.querySelector(`.comment-box[data-file-id="${fileId}"]`);
+    const file = files.find(f => f.id === fileId);
+    if (box && file) {
+        box.textContent = file.comment || '';
+        box.style.display = file.comment ? 'block' : 'none';
     }
 }
 

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2807,6 +2807,14 @@ th:nth-child(10) {
     border-radius: 3px;
     cursor: pointer; /* Box ist jetzt direkt anklickbar */
 }
+.comment-box {
+    font-size: 0.8rem;
+    color: #fff;
+    margin-bottom: 2px;
+}
+.comment-box:empty {
+    display: none;
+}
 .suggestion-box.score-low,
 .suggestion-box.score-high {
     color: #fff;


### PR DESCRIPTION
## Summary
- display GPT-Kommentar über der farbigen Vorschlagsbox
- CSS um weiße Kommentarbox ergänzt
- README um neues Feature erweitert

## Testing
- `npm test --silent 2>&1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6861b398864c83279c2afa7f2863ee4f