### PR TITLE
Update emotion tag rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Emotionaler DE‑Text:** Unter jedem deutschen Textfeld befindet sich ein eigenes Feld mit violettem Hintergrund. Ein Button "Emotional-Text generieren" füllt es automatisch, ein 📋‑Knopf kopiert den Inhalt.
 * **Emotionen generieren:** Ein zentraler Button oberhalb der Tabelle befüllt alle leeren Emotional-Text-Felder automatisch.
 * **Kontextvolle Emotionstags:** Beim Generieren eines Emotional-Texts wird nun der komplette Dialog des Levels an ChatGPT gesendet, damit der Tonfall korrekt erkannt wird.
+* **Tags mitten im Satz:** Die erzeugten Emotionstags stehen jetzt direkt vor der jeweiligen Textstelle und nicht mehr am Ende der Zeile.
 * **Automatische Übersetzungsvorschau** unter jedem DE-Feld via *Argos Translate*
 * **Kompakter Auto-Übersetzungstext:** Vorschläge unter dem DE-Feld werden nun
   mit kleiner Schrift (0.8 rem) angezeigt

--- a/prompts/gpt_emotions.txt
+++ b/prompts/gpt_emotions.txt
@@ -1,6 +1,7 @@
 Du bist ein professioneller Sprechercoach und Game-Dialog-Texter.
-Deine Aufgabe ist es, anhand des kompletten Szenenverlaufs den emotionalen Stil
-eines einzelnen deutschen Satzes zu erkennen.
-Gib nur den deutschen Zieltext zurück und füge am Ende bis zu drei kurze
-Emotionstags in eckigen Klammern an, z. B. [wütend], [ängstlich], [sarkastisch].
+Deine Aufgabe ist es, anhand des kompletten Szenenverlaufs den emotionalen Stil eines einzelnen deutschen Satzes zu erkennen.
+Gib nur den deutschen Zieltext zurück und integriere kurze Emotionstags in eckigen Klammern direkt dort, wo sie inhaltlich passen, z. B. "[erleichtert] Prima, [besorgt] meine Drohne ist noch heil?".
+Setze maximal drei Tags pro Zeile und kombiniere sie bei Bedarf.
+Achte darauf, dass die Tags **vor** der jeweiligen Textstelle stehen und niemals erst am Ende.
+Wenn mehrere Emotionen zutreffen, setze die wichtigste gleich an den Zeilenanfang oder vor den betroffenen Satzteil.
 Keine weiteren Kommentare.

--- a/web/src/gptService.js
+++ b/web/src/gptService.js
@@ -154,7 +154,12 @@ async function evaluateScene({ scene, lines, key, model = 'gpt-4o-mini' }) {
 // Erzeugt einen emotional getaggten Text für eine Zeile unter Berücksichtigung des kompletten Szenenverlaufs
 async function generateEmotionText({ meta, lines, targetPosition, key, model = 'gpt-4o-mini' }) {
     await promptReady;
-    const payload = { ...meta, lines, target_position: targetPosition, instructions: 'Analysiere die Szene und gib den deutschen Text mit Emotionstags zurück.' };
+    const payload = {
+        ...meta,
+        lines,
+        target_position: targetPosition,
+        instructions: 'Analysiere die Szene und gib den deutschen Text zurück. Platziere die Emotionstags direkt vor der jeweiligen Textstelle.'
+    };
     const messages = [
         { role: 'system', content: emotionPrompt },
         { role: 'user', content: JSON.stringify(payload) }


### PR DESCRIPTION
## Summary
- erweiterten Prompt um Vorgaben, wie Emotionstags vor die passende Textstelle gesetzt werden
- Service-Aufruf nutzt die neue Instruktion zum Einfügen der Tags
- README verdeutlicht die Platzierung der Emotionstags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870248696a4832783e52e5ec7657d7d