### PR TITLE
Add dedicated emotional dubbing window and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,9 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Kompaktere Dubbing-Spalte:** Der Statuspunkt und der Download-Pfeil stehen jetzt direkt neben dem Dubbing-Button in einer gemeinsamen Spalte.
 * **Bugfix:** Ein Klick auf den Download-Pfeil öffnet jetzt zuverlässig die korrekte V1-Dubbing-Seite.
 * **Automatik-Button für halbautomatisches Dubbing:** Per Playwright werden alle notwendigen Klicks im ElevenLabs-Studio ausgeführt.
-* **Neuer Button „Dubbing (DE)“:** Erzeugt über ElevenLabs V3 eine deutsche Audiodatei aus dem violetten Emotionsfeld.
+* **Neuer Button „Dubbing (Emo)“:** Öffnet ein eigenes Fenster und erzeugt über die Text‑to‑Speech‑API (V3) eine emotionale Spur. Halbautomatik steht hier nicht zur Verfügung.
+* **API-Schlüssel wie gewohnt:** Auch für Emotionen verwendet das Tool den gespeicherten ElevenLabs-Key aus den Einstellungen.
+* **Eigene Dubbing‑ID für Emotionen:** Das emotionale Dubbing speichert eine separate ID, die über einen zusätzlichen Pfeil erneut geladen werden kann.
 * **Neuer Button „Fertig (DE)“:** Markiert die Zeile als fertig vertont im Emotionsmodus.
 * **Ordnername in Zwischenablage:** Beim halbautomatischen Dubbing kopiert das Tool nur noch den reinen Ordnernamen in die Zwischenablage, sobald auf die fertige Datei gewartet wird.
 * **Bugfix:** Der Ordnername wird jetzt bereits beim Start des Halbautomatik-Dubbings automatisch kopiert.
