### PR TITLE
Dubbing-Spalte erweitert

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Zurücksetzen nach Upload oder Dubbing:** Sowohl beim Hochladen als auch beim erneuten Erzeugen einer deutschen Audiodatei werden Lautstärkeangleichung, Funkgerät‑Effekt und Hall‑Effekt automatisch deaktiviert.
 * **Fehlerhinweise beim Speichern:** Tritt ein Problem auf, erscheint eine rote Toast-Meldung statt eines stummen Abbruchs.
 * **Neue Meldung:** Scheitert das Anlegen einer History-Version, wird "Fehler beim Anlegen der History-Version" ausgegeben.
-* **Dynamische Download-Spalte:** Die Spalte erscheint nur bei Bedarf und blendet sich aus, ohne die Tabellenüberschriften zu verschieben. Der blaue Download-Pfeil zeigt nun beim Überfahren mit der Maus die Dubbing-ID an und öffnet beim Anklicken die ElevenLabs-Seite des entsprechenden Jobs.
+* **Kompaktere Dubbing-Spalte:** Der Statuspunkt und der Download-Pfeil stehen jetzt direkt neben dem Dubbing-Button in einer gemeinsamen Spalte.
 * **Bugfix:** Ein Klick auf den Download-Pfeil öffnet jetzt zuverlässig die korrekte V1-Dubbing-Seite.
 * **Automatik-Button für halbautomatisches Dubbing:** Per Playwright werden alle notwendigen Klicks im ElevenLabs-Studio ausgeführt.
 * **Ordnername in Zwischenablage:** Beim halbautomatischen Dubbing kopiert das Tool nur noch den reinen Ordnernamen in die Zwischenablage, sobald auf die fertige Datei gewartet wird.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -173,10 +173,8 @@
         <th width="40">UT-Suche</th>
         <th width="120" title="Pfad der EN- und DE-Datei">Pfad</th>
         <th width="60">Upload</th>
-        <th width="60">Dubbing</th>
-        <th width="40">Dub-Status</th>
+        <th width="120">Dubbing</th>
         <th width="40" title="Längenvergleich">Länge</th>
-        <th width="90" id="dubDownloadHeader" class="hidden">Download DE</th>
         <th width="60">Historie</th>
         <th width="60">Bearbeiten</th>
         <th width="60">Löschen</th>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2914,10 +2914,14 @@ return `
             <span class="path-detail">EN: sounds/EN/${relPath}<br>DE: ${dePath ? `sounds/DE/${dePath}` : 'fehlend'}</span>
         </td>
         <td><button class="upload-btn" onclick="initiateDeUpload(${file.id})">⬆️</button></td>
-        <td><button class="dubbing-btn" onclick="initiateDubbing(${file.id})">🔈</button></td>
-        <td><span class="dub-status ${!file.dubbingId ? 'none' : (file.dubReady ? 'done' : 'pending')}" title="${!file.dubbingId ? 'kein Dubbing' : (file.dubReady ? 'fertig' : 'Studio generiert noch')}" ${(!file.dubbingId || file.dubReady) ? '' : `onclick="dubStatusClicked(${file.id})"`}>●</span></td>
+        <td>
+            <div class="dubbing-cell">
+                <button class="dubbing-btn" onclick="initiateDubbing(${file.id})">🔈</button>
+                <span class="dub-status ${!file.dubbingId ? 'none' : (file.dubReady ? 'done' : 'pending')}" title="${!file.dubbingId ? 'kein Dubbing' : (file.dubReady ? 'fertig' : 'Studio generiert noch')}" ${(!file.dubbingId || file.dubReady) ? '' : `onclick=\"dubStatusClicked(${file.id})\"`}>●</span>
+                ${file.dubbingId ? `<button class="download-de-btn" data-file-id="${file.id}" title="Dubbing-ID: ${file.dubbingId}" onclick="openDubbingPage(${file.id})">⬇️</button>` : ''}
+            </div>
+        </td>
         <td><span class="length-diff ${lengthClass}">${lengthIndicator}</span></td>
-        <td class="download-cell">${file.dubbingId ? `<button class="download-de-btn" data-file-id="${file.id}" title="Dubbing-ID: ${file.dubbingId}" onclick="openDubbingPage(${file.id})">⬇️</button>` : ''}</td>
         <td>${hasHistory ? `<button class="history-btn" onclick="openHistory(${file.id})">🕒</button>` : ''}</td>
         <td><div style="display:flex;align-items:flex-start;gap:5px;">
             <button class="edit-audio-btn" onclick="openDeEdit(${file.id})">✂️</button>
@@ -3973,16 +3977,10 @@ function addPathCellContextMenus() {
 
 // Prüft bei allen Download-Buttons den Status und aktiviert sie ggf.
 async function updateDubButtons() {
-    const header = document.getElementById('dubDownloadHeader');
     const buttons = document.querySelectorAll('.download-de-btn');
-    const cells   = document.querySelectorAll('.download-cell');
     if (buttons.length === 0) {
-        if (header) header.classList.add('hidden');
-        cells.forEach(c => c.style.display = 'none');
         return;
     }
-    if (header) header.classList.remove('hidden');
-    cells.forEach(c => c.style.display = 'table-cell');
     for (const btn of buttons) {
         const id = parseInt(btn.dataset.fileId, 10);
         const file = files.find(f => f.id === id);

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -9,9 +9,11 @@
             display: none !important;
         }
 
-        /* Download-Spalte standardmäßig ausgeblendet */
-        .download-cell {
-            display: none;
+        /* Zentrale Buttons und Status in einer Zelle */
+        .dubbing-cell {
+            display: flex;
+            align-items: center;
+            gap: 4px;
         }
 
         body {


### PR DESCRIPTION
## Zusammenfassung
- Dubbing-Status und Download-Button direkt in die Spalte *Dubbing* integriert
- HTML-Layout entsprechend angepasst
- Styles für neue `dubbing-cell` hinzugefügt
- README ergänzt

## Testanweisungen
- `npx jest --runInBand --json --outputFile=jest_results.json`


------
https://chatgpt.com/codex/tasks/task_e_6862a806363c8327ae091428dffb460e