### PR TITLE
Verbesserte Backup-Anzeige

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ Dort gibt es jetzt auch einen Bereich **ChatGPT API**. Der Schlüssel wird lokal
 
 ## 💾 Backup
 
-Mit dem Backup-Dialog lassen sich alle Projekt-Daten als JSON speichern. Neu ist die Option, die Ordner **Sounds/DE**, **DE-Backup** und **DE-History** als ZIP-Archiv zu sichern. Die ZIP-Dateien liegen im Benutzerordner unter `Backups/sounds`. Das Tool behält automatisch nur die fünf neuesten ZIP-Backups.
+Mit dem Backup-Dialog lassen sich alle Projekt-Daten als JSON speichern. Neu ist die Option, die Ordner **Sounds/DE**, **DE-Backup** und **DE-History** als ZIP-Archiv zu sichern. Die ZIP-Dateien liegen im Benutzerordner unter `Backups/sounds`. Das Tool behält automatisch nur die fünf neuesten ZIP-Backups. Die Liste der Backups zeigt nun Datum und Uhrzeit an, sortiert mit dem aktuellsten Eintrag oben.
 
 
 ## 🗂️ Projektstruktur

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1736,6 +1736,12 @@ th:nth-child(10) {
             margin-bottom: 8px;
         }
 
+        /* Markiert das neueste Backup */
+        .backup-item.latest {
+            border-color: #888;
+            background: #252525;
+        }
+
         .backup-item button {
             margin-left: 10px;
         }


### PR DESCRIPTION
## Summary
- parse dates from backup-Dateien und sortiere sie
- markiere das neueste Backup im Dialog
- erweitere Style um `.backup-item.latest`
- dokumentiere die neue Anzeige im README

## Testing
- `npm test > /tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_6863bde618948327aff8d0629cb2fbe8