### PR TITLE
Inaktive Level-Gruppen

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Eigenes Wörterbuch:** Der 📚-Knopf speichert nun sowohl englisch‑deutsche Übersetzungen als auch Lautschrift.
-* **Aktives Projekt hervorgehoben:** Das aktuell geöffnete Projekt ist in der Seitenleiste deutlich markiert.
-* **Überarbeitete Seitenleiste:** Kapitel, Level und Projekte zeigen Fortschritt, Sternewertung und Status-Badges in zwei Zeilen.
+* **Aktives Projekt hervorgehoben:** Der gewählte Eintrag hat nun einen blauen Balken und einen hellblauen Hintergrund.
+* **Überarbeitete Seitenleiste:** Jede Projektkarte besteht aus zwei Zeilen mit einheitlich breiten Badges für EN, DE und Audio.
+* **Aktiver Level hervorgehoben:** Geöffnete Level-Gruppen besitzen jetzt einen grünen Rahmen und einen leicht abgedunkelten Hintergrund.
+* **Dezente Level-Gruppen:** Geschlossene Level zeigen einen ganz leichten Hintergrund und nur beim Überfahren einen feinen Rahmen.
+* **Optimierte Titelzeile:** Lange Projektnamen werden mit "…" abgeschnitten, Nummer und Titel bleiben in einer Zeile.
+* **Einheitliche Fortschritts-Badges:** EN, DE und Audio sind nun 64×24 px groß und zentriert dargestellt.
 * **Hinweis-Symbol bei Übersetzungen:** Unter der Lupe erscheint ein kleines 📝, wenn der DE-Text ein Wort aus dem Wörterbuch enthält.
 * **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren oder Anklicken des Scores erscheint nur der Kommentar. Den vorgeschlagenen Text übernimmst du jetzt durch Klick auf die farbige Box über dem DE-Feld
 * **Debug-Ausgabe für GPT:** Ist der Debug-Modus aktiv, erscheinen gesendete Daten und Antworten der GPT-API in der Konsole

--- a/tests/scoreColumn.test.js
+++ b/tests/scoreColumn.test.js
@@ -13,13 +13,13 @@ describe('scoreClass', () => {
     expect(scoreClass(95)).toBe('score-high');
   });
 
