### PR TITLE
Fix context menus for projects and add level/chapter menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,11 +577,13 @@ In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über da
 | **Projekt löschen**       | Rechtsklick auf Projekt → 🗑️ löschen |
 | **Projekt umbenennen**    | Doppelklick auf Projekt‑Name                      |
 | **Projekt sortieren**     | Drag & Drop der Projekt‑Kacheln                   |
-| **Kapitel anpassen**      | ⚙️ neben Kapitel‑Titel → Name, Farbe, Löschen |
+| **Kapitel anpassen**      | Rechtsklick auf Kapitel-Titel → Bearbeiten/Löschen |
+| **Level anpassen**        | Rechtsklick auf Level-Titel → Bearbeiten/Löschen |
 | **Level‑Name kopieren**   | ⧉‑Button in Meta‑Leiste                           |
 | **Half-Life: Alyx starten** | Zentrale Start-Leiste mit Modus‑ und Sprachauswahl sowie optionalem +map‑Parameter |
 
 Beim Rechtsklick auf eine Projekt‑Kachel erscheint ein kleines Menü zum Bearbeiten (⚙️) oder Löschen (🗑️) des Projekts.
+Auch Kapitel und Level bieten dieses Rechtsklick-Menü.
 
 ### Datei‑Management
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -260,6 +260,26 @@
         </div>
     </div>
 
+    <!-- Level Context Menu -->
+    <div class="context-menu" id="levelContextMenu">
+        <div class="context-menu-item" onclick="levelMenuAction('edit')">
+            <span>⚙️</span> Level bearbeiten
+        </div>
+        <div class="context-menu-item danger" onclick="levelMenuAction('delete')">
+            <span>🗑️</span> Level löschen
+        </div>
+    </div>
+
+    <!-- Chapter Context Menu -->
+    <div class="context-menu" id="chapterContextMenu">
+        <div class="context-menu-item" onclick="chapterMenuAction('edit')">
+            <span>⚙️</span> Kapitel bearbeiten
+        </div>
+        <div class="context-menu-item danger" onclick="chapterMenuAction('delete')">
+            <span>🗑️</span> Kapitel löschen
+        </div>
+    </div>
+
     <!-- Import Dialog -->
     <div class="dialog-overlay hidden" id="importDialog">
         <div class="dialog">


### PR DESCRIPTION
## Summary
- fixed project context menu so editing works again
- added context menus for levels and chapters with edit/delete
- implemented deleteLevel and deleteChapter helpers
- documented the new menus in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862b44e9c008327b019669f3a81a2c7