@@ -420,6 +422,29 @@ Ein Watcher überwacht automatisch den Ordner `web/Download` bzw. `web/Downloads
 Der automatische Import greift also nur, wenn eine Dubbing-ID passt.
 Taucht eine unbekannte Datei auf, öffnet sich stattdessen der Import-Dialog.
 Persönliche Zusätze wie `_Alex` oder `-Bob` entfernt er dabei automatisch.
+\n### Emotionales Dubbing (v3)
+\nDie Emotionen nutzen eine eigene Version der ElevenLabs-API. Der neue Button ruft den folgenden Endpunkt auf und speichert die Antwort als WAV-Datei: Der API-Schlüssel wird dabei automatisch aus den Einstellungen übernommen:
+\n```text
+POST https://api.elevenlabs.io/v1/text-to-speech/{voice_id}/stream
+xi-api-key: <DEIN_API_KEY>
+Content-Type: application/json
+Accept: audio/mpeg
+
+{
+  "text": "Deutscher Text mit Emotionen z. B. Hallo, [freudig] wie schön, dich zu sehen!",
+  "model_id": "eleven_v3",
+  "voice_settings": {
+    "stability": 0.5,
+    "similarity_boost": 0.75,
+    "style": 0.4,
+    "use_speaker_boost": true
+  }
+}
+```
+
+**Hinweis:** Unterstützte Tags sind z.&nbsp;B. `[flüsternd]`, `[besorgt]`, `[verzweifelt]`, `[freudig]`, `[sarkastisch]`, `[wütend]`, `[ironisch]`, `[müde]`. Sie lassen sich kombinieren, etwa `[verwirrt][leise] Das meinst du nicht ernst, oder?`
+
+Die API liefert einen Audio-Stream. Dieser wird wie gewohnt im Projekt gespeichert und die erhaltene ID unter `emoDubbingId` abgelegt.
 Seit Patch 1.40.7 merkt sich das Tool außerdem den fertigen Status dauerhaft. Auch nach einem erneuten Download bleibt der grüne Haken erhalten.
 Seit Patch 1.40.8 werden Dateien auch dann korrekt verschoben, wenn sich Download- und Projektordner auf unterschiedlichen Laufwerken befinden.
 Seit Patch 1.40.9 merkt sich der Level-Dialog die zuletzt genutzten fünf Farben und bietet eine Schnellwahl unter dem Farbpicker.

--- a/web/src/dubbing.js
+++ b/web/src/dubbing.js
@@ -87,6 +87,92 @@ async function showDubbingSettings(fileId, mode = currentDubMode) {
     bindDubSettingListeners();
 }
 
+// =========================== SHOWEMODUBBINGSETTINGS START ====================
+// Eigenes Einstellungsfenster für emotionales Dubbing
+async function showEmoDubbingSettings(fileId) {
+    currentDubbingFileId = fileId;
+    currentDubMode = 'beta';
+    const file = files.find(f => f.id === fileId) || {};
+    const voiceId = folderCustomizations[file.folder]?.voiceId || '';
+    let voiceName = voiceId;
+    if (voiceId) {
+        const v = availableVoices.find(v => v.voice_id === voiceId);
+        if (v) voiceName = v.name;
+    }
+    let defaults = storedVoiceSettings || {
+        stability: 0.5,
+        similarity_boost: 0.75,
+        style: 0.4,
+        speed: 1.0,
+        use_speaker_boost: true
+    };
+    const html = `
+        <div class="dialog-overlay hidden" id="emoDubbingDialog">
+            <div class="dialog dubbing-dialog">
+                <button class="dialog-close-btn" onclick="closeEmoDubbingSettings()">×</button>
+                <h3>🎭 Emotionales Dubbing V3</h3>
+                <p class="file-name"><strong>${file.filename || ''}</strong></p>
+                <p class="current-voice-line">Aktuelle Stimme: <span class="current-voice">${voiceName || 'Keine'}</span></p>
+                <div class="dub-settings-grid">
+                    <label for="emoSetStability">Stability</label>
+                    <div class="slider-wrapper"><input type="range" id="emoSetStability" min="0" max="1" step="0.01" value="${defaults.stability}"><span class="slider-value" id="emoValStability">${defaults.stability}</span></div>
+
+                    <label for="emoSetSimilarity">Similarity Boost</label>
+                    <div class="slider-wrapper"><input type="range" id="emoSetSimilarity" min="0" max="1" step="0.01" value="${defaults.similarity_boost}"><span class="slider-value" id="emoValSimilarity">${defaults.similarity_boost}</span></div>
+
+                    <label for="emoSetStyle">Style</label>
+                    <div class="slider-wrapper"><input type="range" id="emoSetStyle" min="0" max="1" step="0.01" value="${defaults.style}"><span class="slider-value" id="emoValStyle">${defaults.style}</span></div>
+
+                    <label for="emoSetSpeed">Speed</label>
+                    <div class="slider-wrapper"><input type="range" id="emoSetSpeed" min="0.5" max="2" step="0.05" value="${defaults.speed}"><span class="slider-value" id="emoValSpeed">${defaults.speed}</span></div>
+
+                    <label for="emoSetSpeaker">use_speaker_boost</label>
+                    <div class="slider-wrapper"><input type="checkbox" id="emoSetSpeaker" ${defaults.use_speaker_boost ? 'checked' : ''}></div>
+                </div>
+                <div class="dialog-buttons">
+                    <button class="btn btn-secondary" onclick="closeEmoDubbingSettings()">Abbrechen</button>
+                    <button class="btn btn-success" id="emoStartBtn" onclick="confirmEmoDubbingSettings(${fileId})">Dubben</button>
+                </div>
+            </div>
+        </div>`;
+    document.body.insertAdjacentHTML('beforeend', html);
+    document.getElementById('emoDubbingDialog').classList.remove('hidden');
+    const fields = [
+        ['emoSetStability', 'emoValStability'],
+        ['emoSetSimilarity', 'emoValSimilarity'],
+        ['emoSetStyle', 'emoValStyle'],
+        ['emoSetSpeed', 'emoValSpeed']
+    ];
+    for (const [inp, val] of fields) {
+        const i = document.getElementById(inp);
+        const v = document.getElementById(val);
+        if (i && v) i.oninput = () => { v.textContent = i.value; };
+    }
+}
+
+function closeEmoDubbingSettings() {
+    const dlg = document.getElementById('emoDubbingDialog');
+    if (dlg) dlg.remove();
+}
+
+async function confirmEmoDubbingSettings(fileId) {
+    const btn = document.getElementById('emoStartBtn');
+    if (btn) {
+        btn.disabled = true;
+        btn.innerHTML = '<span class="loading-spinner"></span>';
+    }
+    const settings = {
+        stability: parseFloat(document.getElementById('emoSetStability').value),
+        similarity_boost: parseFloat(document.getElementById('emoSetSimilarity').value),
+        style: parseFloat(document.getElementById('emoSetStyle').value),
+        speed: parseFloat(document.getElementById('emoSetSpeed').value),
+        use_speaker_boost: document.getElementById('emoSetSpeaker').checked
+    };
+    await startEmoDubbing(fileId, settings);
+    closeEmoDubbingSettings();
+}
+// =========================== SHOWEMODUBBINGSETTINGS END ======================
+
 function closeDubbingSettings() {
     const dlg = document.getElementById('dubbingSettingsDialog');
     if (dlg) dlg.remove();
@@ -477,6 +563,8 @@ function validateCsv(csvText) {
 // =========================== STARTDUBBING START =============================
 // Startet ElevenLabs-Dubbing für eine Datei und speichert das Ergebnis
 async function startDubbing(fileId, settings = {}, targetLang = 'de', mode = 'beta') {
+    const useEmo = targetLang === 'emo';
+    const apiLang = 'de';
     const file = files.find(f => f.id === fileId);
     if (!file) return;
     if (mode === 'manual') {
@@ -533,8 +621,8 @@ async function startDubbing(fileId, settings = {}, targetLang = 'de', mode = 'be
     const form = new FormData();
     form.append('file', audioBlob, file.filename);
     // Zielsprachen sowohl einzeln als auch als Liste übergeben
-    form.append('target_lang', targetLang);
-    form.append('target_languages', JSON.stringify([targetLang]));
+    form.append('target_lang', apiLang);
+    form.append('target_languages', JSON.stringify([apiLang]));
     form.append('mode', 'manual');
     form.append('dubbing_studio', 'true');
     const csvBlob = createDubbingCSV(file, durationMs, targetLang);
@@ -610,8 +698,13 @@ async function startDubbing(fileId, settings = {}, targetLang = 'de', mode = 'be
     addDubbingLog(`Dubbing-ID erhalten: ${id}`);
 
     // Dubbing-ID sofort merken und anzeigen
-    file.dubbingId = id;
-    file.dubReady = false; // Status auf "in Arbeit" setzen
+    if (useEmo) {
+        file.emoDubbingId = id;
+        file.emoDubReady = false;
+    } else {
+        file.dubbingId = id;
+        file.dubReady = false;
+    }
     saveCurrentProject();
     renderFileTable();
 
@@ -652,7 +745,11 @@ async function startDubbing(fileId, settings = {}, targetLang = 'de', mode = 'be
         if (vorhandene) {
             file.version = (file.version || 1) + 1;
         }
-        file.dubReady = true;
+        if (useEmo) {
+            file.emoDubReady = true;
+        } else {
+            file.dubReady = true;
+        }
         // Bearbeitungs-Status zurücksetzen, da es sich um eine neue Datei handelt
         file.trimStartMs = 0;
         file.trimEndMs = 0;
@@ -672,6 +769,86 @@ async function startDubbing(fileId, settings = {}, targetLang = 'de', mode = 'be
         }
     }
 }
+
+// =========================== STARTEMODUBBING START ==========================
+// Erstellt eine emotionale Spur über Text-to-Speech V3
+async function startEmoDubbing(fileId, settings = {}) {
+    const file = files.find(f => f.id === fileId);
+    if (!file) return;
+    if (!elevenLabsApiKey) {
+        updateStatus('API-Key fehlt');
+        return;
+    }
+    const voiceId = folderCustomizations[file.folder]?.voiceId;
+    const text = (file.emotionalText || '').trim();
+    if (!voiceId || !text) {
+        updateStatus('Voice oder Text fehlt');
+        return;
+    }
+    dubbingLogMessages = [];
+    const logPre = document.getElementById('dubbingLog');
+    if (logPre) logPre.textContent = '';
+    openDubbingLog();
+    addDubbingLog(`Starte Emo-Dubbing für ${file.filename}`);
+
+    const body = {
+        text,
+        // Nur der neue V3-Endpunkt nutzt dieses Model
+        model_id: 'eleven_v3',
+        voice_settings: settings
+    };
+
+    addDubbingLog(`POST ${API}/text-to-speech/${voiceId}/stream`);
+    let res;
+    try {
+        res = await fetch(`${API}/text-to-speech/${voiceId}/stream`, {
+            method: 'POST',
+            headers: {
+                'xi-api-key': elevenLabsApiKey,
+                'Content-Type': 'application/json',
+                'Accept': 'audio/mpeg'
+            },
+            body: JSON.stringify(body)
+        });
+        logApiCall('POST', `${API}/text-to-speech/${voiceId}/stream`, res.status);
+    } catch (err) {
+        addDubbingLog('Fehler: ' + err.message);
+        updateStatus('Emo-Dubbing fehlgeschlagen');
+        return;
+    }
+    if (!res.ok) {
+        const txt = await res.text();
+        addDubbingLog(txt);
+        updateStatus('Emo-Dubbing fehlgeschlagen');
+        return;
+    }
+
+    const buffer = await res.arrayBuffer();
+    const id = res.headers.get('x-request-id') || Date.now().toString();
+    const relPath = getFullPath(file);
+    const cleanPath = relPath.replace(/^([\\/]*sounds[\\/])?de[\\/]/i, '');
+    const vorhandene = getDeFilePath(file);
+
+    if (window.electronAPI && window.electronAPI.saveDeFile) {
+        await window.electronAPI.saveDeFile(relPath, new Uint8Array(buffer));
+        deAudioCache[cleanPath] = `sounds/DE/${relPath}`;
+        await updateHistoryCache(cleanPath);
+    } else {
+        await speichereUebersetzungsDatei(new Blob([buffer]), relPath);
+    }
+    if (vorhandene) file.version = (file.version || 1) + 1;
+    file.emoDubbingId = id;
+    file.emoDubReady = true;
+    file.trimStartMs = 0;
+    file.trimEndMs = 0;
+    file.volumeMatched = false;
+    file.radioEffect = false;
+    updateStatus('Emo-Download abgeschlossen');
+    renderFileTable();
+    saveCurrentProject();
+    addDubbingLog('Fertig.');
+}
+// =========================== STARTEMODUBBING END ============================
 // =========================== STARTDUBBING END ===============================
 
 // =========================== ISDUBREADY START ===============================
@@ -688,9 +865,11 @@ async function isDubReady(id, lang = 'de') {
 
 // =========================== REDOWNLOADDUBBING START ========================
 // Lädt bereits erzeugtes Dubbing mithilfe der gespeicherten ID erneut herunter
-async function redownloadDubbing(fileId, mode = 'beta') {
+async function redownloadDubbing(fileId, mode = 'beta', lang = 'de') {
     const file = files.find(f => f.id === fileId);
-    if (!file || !file.dubbingId) return;
+    const useEmo = lang === 'emo';
+    const dubId = useEmo ? file.emoDubbingId : file.dubbingId;
+    if (!file || !dubId) return;
     if (mode === 'manual') {
         await copyFolderName(file.folder);
     }
@@ -699,11 +878,11 @@ async function redownloadDubbing(fileId, mode = 'beta') {
     const logPre = document.getElementById('dubbingLog');
     if (logPre) logPre.textContent = '';
     openDubbingLog();
-    addDubbingLog(`Lade Dubbing ${file.dubbingId} erneut`);
+    addDubbingLog(`Lade Dubbing ${dubId} erneut`);
     if (mode === 'manual') {
         showToast('Bitte Spur manuell generieren und in den Download-Ordner legen.');
-        await openStudioAndWait(file.dubbingId);
-        await showDownloadWaitDialog(file.id, file.dubbingId);
+        await openStudioAndWait(dubId);
+        await showDownloadWaitDialog(file.id, dubId);
         return;
     }
 
@@ -713,15 +892,15 @@ async function redownloadDubbing(fileId, mode = 'beta') {
         return;
     }
 
-    if (!(await isDubReady(file.dubbingId))) {
+    if (!(await isDubReady(dubId))) {
         alert('Deutsch noch nicht fertig – erst im Studio generieren!');
         return;
     }
 
-    const audioRes = await fetch(`${API}/dubbing/${file.dubbingId}/audio/de`, {
+    const audioRes = await fetch(`${API}/dubbing/${dubId}/audio/de`, {
         headers: { 'xi-api-key': elevenLabsApiKey }
     });
-    logApiCall('GET', `${API}/dubbing/${file.dubbingId}/audio/de`, audioRes.status);
+    logApiCall('GET', `${API}/dubbing/${dubId}/audio/de`, audioRes.status);
     if (!audioRes.ok) {
         const errText = await audioRes.text();
         updateStatus('Download fehlgeschlagen');
@@ -752,7 +931,11 @@ async function redownloadDubbing(fileId, mode = 'beta') {
     if (vorhandene) {
         file.version = (file.version || 1) + 1;
     }
-    file.dubReady = true; // Nach erneutem Download fertig
+    if (useEmo) {
+        file.emoDubReady = true; // Nach erneutem Download fertig
+    } else {
+        file.dubReady = true; // Nach erneutem Download fertig
+    }
     // Bearbeitungs-Status zurücksetzen, da eine frische Datei geladen wurde
     file.trimStartMs = 0;
     file.trimEndMs = 0;
@@ -763,13 +946,65 @@ async function redownloadDubbing(fileId, mode = 'beta') {
     renderFileTable();
     saveCurrentProject();
 }
+
+// =========================== REDOWNLOADEMO START ============================
+// Lädt eine emotionale Audiodatei über die History-ID
+async function redownloadEmo(fileId) {
+    const file = files.find(f => f.id === fileId);
+    if (!file || !file.emoDubbingId) return;
+    if (!elevenLabsApiKey) {
+        updateStatus('API-Key fehlt');
+        return;
+    }
+    dubbingLogMessages = [];
+    const logPre = document.getElementById('dubbingLog');
+    if (logPre) logPre.textContent = '';
+    openDubbingLog();
+    addDubbingLog(`Lade Emo-Dubbing ${file.emoDubbingId} erneut`);
+    const res = await fetch(`${API}/history/${file.emoDubbingId}/audio`, {
+        headers: { 'xi-api-key': elevenLabsApiKey }
+    });
+    logApiCall('GET', `${API}/history/${file.emoDubbingId}/audio`, res.status);
+    if (!res.ok) {
+        const txt = await res.text();
+        addDubbingLog(txt);
+        updateStatus('Download fehlgeschlagen');
+        return;
+    }
+    const blob = await res.blob();
+    const relPath = getFullPath(file);
+    const cleanPath = relPath.replace(/^([\\/]*sounds[\\/])?de[\\/]/i, '');
+    const vorhandene = getDeFilePath(file);
+    if (window.electronAPI && window.electronAPI.saveDeFile) {
+        const buf = await blob.arrayBuffer();
+        await window.electronAPI.saveDeFile(relPath, new Uint8Array(buf));
+        deAudioCache[cleanPath] = `sounds/DE/${relPath}`;
+        await updateHistoryCache(cleanPath);
+    } else {
+        await speichereUebersetzungsDatei(blob, relPath);
+    }
+    if (vorhandene) file.version = (file.version || 1) + 1;
+    file.emoDubReady = true;
+    file.trimStartMs = 0;
+    file.trimEndMs = 0;
+    file.volumeMatched = false;
+    file.radioEffect = false;
+    updateStatus('Download abgeschlossen');
+    addDubbingLog('Fertig.');
+    renderFileTable();
+    saveCurrentProject();
+}
+// =========================== REDOWNLOADEMO END ==============================
 // =========================== OPENDUBBINGPAGE START ==========================
 // Öffnet die Dubbing-Seite von ElevenLabs für die gespeicherte ID
-function openDubbingPage(fileId) {
+function openDubbingPage(fileId, lang = 'de') {
     const file = files.find(f => f.id === fileId);
-    if (!file || !file.dubbingId) return;
-    // Direkt zum API-Endpunkt der V1-Dubbing-Seite springen
-    const url = `https://elevenlabs.io/v1/dubbing/${file.dubbingId}`;
+    const id = lang === 'emo' ? file.emoDubbingId : file.dubbingId;
+    if (!file || !id) return;
+    // Direkt zum passenden Endpunkt springen
+    const url = lang === 'emo'
+        ? `https://elevenlabs.io/history/${id}`
+        : `https://elevenlabs.io/v1/dubbing/${id}`;
     if (window.electronAPI && window.electronAPI.openExternal) {
         window.electronAPI.openExternal(url);
     } else {
@@ -790,28 +1025,31 @@ function openLocalFile(rel) {
 }
 
 // Startet den Playwright-Ablauf im Hauptprozess
-function startDubAutomation(fileId) {
+function startDubAutomation(fileId, lang = 'de') {
     const file = files.find(f => f.id === fileId);
-    if (!file || !file.dubbingId || !window.electronAPI || !window.electronAPI.autoDub) return;
+    const id = lang === 'emo' ? file.emoDubbingId : file.dubbingId;
+    if (!file || !id || !window.electronAPI || !window.electronAPI.autoDub) return;
     const folder = file.folder || '';
-    window.electronAPI.autoDub({ id: file.dubbingId, folder });
+    window.electronAPI.autoDub({ id, folder });
 }
 // =========================== OPENDUBBINGPAGE END ============================
 
 // =========================== DOWNLOADDE START ===============================
 // Lädt die fertige DE-Audiodatei ohne Protokoll herunter
-async function downloadDe(fileId) {
+async function downloadDe(fileId, lang = 'de') {
     const file = files.find(f => f.id === fileId);
-    if (!file || !file.dubbingId) return;
+    const useEmo = lang === 'emo';
+    const dubId = useEmo ? file.emoDubbingId : file.dubbingId;
+    if (!file || !dubId) return;
     if (!elevenLabsApiKey) {
         updateStatus('API-Key fehlt');
         return;
     }
-    if (!(await isDubReady(file.dubbingId))) {
+    if (!(await isDubReady(dubId))) {
         alert('Deutsch noch nicht fertig – erst im Studio generieren!');
         return;
     }
-    const blob = await downloadDubbingAudio(elevenLabsApiKey, file.dubbingId, 'de');
+    const blob = await downloadDubbingAudio(elevenLabsApiKey, dubId, 'de');
     const relPath = getFullPath(file);
     // Existiert bereits eine DE-Datei, soll die Version steigen
     const vorhandene = getDeFilePath(file);
@@ -827,7 +1065,11 @@ async function downloadDe(fileId) {
     if (vorhandene) {
         file.version = (file.version || 1) + 1;
     }
-    file.dubReady = true; // Status auf fertig setzen
+    if (useEmo) {
+        file.emoDubReady = true; // Status auf fertig setzen
+    } else {
+        file.dubReady = true; // Status auf fertig setzen
+    }
     // Bearbeitungs-Status zurücksetzen, da eine neue Datei gespeichert wurde
     file.trimStartMs = 0;
     file.trimEndMs = 0;
@@ -845,9 +1087,12 @@ if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         getDefaultVoiceSettings,
         showDubbingSettings,
+        showEmoDubbingSettings,
         closeDubbingSettings,
+        closeEmoDubbingSettings,
         bindDubSettingListeners,
         confirmDubbingSettings,
+        confirmEmoDubbingSettings,
         resetStoredVoiceSettings,
         toggleDubAdvanced,
         openDubTooltip,
@@ -868,8 +1113,10 @@ if (typeof module !== 'undefined' && module.exports) {
         splitCsvLines,
         validateCsv,
         startDubbing,
+        startEmoDubbing,
         isDubReady,
         redownloadDubbing,
+        redownloadEmo,
         openDubbingPage,
         openLocalFile,
         startDubAutomation,
@@ -881,9 +1128,12 @@ if (typeof module !== 'undefined' && module.exports) {
 if (typeof window !== 'undefined') {
     window.getDefaultVoiceSettings = getDefaultVoiceSettings;
     window.showDubbingSettings = showDubbingSettings;
+    window.showEmoDubbingSettings = showEmoDubbingSettings;
     window.closeDubbingSettings = closeDubbingSettings;
+    window.closeEmoDubbingSettings = closeEmoDubbingSettings;
     window.bindDubSettingListeners = bindDubSettingListeners;
     window.confirmDubbingSettings = confirmDubbingSettings;
+    window.confirmEmoDubbingSettings = confirmEmoDubbingSettings;
     window.resetStoredVoiceSettings = resetStoredVoiceSettings;
     window.toggleDubAdvanced = toggleDubAdvanced;
     window.openDubTooltip = openDubTooltip;
@@ -904,8 +1154,10 @@ if (typeof window !== 'undefined') {
     window.splitCsvLines = splitCsvLines;
     window.validateCsv = validateCsv;
     window.startDubbing = startDubbing;
+    window.startEmoDubbing = startEmoDubbing;
     window.isDubReady = isDubReady;
     window.redownloadDubbing = redownloadDubbing;
+    window.redownloadEmo = redownloadEmo;
     window.openDubbingPage = openDubbingPage;
     window.openLocalFile = openLocalFile;
     window.startDubAutomation = startDubAutomation;

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -210,10 +210,13 @@ let applyEvaluationResults;
 let scoreVisibleLines;
 let scoreCellTemplate, attachScoreHandlers, scoreClass, getContrastingTextColor, SCORE_COLORS;
 // Platzhalter für Dubbing-Funktionen
-let showDubbingSettings, createDubbingCSV, validateCsv, msToSeconds, isDubReady,
-    startDubbing, redownloadDubbing, openDubbingPage, openLocalFile,
-    startDubAutomation, showDownloadWaitDialog, copyFolderName,
-    copyDownloadFolder, openStudioAndWait, dubStatusClicked, downloadDe;
+let showDubbingSettings, showEmoDubbingSettings,
+    closeEmoDubbingSettings, confirmEmoDubbingSettings,
+    createDubbingCSV, validateCsv, msToSeconds, isDubReady,
+    startDubbing, startEmoDubbing, redownloadDubbing, redownloadEmo,
+    openDubbingPage, openLocalFile, startDubAutomation,
+    showDownloadWaitDialog, copyFolderName, copyDownloadFolder,
+    openStudioAndWait, dubStatusClicked, downloadDe;
 if (typeof module !== 'undefined' && module.exports) {
     ({ createDubbing, downloadDubbingAudio, renderLanguage, pollRender } = require('../../elevenlabs'));
     moduleStatus.elevenlabs = { loaded: true, source: 'Main' };
@@ -846,12 +849,17 @@ document.addEventListener('DOMContentLoaded', async () => {
             // Bei ES-Modulen stehen die Funktionen direkt im Importobjekt
             // Fallback auf window für klassische Skripte ohne Exporte
             showDubbingSettings = dub.showDubbingSettings || window.showDubbingSettings;
+            showEmoDubbingSettings = dub.showEmoDubbingSettings || window.showEmoDubbingSettings;
+            closeEmoDubbingSettings = dub.closeEmoDubbingSettings || window.closeEmoDubbingSettings;
+            confirmEmoDubbingSettings = dub.confirmEmoDubbingSettings || window.confirmEmoDubbingSettings;
             createDubbingCSV   = dub.createDubbingCSV   || window.createDubbingCSV;
             validateCsv        = dub.validateCsv        || window.validateCsv;
             msToSeconds        = dub.msToSeconds        || window.msToSeconds;
             isDubReady         = dub.isDubReady         || window.isDubReady;
             startDubbing       = dub.startDubbing       || window.startDubbing;
+            startEmoDubbing    = dub.startEmoDubbing    || window.startEmoDubbing;
             redownloadDubbing  = dub.redownloadDubbing  || window.redownloadDubbing;
+            redownloadEmo      = dub.redownloadEmo      || window.redownloadEmo;
             openDubbingPage    = dub.openDubbingPage    || window.openDubbingPage;
             openLocalFile      = dub.openLocalFile      || window.openLocalFile;
             startDubAutomation = dub.startDubAutomation || window.startDubAutomation;
@@ -1888,6 +1896,8 @@ function selectProject(id){
         if(!f.hasOwnProperty('autoSource')){f.autoSource='';}
         if(!f.hasOwnProperty('emotionalText')){f.emotionalText='';}
         if(!f.hasOwnProperty('emoCompleted')){f.emoCompleted=false;}
+        if(!f.hasOwnProperty('emoDubbingId')){f.emoDubbingId='';}
+        if(!f.hasOwnProperty('emoDubReady')){f.emoDubReady=null;}
         if(!f.hasOwnProperty('version')){f.version=1;migrated=true;}
     });
     if(migrated) isDirty=true;
@@ -2099,6 +2109,8 @@ function addFiles() {
                 deText: textDatabase[fileKey]?.de || '',
                 emotionalText: textDatabase[fileKey]?.emo || '',
                 emoCompleted: false,
+                emoDubbingId: '',
+                emoDubReady: null,
                 autoTranslation: '',
                 autoSource: '',
                 selected: true,
@@ -3159,9 +3171,11 @@ return `
         <td>
             <div class="dubbing-cell">
                 <button class="dubbing-btn" onclick="initiateDubbing(${file.id})">🔈</button>
-                ${file.emotionalText && file.emotionalText.trim() ? `<button class="dubbing-btn emo" onclick="initiateDubbing(${file.id}, 'emo')">🟣</button>` : ''}
+                ${file.emotionalText && file.emotionalText.trim() ? `<button class="dubbing-btn emo" onclick="initiateEmoDubbing(${file.id})">🟣</button>` : ''}
                 <span class="dub-status ${!file.dubbingId ? 'none' : (file.dubReady ? 'done' : 'pending')}" title="${!file.dubbingId ? 'kein Dubbing' : (file.dubReady ? 'fertig' : 'Studio generiert noch')}" ${(!file.dubbingId || file.dubReady) ? '' : `onclick=\"dubStatusClicked(${file.id})\"`}>●</span>
                 ${file.dubbingId ? `<button class="download-de-btn" data-file-id="${file.id}" title="Dubbing-ID: ${file.dubbingId}" onclick="openDubbingPage(${file.id})">⬇️</button>` : ''}
+                ${file.emotionalText && file.emotionalText.trim() ? `<span class="emo-dub-status ${!file.emoDubbingId ? 'none' : (file.emoDubReady ? 'done' : 'pending')}" title="${!file.emoDubbingId ? 'kein Dubbing' : (file.emoDubReady ? 'fertig' : 'Studio generiert noch')}" ${(!file.emoDubbingId || file.emoDubReady) ? '' : `onclick=\"dubStatusClicked(${file.id})\"`}>●</span>` : ''}
+                ${file.emoDubbingId ? `<button class="download-emo-btn" data-file-id="${file.id}" title="Emo-ID: ${file.emoDubbingId}" onclick="openDubbingPage(${file.id}, 'emo')">⬇️</button>` : ''}
             </div>
         </td>
         <td><span class="length-diff ${lengthClass}">${lengthIndicator}</span></td>
@@ -4221,7 +4235,7 @@ function addPathCellContextMenus() {
 
 // Prüft bei allen Download-Buttons den Status und aktiviert sie ggf.
 async function updateDubButtons() {
-    const buttons = document.querySelectorAll('.download-de-btn');
+    const buttons = document.querySelectorAll('.download-de-btn, .download-emo-btn');
     if (buttons.length === 0) {
         return;
     }
@@ -4229,16 +4243,19 @@ async function updateDubButtons() {
         const id = parseInt(btn.dataset.fileId, 10);
         const file = files.find(f => f.id === id);
         if (!file) continue;
-        if (file.dubbingId) {
-            if (typeof file.dubReady === 'undefined') {
+        const useEmo = btn.classList.contains('download-emo-btn');
+        const dubId = useEmo ? file.emoDubbingId : file.dubbingId;
+        if (dubId) {
+            const prop = useEmo ? 'emoDubReady' : 'dubReady';
+            if (typeof file[prop] === 'undefined' || file[prop] === null) {
                 try {
-                    file.dubReady = await isDubReady(file.dubbingId);
+                    file[prop] = await isDubReady(dubId);
                 } catch (err) {
                     console.error('isDubReady fehlgeschlagen', err);
-                    file.dubReady = false;
+                    file[prop] = false;
                 }
             }
-            if (file.dubReady) btn.disabled = false;
+            if (file[prop]) btn.disabled = false;
         }
     }
 }
@@ -4256,6 +4273,16 @@ async function updateDubStatusForFiles() {
         } else {
             f.dubReady = null;
         }
+        if (f.emoDubbingId) {
+            try {
+                f.emoDubReady = await isDubReady(f.emoDubbingId);
+            } catch (err) {
+                console.error('isDubReady fehlgeschlagen', err);
+                f.emoDubReady = false;
+            }
+        } else {
+            f.emoDubReady = null;
+        }
         updateDubStatusIcon(f);
     });
     await Promise.all(promises);
@@ -4265,10 +4292,15 @@ async function updateDubStatusForFiles() {
 // Prüft nur Dateien mit gelbem Icon erneut
 async function updatePendingDubStatuses() {
     // Nur Jobs abfragen, die nicht auf manuellen Import warten
-    const pending = files.filter(f => f.dubbingId && f.dubReady === false && !f.waitingForManual);
+    const pending = files.filter(f => (f.dubbingId && f.dubReady === false) || (f.emoDubbingId && f.emoDubReady === false));
     for (const f of pending) {
         try {
-            f.dubReady = await isDubReady(f.dubbingId);
+            if (f.dubbingId && f.dubReady === false) {
+                f.dubReady = await isDubReady(f.dubbingId);
+            }
+            if (f.emoDubbingId && f.emoDubReady === false) {
+                f.emoDubReady = await isDubReady(f.emoDubbingId);
+            }
         } catch {}
         updateDubStatusIcon(f);
     }
@@ -4277,21 +4309,28 @@ async function updatePendingDubStatuses() {
 
 // Setzt das Icon je nach Status
 function updateDubStatusIcon(file) {
-    const el = document.querySelector(`tr[data-id="${file.id}"] .dub-status`);
-    if (!el) return;
-    let cls, title;
-    if (!file.dubbingId) {
-        cls = 'none';
-        title = 'kein Dubbing';
-    } else if (file.dubReady) {
-        cls = 'done';
-        title = 'fertig';
-    } else {
-        cls = 'pending';
-        title = 'Studio generiert noch';
-    }
-    el.className = 'dub-status ' + cls;
-    el.title = title;
+    const normal = document.querySelector(`tr[data-id="${file.id}"] .dub-status`);
+    const emo = document.querySelector(`tr[data-id="${file.id}"] .emo-dub-status`);
+
+    const apply = (el, id, ready) => {
+        if (!el) return;
+        let cls, title;
+        if (!id) {
+            cls = 'none';
+            title = 'kein Dubbing';
+        } else if (ready) {
+            cls = 'done';
+            title = 'fertig';
+        } else {
+            cls = 'pending';
+            title = 'Studio generiert noch';
+        }
+        el.className = el.className.replace(/\bnone|done|pending\b/g, '').trim() + ' ' + cls;
+        el.title = title;
+    };
+
+    apply(normal, file.dubbingId, file.dubReady);
+    apply(emo, file.emoDubbingId, file.emoDubReady);
 }
 
         // Text editing
@@ -8814,15 +8853,20 @@ async function handleDeUpload(input) {
 
 // =========================== INITIATEDUBBING START ==========================
 function initiateDubbing(fileId, lang = 'de') {
+    if (lang === 'emo') {
+        initiateEmoDubbing(fileId);
+        return;
+    }
     currentDubLang = lang;
     const file = files.find(f => f.id === fileId);
     if (!file) return;
-    if (file.dubbingId) {
+    const idProp = 'dubbingId';
+    if (file[idProp]) {
         const html = `
             <div class="dialog-overlay hidden" id="dubbingActionDialog">
                 <div class="dialog">
                     <h3>Vorhandenes Dubbing</h3>
-                    <p>Für diese Datei existiert bereits eine Dubbing-ID.<br>ID: ${file.dubbingId}</p>
+                    <p>Für diese Datei existiert bereits eine Dubbing-ID.<br>ID: ${file[idProp]}</p>
                     <div class="dialog-buttons">
                         <button class="btn btn-secondary" onclick="closeDubbingAction()">Abbrechen</button>
                         <button class="btn btn-warning" onclick="proceedNewDubbing(${fileId})">Neu dubben</button>
@@ -8844,17 +8888,30 @@ function closeDubbingAction() {
 
 function proceedNewDubbing(fileId) {
     closeDubbingAction();
-    chooseDubbingMode(fileId);
+    if (currentDubLang === 'emo') {
+        currentDubMode = 'beta';
+        showEmoDubbingSettings(fileId);
+    } else {
+        chooseDubbingMode(fileId);
+    }
 }
 
 // Startet den Auswahl-Dialog für erneutes Herunterladen
 function proceedRedownload(fileId) {
     closeDubbingAction();
-    chooseRedownloadMode(fileId);
+    if (currentDubLang === 'emo') {
+        redownloadEmo(fileId);
+    } else {
+        chooseRedownloadMode(fileId);
+    }
 }
 
 // Zeigt die Auswahl zwischen Beta und Halbautomatik an
 function chooseRedownloadMode(fileId) {
+    if (currentDubLang === 'emo') {
+        redownloadEmo(fileId);
+        return;
+    }
     const html = `
         <div class="dialog-overlay hidden" id="redlModeDialog">
             <div class="dialog">
@@ -8878,11 +8935,16 @@ function closeRedownloadMode() {
 
 function selectRedownloadMode(mode, fileId) {
     closeRedownloadMode();
-    redownloadDubbing(fileId, mode);
+    redownloadDubbing(fileId, mode, currentDubLang);
 }
 
 // Fragt den Benutzer nach dem gewünschten Dubbing-Modus
 function chooseDubbingMode(fileId) {
+    if (currentDubLang === 'emo') {
+        currentDubMode = 'beta';
+        showEmoDubbingSettings(fileId);
+        return;
+    }
     const html = `
         <div class="dialog-overlay hidden" id="dubModeDialog">
             <div class="dialog">
@@ -8907,9 +8969,41 @@ function closeDubMode() {
 function selectDubMode(mode, fileId) {
     currentDubMode = mode;
     closeDubMode();
-    showDubbingSettings(fileId);
+    if (currentDubLang === 'emo') {
+        showEmoDubbingSettings(fileId);
+    } else {
+        showDubbingSettings(fileId);
+    }
 }
 // =========================== INITIATEDUBBING END ============================
+
+// =========================== INITIATEEMODUBBING START ========================
+// Startet das emotionale Dubbing ohne Halbautomatik
+function initiateEmoDubbing(fileId) {
+    currentDubLang = 'emo';
+    currentDubMode = 'beta';
+    const file = files.find(f => f.id === fileId);
+    if (!file) return;
+    if (file.emoDubbingId) {
+        const html = `
+            <div class="dialog-overlay hidden" id="dubbingActionDialog">
+                <div class="dialog">
+                    <h3>Vorhandenes Emotional-Dubbing</h3>
+                    <p>Für diese Datei existiert bereits eine Dubbing-ID.<br>ID: ${file.emoDubbingId}</p>
+                    <div class="dialog-buttons">
+                        <button class="btn btn-secondary" onclick="closeDubbingAction()">Abbrechen</button>
+                        <button class="btn btn-warning" onclick="proceedNewDubbing(${fileId})">Neu dubben</button>
+                        <button class="btn btn-success" onclick="proceedRedownload(${fileId})">Erneut herunterladen</button>
+                    </div>
+                </div>
+            </div>`;
+        document.body.insertAdjacentHTML('beforeend', html);
+        document.getElementById('dubbingActionDialog').classList.remove('hidden');
+    } else {
+        showEmoDubbingSettings(fileId);
+    }
+}
+// =========================== INITIATEEMODUBBING END ==========================
 
 
 // =========================== LOADAUDIOBUFFER START ===========================
@@ -11921,14 +12015,14 @@ function quickAddLevel(chapterName) {
         // Markiert eine Datei als bereit und aktualisiert die Anzeige
         // Markiert eine Datei als bereit und aktualisiert die Anzeige
         // Das Präfix "sounds/DE/" wird nun Groß-/Kleinschreibungs-unabhängig entfernt
-        function markDubAsReady(id, dest) {
+        function markDubAsReady(id, dest, lang = 'de') {
             const file = files.find(f => f.id === id);
             if (!file) return;
             const rel = dest.replace(/^sounds\/DE\//i, '');
             // Vorhandene Datei vor Überschreiben prüfen
             const vorhandene = getDeFilePath(file);
             deAudioCache[rel] = dest;
-            file.dubReady = true;
+            if (lang === 'emo') file.emoDubReady = true; else file.dubReady = true;
             if (vorhandene) {
                 file.version = (file.version || 1) + 1;
             }
@@ -12084,6 +12178,8 @@ function quickAddLevel(chapterName) {
 if (typeof module !== "undefined" && module.exports) {
     module.exports = {
         initiateDubbing,
+        initiateEmoDubbing,
+        showEmoDubbingSettings,
         openDubbingPage,
         openLocalFile,
         startDubAutomation,

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -823,6 +823,13 @@ th:nth-child(10) {
             text-align: center;
         }
 
+        .emo-dub-status {
+            font-size: 18px;
+            display: inline-block;
+            width: 24px;
+            text-align: center;
+        }
+
         .dub-status.none {
             color: #777;
         }
@@ -832,6 +839,18 @@ th:nth-child(10) {
         }
 
         .dub-status.done {
+            color: #4caf50;
+        }
+
+        .emo-dub-status.none {
+            color: #777;
+        }
+
+        .emo-dub-status.pending {
+            color: #ffc107;
+        }
+
+        .emo-dub-status.done {
             color: #4caf50;
         }
 


### PR DESCRIPTION
## Summary
- Neuer Emo-Dubbing-Dialog nutzt ElevenLabs Text-to-Speech v3
- Eigenständige ID und Download-Logik für emotionale Spuren
- README mit API-Beispiel und Hinweisen ergänzt
- Emo-Dubbing verwendet jetzt das Modell **eleven_v3**
- Klarstellung: Emotionales Dubbing greift auf den gespeicherten API-Key zu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687004eb84a483278fd57318c7997ecf