### PR TITLE
Inaktive Level-Gruppen

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,14 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Eigenes Wörterbuch:** Der 📚-Knopf speichert nun sowohl englisch‑deutsche Übersetzungen als auch Lautschrift.
-* **Aktives Projekt hervorgehoben:** Das aktuell geöffnete Projekt ist in der Seitenleiste deutlich markiert.
-* **Überarbeitete Seitenleiste:** Kapitel, Level und Projekte zeigen Fortschritt, Sternewertung und Status-Badges in zwei Zeilen.
+* **Aktives Projekt hervorgehoben:** Der gewählte Eintrag hat nun einen blauen Balken und einen hellblauen Hintergrund.
+* **Überarbeitete Seitenleiste:** Jede Projektkarte besteht aus zwei Zeilen mit einheitlich breiten Badges für EN, DE und Audio.
+* **Aktiver Level hervorgehoben:** Geöffnete Level-Gruppen besitzen jetzt einen grünen Rahmen und einen leicht abgedunkelten Hintergrund.
+* **Dezente Level-Gruppen:** Geschlossene Level zeigen einen ganz leichten Hintergrund und nur beim Überfahren einen feinen Rahmen.
+* **Technische Level-Zeilen:** Level-Namen erscheinen in Monospace mit dezentem Hintergrund; beim Überfahren ändert sich der Pfeil kurz nach unten.
+* **Schlichte Kapitelüberschriften:** Jeder Abschnitt beginnt mit einer hellen Zeile samt Sternwertung, ohne Hover-Effekt oder Hintergrund.
+* **Optimierte Titelzeile:** Lange Projektnamen werden mit "…" abgeschnitten, Nummer und Titel bleiben in einer Zeile.
+* **Einheitliche Fortschritts-Badges:** EN, DE und Audio sind nun 64×24 px groß und zentriert dargestellt.
 * **Hinweis-Symbol bei Übersetzungen:** Unter der Lupe erscheint ein kleines 📝, wenn der DE-Text ein Wort aus dem Wörterbuch enthält.
 * **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren oder Anklicken des Scores erscheint nur der Kommentar. Den vorgeschlagenen Text übernimmst du jetzt durch Klick auf die farbige Box über dem DE-Feld
 * **Debug-Ausgabe für GPT:** Ist der Debug-Modus aktiv, erscheinen gesendete Daten und Antworten der GPT-API in der Konsole

--- a/tests/scoreColumn.test.js
+++ b/tests/scoreColumn.test.js
@@ -13,13 +13,13 @@ describe('scoreClass', () => {
     expect(scoreClass(95)).toBe('score-high');
   });
 
