### PR TITLE
Bugfix: Windows-Start für Steam-URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,8 @@ Seit Patch 1.40.98 erlaubt die Content Security Policy nun auch Verbindungen zu 
 Seit Patch 1.40.99 befindet sich der Hinweis zu oEmbed nicht mehr im Meta-Tag selbst. Dadurch zeigt der Browser keine CSP-Warnung mehr an.
 Seit Patch 1.40.100 erlaubt die Content Security Policy nun Verbindungen zu `api.openai.com`, damit der GPT-Key-Test im Einstellungsdialog funktioniert.
 Seit Patch 1.40.101 besitzt das Wörterbuch zwei Bereiche: Englisch‑Deutsch und Englisch‑Phonetisch.
+Seit Patch 1.40.102 öffnet `launch_hla.py` Steam-URLs unter Windows korrekt mit `os.startfile`,
+damit kein `[WinError 2]` mehr auftritt.
 
 Beispiel einer gültigen CSV:
 

--- a/launch_hla.py
+++ b/launch_hla.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from urllib.parse import quote
 try:
     import winreg
@@ -69,11 +70,19 @@ def start_hla(mode: str = "normal", lang: str = "english", level: str | None = N
         encoded = quote(" ".join(args))
         url = f"{base_url}/{encoded}"
 
-    opener = "xdg-open" if os.name == "posix" else "open"
-    try:
-        subprocess.Popen([opener, url])
-    except OSError:
-        return False
+    # Unter Windows nutzen wir os.startfile, da es keinen 'open'-Befehl gibt
+    if os.name == "nt":
+        try:
+            os.startfile(url)
+        except OSError:
+            return False
+    else:
+        # macOS verwendet 'open', Linux 'xdg-open'
+        opener = "open" if sys.platform == "darwin" else "xdg-open"
+        try:
+            subprocess.Popen([opener, url])
+        except OSError:
+            return False
     return True
 
 


### PR DESCRIPTION
## Zusammenfassung
- beende `[WinError 2]` beim Aufruf von Steam-URLs
- Kommentar auf Deutsch für den neuen Zweig
- Hinweis auf den Fix im README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68653528f6d083279787073c1f4626e7