-  test('liefert score-medium zwischen 85 und 94', () => {
+  test('liefert score-medium zwischen 80 und 94', () => {
     expect(scoreClass(94)).toBe('score-medium');
-    expect(scoreClass(85)).toBe('score-medium');
+    expect(scoreClass(80)).toBe('score-medium');
   });
 
-  test('liefert score-low unter 85', () => {
-    expect(scoreClass(84)).toBe('score-low');
+  test('liefert score-low unter 80', () => {
+    expect(scoreClass(79)).toBe('score-low');
     expect(scoreClass(0)).toBe('score-low');
   });
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1504,6 +1504,8 @@ function renderProjects() {
             .forEach(([lvl, prjs]) => {
             const group = document.createElement('div');
             group.className = 'level-container';
+            // Aktiver Level-Block erhält spezielle Klasse
+            if (expandedLevel === lvl) group.classList.add('active');
             if (expandedLevel && expandedLevel !== lvl) group.classList.add('collapsed');
 
         const order  = getLevelOrder(lvl);
@@ -1511,6 +1513,7 @@ function renderProjects() {
         let levelDone = true; // zeigt, ob alle Projekte fertig sind
         const header = document.createElement('div');
         header.className = 'level';
+        if (expandedLevel === lvl) header.classList.add('active');
         header.innerHTML = `
             <span>${order}.${lvl}</span>
             <div class="progress-bar"><div class="${levelStat.progress >= 90 ? 'progress-green' : levelStat.progress >= 75 ? 'progress-yellow' : 'progress-red'}" style="width:${levelStat.progress}%"></div></div>

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -4,7 +4,8 @@
 // Liefert die CSS-Klasse abhängig von der prozentualen Bewertung
 export function scoreClass(score) {
     if (score === undefined || score === null) return 'score-none';
-    return score >= 95 ? 'score-high' : score >= 85 ? 'score-medium' : 'score-low';
+    // Ab 95 grün, 80–94 gelb, darunter rot
+    return score >= 95 ? 'score-high' : score >= 80 ? 'score-medium' : 'score-low';
 }
 
 // Farbwerte passend zu den Score-Klassen

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -112,9 +112,10 @@ th:nth-child(10) {
 
         /* Aktuelles Projekt hervorheben */
         .project-item.active {
-            background: #ff6b1a !important; /* überschreibt Level-Farbe */
+            background: rgba(33,150,243,0.4) !important; /* leicht blau */
+            border-left: 3px solid #2196f3;
             color: #fff;
-            outline: 2px solid #fff;
+            outline: none;
         }
 
         .project-item .delete-btn {
@@ -2395,6 +2396,19 @@ th:nth-child(10) {
 
 /* =========================== LEVEL-GROUP STYLES START ======================= */
 .level-container { margin-bottom: 10px; }
+.level-container.active {
+    /* Gruener Rahmen und leichter Hintergrund fuer aktive Level-Gruppe */
+    border: 2px solid #66bb6a;
+    border-radius: 6px;
+    padding: 8px 0;
+    background: rgba(102,187,106,0.08);
+}
+.level-container.active .project-item {
+    margin-bottom: 6px;
+}
+.level-container.active .level {
+    margin-bottom: 6px;
+}
 .level {
     padding: 6px 10px;
     cursor: pointer;
@@ -2950,7 +2964,30 @@ th:nth-child(10) {
 .progress-green { background: #4caf50; }
 .progress-yellow { background: #ff9800; }
 .progress-red { background: #f44336; }
-.level-container { margin-left: 10px; margin-bottom: 8px; }
+.level-container {
+    margin-left: 10px;
+    margin-bottom: 8px;
+    padding: 4px 0;                     /* Weniger Abstand bei inaktiven Levels */
+    background: rgba(255,255,255,0.03); /* Dezente Abgrenzung */
+    border-radius: 6px;                 /* Gleiche Rundung wie aktive Box */
+}
+.level-container:not(.active):hover {
+    /* Neutraler Rahmen nur bei Mausberührung */
+    border: 1px solid rgba(255,255,255,0.1);
+}
+.level-container.active {
+    /* Gruener Rahmen und leichter Hintergrund fuer aktive Level-Gruppe */
+    border: 2px solid #66bb6a;
+    border-radius: 6px;
+    padding: 8px 0;
+    background: rgba(102,187,106,0.08);
+}
+.level-container.active .project-item {
+    margin-bottom: 6px;
+}
+.level-container.active .level {
+    margin-bottom: 6px;
+}
 .level {
     display: grid;
     grid-template-columns: auto 1fr auto;
@@ -2958,6 +2995,9 @@ th:nth-child(10) {
     align-items: center;
     cursor: pointer;
     font-weight: 500;
+}
+.level > span:last-child {
+    font-size: 0.9em; /* Pfeil wirkt nicht zu groß */
 }
 .projects { list-style: none; margin-left: 20px; padding-left: 0; }
 .project { margin-bottom: 6px; }
@@ -2968,6 +3008,16 @@ th:nth-child(10) {
     gap: 6px;
     align-items: center;
 }
+.project-title {
+    /* Nummer und Titel bleiben in einer Zeile */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 0.9em;
+    /* leichte Verschiebung nach oben für mittige Ausrichtung */
+    position: relative;
+    top: -1px;
+}
 .badge-summary {
     background: #673ab7;
     padding: 0 4px;
@@ -2975,16 +3025,27 @@ th:nth-child(10) {
     text-align: center;
 }
 .badge-detail {
+    /* Einheitliche Breite und Höhe der Fortschritts-Badges */
+    width: 64px;
+    height: 24px;
     padding: 0 4px;
     border-radius: 3px;
-    width: 60px;
-    text-align: center;
     font-size: 12px;
+    /* Text zentriert */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
 }
 .badge-detail.en { background: #2196f3; }
 .badge-detail.de { background: #4caf50; }
 .badge-detail.audio { background: #ff9800; }
-.details { display: flex; gap: 4px; }
+.details {
+    /* Flex-Layout mit gleichmäßigem Abstand */
+    display: flex;
+    gap: 6px;
+    flex-wrap: nowrap;
+}
 
 /* Fehlerbanner bei API-Problemen */
 .error-banner {


### PR DESCRIPTION
## Summary
- geschlossene Level erhalten dezente Darstellung mit Hover-Rahmen
- Pfeil im Level-Header etwas kleiner
- README listet die sanfte Abgrenzung der Level-Gruppen

## Testing
- `CI=true npm test --silent 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68626d4dd35083278637c7f9fb62f26a