-  test('liefert score-medium zwischen 85 und 94', () => {
+  test('liefert score-medium zwischen 80 und 94', () => {
     expect(scoreClass(94)).toBe('score-medium');
-    expect(scoreClass(85)).toBe('score-medium');
+    expect(scoreClass(80)).toBe('score-medium');
   });
 
-  test('liefert score-low unter 85', () => {
-    expect(scoreClass(84)).toBe('score-low');
+  test('liefert score-low unter 80', () => {
+    expect(scoreClass(79)).toBe('score-low');
     expect(scoreClass(0)).toBe('score-low');
   });
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1470,21 +1470,15 @@ function renderProjects() {
         const chapterScore = chapterScoreCount ? Math.round(chapterScoreSum / chapterScoreCount) : 0;
         const chGroup = document.createElement('div');
         chGroup.className = 'chapter-container';
-        if (expandedChapter && expandedChapter !== chp) chGroup.classList.add('collapsed');
 
         const chHeader = document.createElement('div');
-        chHeader.className = 'chapter';
-        chHeader.style.background = getChapterColor(chp);
+        chHeader.className = 'chapter-header';
         chHeader.innerHTML = `
             <span class="chapter-title">${getChapterOrder(chp)}.${chp}</span>
             <span class="star ${scoreClass(chapterScore)}">★ ${chapterScore}</span>
             <button class="chapter-edit-btn" data-chapter="${chp}" onclick="showChapterCustomization(this.dataset.chapter, event)">⚙️</button>
         `;
-        chHeader.onclick = (e) => {
-            if (e.target.classList.contains('chapter-edit-btn')) return;
-            expandedChapter = expandedChapter === chp ? null : chp;
-            renderProjects();
-        };
+        // Kapitel-Header sind reine Überschriften ohne Klick-Funktion
         chGroup.appendChild(chHeader);
         const chBar = document.createElement('div');
         const chFillClass = chapterProgress >= 90 ? 'progress-green'
@@ -1504,22 +1498,33 @@ function renderProjects() {
             .forEach(([lvl, prjs]) => {
             const group = document.createElement('div');
             group.className = 'level-container';
+            // Aktiver Level-Block erhält spezielle Klasse
+            if (expandedLevel === lvl) group.classList.add('active');
             if (expandedLevel && expandedLevel !== lvl) group.classList.add('collapsed');
 
         const order  = getLevelOrder(lvl);
         const levelStat = levelStatsMap[lvl] || { progress: 0, score: 0 };
         let levelDone = true; // zeigt, ob alle Projekte fertig sind
         const header = document.createElement('div');
-        header.className = 'level';
+        header.className = 'level level-header';
+        if (expandedLevel === lvl) header.classList.add('active');
         header.innerHTML = `
             <span>${order}.${lvl}</span>
             <div class="progress-bar"><div class="${levelStat.progress >= 90 ? 'progress-green' : levelStat.progress >= 75 ? 'progress-yellow' : 'progress-red'}" style="width:${levelStat.progress}%"></div></div>
-            <span>${expandedLevel === lvl ? '▼' : '▶'}</span>
+            <span class="level-arrow">${expandedLevel === lvl ? '▼' : '▶'}</span>
         `;
         header.onclick = (e) => {
             expandedLevel = expandedLevel === lvl ? null : lvl;
             renderProjects();
         };
+        const arrowEl = header.querySelector('.level-arrow');
+        // Pfeil bei Hover vorübergehend nach unten zeigen
+        header.addEventListener('mouseenter', () => {
+            if (!header.classList.contains('active') && arrowEl) arrowEl.textContent = '▼';
+        });
+        header.addEventListener('mouseleave', () => {
+            if (!header.classList.contains('active') && arrowEl) arrowEl.textContent = '▶';
+        });
         group.appendChild(header);
 
         const wrap = document.createElement('div');

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -4,7 +4,8 @@
 // Liefert die CSS-Klasse abhängig von der prozentualen Bewertung
 export function scoreClass(score) {
     if (score === undefined || score === null) return 'score-none';
-    return score >= 95 ? 'score-high' : score >= 85 ? 'score-medium' : 'score-low';
+    // Ab 95 grün, 80–94 gelb, darunter rot
+    return score >= 95 ? 'score-high' : score >= 80 ? 'score-medium' : 'score-low';
 }
 
 // Farbwerte passend zu den Score-Klassen

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -112,9 +112,10 @@ th:nth-child(10) {
 
         /* Aktuelles Projekt hervorheben */
         .project-item.active {
-            background: #ff6b1a !important; /* überschreibt Level-Farbe */
+            background: rgba(33,150,243,0.4) !important; /* leicht blau */
+            border-left: 3px solid #2196f3;
             color: #fff;
-            outline: 2px solid #fff;
+            outline: none;
         }
 
         .project-item .delete-btn {
@@ -2395,6 +2396,19 @@ th:nth-child(10) {
 
 /* =========================== LEVEL-GROUP STYLES START ======================= */
 .level-container { margin-bottom: 10px; }
+.level-container.active {
+    /* Gruener Rahmen und leichter Hintergrund fuer aktive Level-Gruppe */
+    border: 2px solid #66bb6a;
+    border-radius: 6px;
+    padding: 8px 0;
+    background: rgba(102,187,106,0.08);
+}
+.level-container.active .project-item {
+    margin-bottom: 6px;
+}
+.level-container.active .level {
+    margin-bottom: 6px;
+}
 .level {
     padding: 6px 10px;
     cursor: pointer;
@@ -2413,18 +2427,28 @@ th:nth-child(10) {
 }
 
 /* =========================== CHAPTER-GROUP STYLES START ==================== */
-.chapter-container { margin-bottom: 14px; }
-.chapter {
-    padding: 8px 10px;
-    background: #222;
-    color: #fff;
-    font-weight: 700;
-    border-radius: 4px;
-    cursor: pointer;
-    margin-bottom: 6px;
+.chapter-container {
+    margin-bottom: 12px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid rgba(255,255,255,0.05); /* leichter Trennstrich */
+}
+.chapter-header {
+    padding: 0;
+    background: transparent;
+    color: #eee;
+    font-weight: bold;
+    margin: 8px 0;
     display: flex;
     align-items: center;
     justify-content: space-between;
+    cursor: default;
+}
+.chapter-header .star {
+    font-size: 0.9em;             /* Stern etwas kleiner */
+    padding: 0 4px;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;           /* Vertikal mittig */
 }
 .chapter-edit-btn {
     background: none;
@@ -2437,7 +2461,7 @@ th:nth-child(10) {
     transition: opacity 0.2s;
     font-size: 12px;
 }
-.chapter:hover .chapter-edit-btn { opacity: 1; }
+.chapter-header:hover .chapter-edit-btn { opacity: 1; }
 .chapter-edit-btn:hover { background: rgba(255,255,255,0.2); }
 .chapter-container.collapsed .chapter-levels { display: none; }
 /* =========================== CHAPTER-GROUP STYLES END ====================== */
@@ -2923,23 +2947,6 @@ th:nth-child(10) {
     top: 0;
 }
 
-/* ===== Neue Sidebar-Elemente ===== */
-.chapter-container {
-    margin-bottom: 12px;
-}
-.chapter {
-    display: flex;
-    justify-content: space-between;
-    padding: 4px 8px;
-    background: #222;
-    font-weight: 600;
-    border-radius: 4px;
-    cursor: pointer;
-}
-.chapter .star {
-    padding: 0 4px;
-    border-radius: 3px;
-}
 .progress-bar {
     height: 4px;
     background: #333;
@@ -2950,7 +2957,30 @@ th:nth-child(10) {
 .progress-green { background: #4caf50; }
 .progress-yellow { background: #ff9800; }
 .progress-red { background: #f44336; }
-.level-container { margin-left: 10px; margin-bottom: 8px; }
+.level-container {
+    margin-left: 10px;
+    margin-bottom: 8px;
+    padding: 4px 0;                     /* Weniger Abstand bei inaktiven Levels */
+    background: rgba(255,255,255,0.03); /* Dezente Abgrenzung */
+    border-radius: 6px;                 /* Gleiche Rundung wie aktive Box */
+}
+.level-container:not(.active):hover {
+    /* Neutraler Rahmen nur bei Mausberührung */
+    border: 1px solid rgba(255,255,255,0.1);
+}
+.level-container.active {
+    /* Gruener Rahmen und leichter Hintergrund fuer aktive Level-Gruppe */
+    border: 2px solid #66bb6a;
+    border-radius: 6px;
+    padding: 8px 0;
+    background: rgba(102,187,106,0.08);
+}
+.level-container.active .project-item {
+    margin-bottom: 6px;
+}
+.level-container.active .level {
+    margin-bottom: 6px;
+}
 .level {
     display: grid;
     grid-template-columns: auto 1fr auto;
@@ -2958,6 +2988,24 @@ th:nth-child(10) {
     align-items: center;
     cursor: pointer;
     font-weight: 500;
+}
+.level-header {
+    font-family: "Courier New", monospace; /* technische IDs in Monospace */
+    font-size: 1em;
+    color: #ccc;
+    padding: 4px 8px;
+    background: rgba(255,255,255,0.05);
+    border-radius: 4px;
+}
+.level-header .level-arrow {
+    color: #888;
+    transition: color 0.2s;
+}
+.level-header:hover .level-arrow {
+    color: #aaa;
+}
+.level > span:last-child {
+    font-size: 0.9em; /* Pfeil wirkt nicht zu groß */
 }
 .projects { list-style: none; margin-left: 20px; padding-left: 0; }
 .project { margin-bottom: 6px; }
@@ -2968,6 +3016,16 @@ th:nth-child(10) {
     gap: 6px;
     align-items: center;
 }
+.project-title {
+    /* Nummer und Titel bleiben in einer Zeile */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 0.9em;
+    /* leichte Verschiebung nach oben für mittige Ausrichtung */
+    position: relative;
+    top: -1px;
+}
 .badge-summary {
     background: #673ab7;
     padding: 0 4px;
@@ -2975,16 +3033,27 @@ th:nth-child(10) {
     text-align: center;
 }
 .badge-detail {
+    /* Einheitliche Breite und Höhe der Fortschritts-Badges */
+    width: 64px;
+    height: 24px;
     padding: 0 4px;
     border-radius: 3px;
-    width: 60px;
-    text-align: center;
     font-size: 12px;
+    /* Text zentriert */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
 }
 .badge-detail.en { background: #2196f3; }
 .badge-detail.de { background: #4caf50; }
 .badge-detail.audio { background: #ff9800; }
-.details { display: flex; gap: 4px; }
+.details {
+    /* Flex-Layout mit gleichmäßigem Abstand */
+    display: flex;
+    gap: 6px;
+    flex-wrap: nowrap;
+}
 
 /* Fehlerbanner bei API-Problemen */
 .error-banner {


### PR DESCRIPTION
## Summary
- geschlossene Level erhalten dezente Darstellung mit Hover-Rahmen
- Pfeil im Level-Header etwas kleiner
- README listet die sanfte Abgrenzung der Level-Gruppen
- Kapitelüberschriften sind jetzt hell und ohne Hintergrund
- Levelzeilen sind in Monospace gesetzt, haben einen leichten Hintergrund und zeigen beim Überfahren kurzfristig einen Pfeil nach unten

## Testing
- `CI=true npm test --silent > /tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68626d4dd35083278637c7f9fb62f26a