### PR TITLE
Add quick project/level context actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 * **Keyboard‑Navigation:** Pfeiltasten, Tab, Leertaste für Audio, Enter für Texteingabe
 * **Context‑Menu** (Rechtsklick): Audio, Kopieren, Einfügen, Ordner öffnen, Löschen
+* **Schnell hinzufügen:** Rechtsklick auf Level → Schnellprojekt, Rechtsklick auf Kapitel → Schnell‑Level
 * **Drag & Drop:** Projekte und Dateien sortieren
 * **Klick auf Zeilennummer:** Position über Dialog anpassen
 * **Doppelklick:** Projekt umbenennen
@@ -546,6 +547,7 @@ In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über da
 * Beim Start liest die App automatisch alle Audio‑Dateien aus `web/sounds/EN` und vorhandene Übersetzungen aus `web/sounds/DE` ein
 
 ### 2. 📂 Neues Projekt erstellen
+| **Schnellprojekt**        | Rechtsklick auf Level → Schnellprojekt |
 * Klicken Sie auf **„+ Neues Projekt"**
 * Vergeben Sie einen Namen
 * Optional: Level‑Name und Teil‑Nummer angeben
@@ -572,12 +574,14 @@ In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über da
 |  Aktion                    |  Bedienung                                          |
 | -------------------------- | --------------------------------------------------- |
 | **Projekt erstellen**     | `+ Neues Projekt` Button                          |
+| **Schnellprojekt**        | Rechtsklick auf Level → Schnellprojekt |
 | **Projekt auswählen**     | Klick auf Projekt‑Kachel                          |
 | **Projekt anpassen**      | Rechtsklick auf Projekt → ⚙️ bearbeiten |
 | **Projekt löschen**       | Rechtsklick auf Projekt → 🗑️ löschen |
 | **Projekt umbenennen**    | Doppelklick auf Projekt‑Name                      |
 | **Projekt sortieren**     | Drag & Drop der Projekt‑Kacheln                   |
 | **Kapitel anpassen**      | Rechtsklick auf Kapitel-Titel → Bearbeiten/Löschen |
+| **Schnell-Level**         | Rechtsklick auf Kapitel → Schnell-Level |
 | **Level anpassen**        | Rechtsklick auf Level-Titel → Bearbeiten/Löschen |
 | **Level‑Name kopieren**   | ⧉‑Button in Meta‑Leiste                           |
 | **Half-Life: Alyx starten** | Zentrale Start-Leiste mit Modus‑ und Sprachauswahl sowie optionalem +map‑Parameter |

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -265,6 +265,9 @@
         <div class="context-menu-item" onclick="levelMenuAction('edit')">
             <span>⚙️</span> Level bearbeiten
         </div>
+        <div class="context-menu-item" onclick="levelMenuAction('quickProject')">
+            <span>➕</span> Schnellprojekt
+        </div>
         <div class="context-menu-item danger" onclick="levelMenuAction('delete')">
             <span>🗑️</span> Level löschen
         </div>
@@ -274,6 +277,9 @@
     <div class="context-menu" id="chapterContextMenu">
         <div class="context-menu-item" onclick="chapterMenuAction('edit')">
             <span>⚙️</span> Kapitel bearbeiten
+        </div>
+        <div class="context-menu-item" onclick="chapterMenuAction('quickLevel')">
+            <span>➕</span> Schnell-Level
         </div>
         <div class="context-menu-item danger" onclick="chapterMenuAction('delete')">
             <span>🗑️</span> Kapitel löschen

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1796,6 +1796,36 @@ function addProject() {
 }
 /* =========================== ADD PROJECT END =========================== */
 
+/* =========================== QUICK ADD PROJECT START =========================== */
+function quickAddProject(levelName) {
+    // Nächste freie Nummer für ein "Neu"-Projekt bestimmen
+    const existing = projects
+        .filter(p => p.levelName === levelName)
+        .map(p => p.name);
+    let maxNum = 0;
+    existing.forEach(n => {
+        const m = n.match(/^Neu (\d+)$/);
+        if (m) {
+            const num = parseInt(m[1]);
+            if (num > maxNum) maxNum = num;
+        }
+    });
+    const prj = {
+        id: Date.now(),
+        name: `Neu ${maxNum + 1}`,
+        levelName: levelName,
+        levelPart: 1,
+        files: [],
+        icon: '🗂️',
+        color: getLevelColor(levelName)
+    };
+
+    projects.push(prj);
+    saveProjects();
+    renderProjects();
+}
+/* =========================== QUICK ADD PROJECT END =========================== */
+
 
 
         function deleteProject(id, event) {
@@ -2771,7 +2801,7 @@ function addFiles() {
             levelContextName = null;
         }
 
-        function levelMenuAction(action) {
+function levelMenuAction(action) {
             if (!levelContextName) return;
             const lvl = levelContextName;
             hideLevelMenu();
@@ -2779,6 +2809,8 @@ function addFiles() {
                 showLevelCustomization(lvl);
             } else if (action === 'delete') {
                 deleteLevel(lvl);
+            } else if (action === 'quickProject') {
+                quickAddProject(lvl);
             }
         }
 
@@ -2801,7 +2833,7 @@ function addFiles() {
             chapterContextName = null;
         }
 
-        function chapterMenuAction(action) {
+function chapterMenuAction(action) {
             if (!chapterContextName) return;
             const ch = chapterContextName;
             hideChapterMenu();
@@ -2809,6 +2841,8 @@ function addFiles() {
                 showChapterCustomization(ch);
             } else if (action === 'delete') {
                 deleteChapter(ch);
+            } else if (action === 'quickLevel') {
+                quickAddLevel(ch);
             }
         }
 
@@ -11342,6 +11376,36 @@ function deleteChapter(chapterName) {
     saveChapterColors();
     renderProjects();
 }
+
+/* =========================== QUICK ADD LEVEL START =========================== */
+function quickAddLevel(chapterName) {
+    // Nächste freie Nummer für ein "Neu"-Level finden
+    const levelNames = Object.keys(levelOrders);
+    let maxNum = 0;
+    levelNames.forEach(n => {
+        const m = n.match(/^Neu (\d+)$/);
+        if (m) {
+            const num = parseInt(m[1]);
+            if (num > maxNum) maxNum = num;
+        }
+    });
+
+    const orderValues = Object.values(levelOrders);
+    const nextOrder = orderValues.length ? Math.max(...orderValues) + 1 : 1;
+    const name = `Neu ${maxNum + 1}`;
+
+    levelOrders[name] = nextOrder;
+    levelChapters[name] = chapterName;
+    levelColors[name] = '#444444';
+    levelIcons[name] = '📁';
+
+    saveLevelOrders();
+    saveLevelChapters();
+    saveLevelColors();
+    saveLevelIcons();
+    renderProjects();
+}
+/* =========================== QUICK ADD LEVEL END =========================== */
 
 
 


### PR DESCRIPTION
## Summary
- add Schnellprojekt and Schnell-Level context menu actions
- create helper functions to quickly create numbered projects and levels
- document new features in README

## Testing
- `npx jest tests/markDubAsReady.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6863a10de7a08327ae161a3c7b7ba833