### PR TITLE
Add dedicated emotional dubbing button

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Kompaktere Dubbing-Spalte:** Der Statuspunkt und der Download-Pfeil stehen jetzt direkt neben dem Dubbing-Button in einer gemeinsamen Spalte.
 * **Bugfix:** Ein Klick auf den Download-Pfeil öffnet jetzt zuverlässig die korrekte V1-Dubbing-Seite.
 * **Automatik-Button für halbautomatisches Dubbing:** Per Playwright werden alle notwendigen Klicks im ElevenLabs-Studio ausgeführt.
-* **Neuer Button „Dubbing (DE)“:** Erzeugt über ElevenLabs V3 eine deutsche Audiodatei aus dem violetten Emotionsfeld.
+* **Neuer Button „Dubbing (Emo)“:** Erstellt automatisch eine emotionale Spur über ElevenLabs V3. Halbautomatik ist hier nicht verfügbar.
+* **Eigene Dubbing‑ID für Emotionen:** Das emotionale Dubbing speichert eine separate ID und besitzt einen eigenen Download‑Pfeil.
 * **Neuer Button „Fertig (DE)“:** Markiert die Zeile als fertig vertont im Emotionsmodus.
 * **Ordnername in Zwischenablage:** Beim halbautomatischen Dubbing kopiert das Tool nur noch den reinen Ordnernamen in die Zwischenablage, sobald auf die fertige Datei gewartet wird.
 * **Bugfix:** Der Ordnername wird jetzt bereits beim Start des Halbautomatik-Dubbings automatisch kopiert.

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -823,6 +823,13 @@ th:nth-child(10) {
             text-align: center;
         }
 
+        .emo-dub-status {
+            font-size: 18px;
+            display: inline-block;
+            width: 24px;
+            text-align: center;
+        }
+
         .dub-status.none {
             color: #777;
         }
@@ -832,6 +839,18 @@ th:nth-child(10) {
         }
 
         .dub-status.done {
+            color: #4caf50;
+        }
+
+        .emo-dub-status.none {
+            color: #777;
+        }
+
+        .emo-dub-status.pending {
+            color: #ffc107;
+        }
+
+        .emo-dub-status.done {
             color: #4caf50;
         }
 


### PR DESCRIPTION
## Summary
- Emotionale Dubbing-Spur über eigenen Button starten
- Halbautomatik beim emotionalen Dubbing deaktiviert
- Neues Fenster für emotionales Dubbing mit eigener ID
- README um Beschreibung des Buttons ergänzt

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687004eb84a483278fd57318c7997ecf