### PR TITLE
Improve segment dialog cleanup and context handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Eigenes Wörterbuch:** Der 📚-Knopf speichert nun sowohl englisch‑deutsche Übersetzungen als auch Lautschrift.
+* **Audio-Datei zuordnen:** Lange Aufnahmen lassen sich automatisch in Segmente teilen, per Klick auswählen, farblich passenden Textzeilen zuweisen und direkt ins Projekt importieren. Fehlhafte Eingaben löschen die Zuordnung automatisch, laufende Wiedergaben stoppen beim Neu‑Upload.
 * **Projektkarten mit Rahmen:** Jede Karte besitzt einen grauen Rand und nutzt nun die volle Breite. Im geöffneten Level wird der Rand grün. Das aktuell gewählte Projekt hebt sich mit einem blauen Balken, leicht transparentem Hintergrund (rgba(33,150,243,0.2)) und weißer Schrift deutlich ab.
 * **Überarbeitete Seitenleiste:** Jede Projektkarte besteht aus zwei Zeilen mit einheitlich breiten Badges für EN, DE und Audio.
 * **Breitere Projektleiste:** Die Sidebar ist jetzt 320 px breit, damit lange Einträge korrekt angezeigt werden.
@@ -645,6 +646,13 @@ Auch Kapitel und Level bieten dieses Rechtsklick-Menü.
 | **Zwischen Feldern**      | `Tab` / `Shift + Tab` |
 | **Auto-Resize verbessert** | Textfelder passen sich sauber an und schneiden keine Zeilen mehr ab; beim Projektstart wird die korrekte Höhe jetzt sofort gesetzt |
 * Beim Speichern eines DE-Audios verhindert das Tool nun ungültige Schnittbereiche und zeigt einen Fehler an.
+
+#### Lange Aufnahmen aufteilen
+Über den Button „🔊 Audio-Datei zuordnen“ lässt sich eine lange Aufnahme hochladen. Das Tool erkennt leise Pausen und zeichnet die Segmente farbig in der Waveform ein. Unterhalb stehen alle deutschen Textzeilen des Projekts bereit. Segmente lassen sich nun direkt in der Grafik anklicken – mit gedrückter Umschalttaste auch mehrere nebeneinander. Ein Klick auf die gewünschte Zeile ordnet die Auswahl zu und füllt das Eingabefeld automatisch. Die aktuell gewählte Auswahl wird dabei stets neu gezeichnet, sodass keine Überlagerungen entstehen. Mit „Importieren“ schneidet das Tool die markierten Bereiche zurecht und verknüpft sie mit den Zeilen. Bei längerer Analyse erscheint ein Fortschrittsbalken. Über „Neu hochladen“ kann jederzeit eine andere Datei analysiert werden; eine laufende Wiedergabe stoppt dabei automatisch.
+Die Waveform passt ihre Breite nun automatisch an den Dialog an, damit Segmentmarkierungen exakt übereinstimmen.
+Ungültige Segmentnummern werden abgefangen, rot markiert und die Zuordnung gelöscht. Nach erfolgreichem Analysieren erscheint die Meldung „Fertig“. Tritt ein Fehler auf, wird der Fortschrittsbalken beendet, der Dialog geleert und die Fehlermeldung bleibt sichtbar.
+Beim Laden neuer Dateien schließt das Tool den verwendeten AudioContext sofort wieder, damit der Browser nicht zu viele offene Instanzen ansammelt.
+Beim Zurücksetzen springt die Statusanzeige wieder auf „Analysiere…“, damit neue Uploads korrekt starten. Schließt man den Dialog, stoppt das Tool laufende Wiedergaben und gibt die erzeugten Object‑URLs frei.
 ---
 
 ## ⌨️ Keyboard Shortcuts

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -47,6 +47,7 @@
                     <button class="btn btn-secondary" onclick="showImportDialog()">📥 Import</button>
                     <button class="btn btn-secondary" onclick="showCcImportDialog()">📥 Untertitel importieren</button>
                     <button class="btn btn-secondary" onclick="showFolderBrowser()">📁 Ordner durchsuchen</button>
+                    <button class="btn btn-secondary" onclick="openSegmentDialog()">🔊 Audio-Datei zuordnen</button>
                 </div>
                 <div class="system-tools">
                     <button id="wordListButton" class="btn btn-secondary" onclick="openWordList()">📚 Wörter</button>
@@ -640,6 +641,27 @@
         </div>
     </div>
 
+    <!-- Audio-Segmentierung Dialog -->
+    <div class="dialog-overlay hidden" id="segmentDialog">
+        <div class="dialog">
+            <button class="dialog-close-btn" onclick="closeSegmentDialog()">×</button>
+            <h3>🎵 Audio-Datei zuordnen</h3>
+            <input type="file" id="segmentFileInput" accept=".mp3,.wav" onchange="analyzeSegmentFile(event)">
+            <div class="segment-progress" id="segmentProgress">
+                <div class="segment-status" id="segmentStatus">Analysiere...</div>
+                <div class="progress-bar"><div class="progress-fill" id="segmentFill"></div></div>
+            </div>
+            <button class="btn btn-secondary" onclick="playSegmentFull()" style="margin-top:6px;">▶ Gesamt</button>
+            <canvas id="segmentWaveform" width="600" height="80" style="width:100%; background:#111; margin-top:10px;"></canvas>
+            <div id="segmentTextList" style="margin-top:10px;"></div>
+            <div class="dialog-buttons">
+                <button class="btn btn-secondary" onclick="resetSegmentDialog()">Neu hochladen</button>
+                <button class="btn btn-blue" onclick="exportSegmentsToProject()">Importieren</button>
+                <button class="btn btn-secondary" onclick="closeSegmentDialog()">Schließen</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Protokoll Dialog -->
     <div class="dialog-overlay hidden" id="dubbingLogDialog">
         <div class="dialog">
@@ -758,6 +780,7 @@
 
     <script src="src/colorUtils.js"></script>
     <script src="src/main.js"></script>
+    <script src="src/audioSegmenter.js"></script>
     <script type="module" src="renderer.js"></script>
 </body>
 </html>

--- a/web/src/audioSegmenter.js
+++ b/web/src/audioSegmenter.js
@@ -1,0 +1,76 @@
+// Funktionen zur Audio-Segmentierung
+// Erkennt Pausen und liefert passende Abschnitte zurueck
+
+async function detectSegments(file, silenceMs = 300, threshold = 0.01, onProgress) {
+    const buffer = await loadAudioBuffer(file);
+    const data = buffer.getChannelData(0);
+    const sr = buffer.sampleRate;
+    const windowSize = Math.round(sr * 0.03); // 30 ms
+    const silenceSamples = Math.round(sr * silenceMs / 1000);
+    let segments = [];
+    let start = 0;
+    let silent = 0;
+    let inSound = false;
+    const total = data.length;
+    for (let i = 0; i < total; i += windowSize) {
+        let sum = 0;
+        for (let j = 0; j < windowSize && i + j < data.length; j++) {
+            sum += Math.abs(data[i + j]);
+        }
+        const amp = sum / windowSize;
+        const ms = i / sr * 1000;
+        if (amp < threshold) {
+            silent += windowSize;
+            if (inSound && silent >= silenceSamples) {
+                const end = (i - silent) / sr * 1000;
+                if (end > start) segments.push({ start, end });
+                inSound = false;
+            }
+        } else {
+            if (!inSound) {
+                start = ms;
+                inSound = true;
+            }
+            silent = 0;
+        }
+        if (onProgress && i % (sr * 0.5) === 0) {
+            onProgress(i / total);
+        }
+    }
+    if (inSound) {
+        const end = data.length / sr * 1000;
+        segments.push({ start, end });
+    }
+    if (onProgress) onProgress(1);
+    return { buffer, segments };
+}
+
+function drawSegments(canvas, buffer, segments) {
+    drawWaveform(canvas, buffer);
+    const ctx = canvas.getContext('2d');
+    const width = canvas.width;
+    const height = canvas.height;
+    const durationMs = buffer.length / buffer.sampleRate * 1000;
+    segments.forEach((s, i) => {
+        const startX = (s.start / durationMs) * width;
+        const endX = (s.end / durationMs) * width;
+        ctx.fillStyle = i % 2 ? 'rgba(0,0,255,0.3)' : 'rgba(255,0,255,0.3)';
+        ctx.fillRect(startX, 0, endX - startX, height);
+    });
+}
+
+// Schneidet einen Bereich aus einem Buffer heraus
+function sliceBuffer(buffer, startMs, endMs) {
+    const sr = buffer.sampleRate;
+    const start = Math.max(0, Math.floor(startMs * sr / 1000));
+    const end = Math.min(buffer.length, Math.floor(endMs * sr / 1000));
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const newBuf = ctx.createBuffer(buffer.numberOfChannels, end - start, sr);
+    for (let ch = 0; ch < buffer.numberOfChannels; ch++) {
+        const data = buffer.getChannelData(ch).subarray(start, end);
+        newBuf.copyToChannel(data, ch);
+    }
+    // AudioContext wieder schließen, um Browser-Limit zu vermeiden
+    ctx.close();
+    return newBuf;
+}

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -16,6 +16,11 @@ let folderCustomizations   = {}; // Speichert Icons/Farben pro Ordner
 let isDirty                = false;
 let aktiveOrdnerDateien    = []; // Aktuelle Dateiliste im Ordner-Browser
 let debugInfo              = {}; // Pfadinformationen von Electron
+let segmentInfo            = null; // Ergebnisse der Audio-Segmentierung
+let segmentAssignments    = {};    // Zuordnung Segmente -> Zeilen
+let segmentPlayer         = null;  // Wiedergabe der Ausschnitte
+let segmentSelection      = [];    // aktuell ausgewaehlte Segmente
+let segmentPlayerUrl      = null;  // zuletzt erzeugte Object-URL
 
 // Verfügbarkeit der Electron-API einmalig prüfen
 const isElectron = !!window.electronAPI;
@@ -5976,6 +5981,309 @@ function cleanupOrphanCustomizations() {
     }
 }
 // =========================== CLEANUPORPHANCUSTOMIZATIONS END ===============
+
+// =========================== SEGMENT DIALOG START ==========================
+function openSegmentDialog() {
+    const dlg = document.getElementById('segmentDialog');
+    dlg.classList.remove('hidden');
+    const canvas = document.getElementById('segmentWaveform');
+    canvas.width = canvas.clientWidth; // Canvas-Breite ans Layout anpassen
+    canvas.addEventListener('click', handleSegmentCanvasClick);
+    if (segmentInfo) {
+        drawSegments(canvas, segmentInfo.buffer, segmentInfo.segments);
+        populateSegmentList();
+        highlightAssignedSegments();
+    } else {
+        resetSegmentDialog();
+    }
+}
+
+function closeSegmentDialog() {
+    document.getElementById('segmentDialog').classList.add('hidden');
+    if (segmentPlayer) {
+        segmentPlayer.pause();
+        // beim Schließen auch die erzeugte URL freigeben
+        if (segmentPlayerUrl) {
+            URL.revokeObjectURL(segmentPlayerUrl);
+            segmentPlayerUrl = null;
+        }
+        segmentPlayer = null;
+    }
+    document.getElementById('segmentWaveform').removeEventListener('click', handleSegmentCanvasClick);
+    segmentSelection = [];
+}
+
+// Setzt den Dialog zurück und beendet eine laufende Wiedergabe
+// Ist keepStatus=true, bleibt der aktuelle Meldungstext erhalten
+function resetSegmentDialog(keepStatus=false) {
+    document.getElementById('segmentFileInput').value = '';
+    document.getElementById('segmentTextList').innerHTML = '';
+    const canvas = document.getElementById('segmentWaveform');
+    canvas.width = canvas.clientWidth; // Canvas-Breite ans Layout anpassen
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    segmentInfo = null;
+    segmentAssignments = {};
+    segmentSelection = [];
+    // laufende Wiedergabe stoppen und URL freigeben
+    if (segmentPlayer) {
+        segmentPlayer.pause();
+        if (segmentPlayerUrl) {
+            URL.revokeObjectURL(segmentPlayerUrl);
+            segmentPlayerUrl = null;
+        }
+        segmentPlayer = null;
+    }
+    const progress = document.getElementById('segmentProgress');
+    const fill = document.getElementById('segmentFill');
+    const status = document.getElementById('segmentStatus');
+    // Fortschrittsbalken und Status zurücksetzen
+    progress.classList.remove('active');
+    fill.style.width = '0%';
+    if (!keepStatus) {
+        status.textContent = 'Analysiere...';
+    }
+}
+
+async function analyzeSegmentFile(ev) {
+    const file = ev.target.files[0];
+    if (!file) return;
+    segmentAssignments = {};
+    segmentSelection = [];
+    const progress = document.getElementById('segmentProgress');
+    const fill = document.getElementById('segmentFill');
+    const status = document.getElementById('segmentStatus');
+    let shown = false;
+    const timer = setTimeout(() => { progress.classList.add('active'); shown = true; }, 5000);
+    try {
+        segmentInfo = await detectSegments(file, 300, 0.01, p => {
+            fill.style.width = `${Math.round(p * 100)}%`;
+        });
+        status.textContent = 'Fertig';
+        drawSegments(document.getElementById('segmentWaveform'), segmentInfo.buffer, segmentInfo.segments);
+        populateSegmentList();
+    } catch (err) {
+        console.error('Analyse fehlgeschlagen', err);
+        resetSegmentDialog(true);
+        status.textContent = 'Fehler beim Analysieren';
+    } finally {
+        clearTimeout(timer);
+        if (shown) {
+            progress.classList.remove('active');
+            fill.style.width = '0%';
+        }
+    }
+}
+
+function populateSegmentList() {
+    const list = document.getElementById('segmentTextList');
+    list.innerHTML = '';
+    files.forEach((f, i) => {
+        const div = document.createElement('div');
+        div.className = 'seg-line';
+        div.dataset.line = i;
+        const playBtn = `<button class="seg-play" data-line="${i}">▶</button>`;
+        const value = segmentAssignments[i] ? segmentAssignments[i].join(',') : '';
+        div.innerHTML = `<span class="seg-label">${i + 1}. ${escapeHtml(f.deText || '')}</span>`+
+                        `<input type="text" data-line="${i}" placeholder="Segmente" value="${value}">`+
+                        playBtn;
+        list.appendChild(div);
+    });
+
+    list.querySelectorAll('input').forEach(inp => {
+        inp.addEventListener('input', () => updateSegmentAssignment(inp));
+    });
+    list.querySelectorAll('.seg-play').forEach(btn => {
+        btn.addEventListener('click', () => playSegmentLine(parseInt(btn.dataset.line)));
+    });
+    // Klick auf eine Zeile ordnet aktuelle Segmentauswahl zu
+    list.querySelectorAll('.seg-line').forEach(div => {
+        div.addEventListener('click', ev => {
+            if (ev.target.tagName === 'INPUT' || ev.target.classList.contains('seg-play')) return;
+            if (segmentSelection.length === 0) return;
+            const line = parseInt(div.dataset.line);
+            segmentAssignments[line] = segmentSelection.map(n => n + 1);
+            const inp = div.querySelector('input');
+            inp.value = segmentAssignments[line].join(',');
+            segmentSelection = [];
+            highlightAssignedSegments();
+        });
+    });
+}
+
+// Parst das Eingabefeld und validiert Zahlenbereich
+function parseSegmentInput(val, max) {
+    if (!val) return [];
+    val = val.replace(/\s+/g, '');
+    const parts = val.split(',');
+    let nums = [];
+    for (const p of parts) {
+        if (p.includes('-')) {
+            const [a,b] = p.split('-').map(n => parseInt(n));
+            if (isNaN(a) || isNaN(b) || a>b || a<1 || b>max) return null;
+            for (let n=a;n<=b;n++) nums.push(n);
+        } else {
+            const n = parseInt(p);
+            if (isNaN(n) || n<1 || n>max) return null;
+            nums.push(n);
+        }
+    }
+    return nums;
+}
+
+function updateSegmentAssignment(input) {
+    const line = parseInt(input.dataset.line);
+    const max = segmentInfo ? segmentInfo.segments.length : 0;
+    const nums = parseSegmentInput(input.value, max);
+    if (!nums) {
+        input.classList.add('error');
+        // ungültige Eingabe entfernt die bisherige Zuordnung
+        delete segmentAssignments[line];
+        highlightAssignedSegments();
+        return;
+    }
+    nums.sort((a,b)=>a-b);
+    for (let i=1;i<nums.length;i++) {
+        if (nums[i] !== nums[i-1] + 1) {
+            input.classList.add('error');
+            delete segmentAssignments[line];
+            highlightAssignedSegments();
+            return;
+        }
+    }
+    input.classList.remove('error');
+    segmentAssignments[line] = nums;
+    highlightAssignedSegments();
+}
+
+function highlightAssignedSegments() {
+    if (!segmentInfo) return;
+    const canvas = document.getElementById('segmentWaveform');
+    drawSegments(canvas, segmentInfo.buffer, segmentInfo.segments);
+    const ctx = canvas.getContext('2d');
+    const width = canvas.width;
+    const height = canvas.height;
+    const dur = segmentInfo.buffer.length / segmentInfo.buffer.sampleRate * 1000;
+    const colors = ['rgba(255,100,100,0.4)','rgba(100,255,100,0.4)','rgba(100,100,255,0.4)','rgba(255,255,100,0.4)','rgba(255,100,255,0.4)'];
+
+    // Zuerst alle Zeilen zurücksetzen
+    document.querySelectorAll('#segmentTextList .seg-line').forEach(div => {
+        div.style.background = '';
+    });
+
+    Object.keys(segmentAssignments).forEach((lineIdx, ci) => {
+        const segNums = segmentAssignments[lineIdx];
+        if (!segNums || segNums.length===0) return;
+        const first = segmentInfo.segments[segNums[0]-1];
+        const last  = segmentInfo.segments[segNums[segNums.length-1]-1];
+        if (!first || !last) return;
+        const color = colors[ci % colors.length];
+        const sx = (first.start / dur) * width;
+        const ex = (last.end / dur) * width;
+        ctx.fillStyle = color;
+        ctx.fillRect(sx,0,ex-sx,height);
+
+        const row = document.querySelector(`#segmentTextList .seg-line[data-line="${lineIdx}"]`);
+        if (row) row.style.background = color;
+    });
+
+    highlightSegmentSelection();
+}
+
+function highlightSegmentSelection() {
+    if (!segmentInfo || segmentSelection.length === 0) return;
+    const canvas = document.getElementById('segmentWaveform');
+    const ctx = canvas.getContext('2d');
+    const width = canvas.width;
+    const height = canvas.height;
+    const dur = segmentInfo.buffer.length / segmentInfo.buffer.sampleRate * 1000;
+    const first = segmentInfo.segments[segmentSelection[0]];
+    const last = segmentInfo.segments[segmentSelection[segmentSelection.length-1]];
+    if (!first || !last) return;
+    const sx = (first.start / dur) * width;
+    const ex = (last.end / dur) * width;
+    ctx.fillStyle = 'rgba(255,255,255,0.3)';
+    ctx.fillRect(sx, 0, ex - sx, height);
+}
+
+function handleSegmentCanvasClick(ev) {
+    if (!segmentInfo) return;
+    const canvas = ev.target;
+    const rect = canvas.getBoundingClientRect();
+    const x = ev.clientX - rect.left;
+    const width = canvas.width;
+    const dur = segmentInfo.buffer.length / segmentInfo.buffer.sampleRate * 1000;
+    const ms = (x / width) * dur;
+    const idx = segmentInfo.segments.findIndex(s => ms >= s.start && ms <= s.end);
+    if (idx === -1) return;
+    if (ev.shiftKey && segmentSelection.length > 0) {
+        const min = Math.min(...segmentSelection);
+        const max = Math.max(...segmentSelection);
+        if (idx > max) {
+            for (let i = max + 1; i <= idx; i++) segmentSelection.push(i);
+        } else if (idx < min) {
+            const neu = [];
+            for (let i = idx; i <= max; i++) neu.push(i);
+            segmentSelection = neu;
+        } else {
+            segmentSelection = [idx];
+        }
+    } else {
+        segmentSelection = [idx];
+    }
+    highlightAssignedSegments();
+}
+
+function playSegmentLine(line) {
+    if (!segmentInfo || !segmentAssignments[line]) return;
+    if (segmentPlayer) {
+        segmentPlayer.pause();
+        if (segmentPlayerUrl) { URL.revokeObjectURL(segmentPlayerUrl); }
+    }
+    const nums = segmentAssignments[line];
+    const first = segmentInfo.segments[nums[0]-1];
+    const last  = segmentInfo.segments[nums[nums.length-1]-1];
+    if (!first || !last) return;
+    const buf = sliceBuffer(segmentInfo.buffer, first.start, last.end);
+    const blob = bufferToWav(buf);
+    const url = URL.createObjectURL(blob);
+    segmentPlayerUrl = url;
+    segmentPlayer = new Audio(url);
+    segmentPlayer.onended = () => { URL.revokeObjectURL(url); segmentPlayerUrl = null; };
+    segmentPlayer.play();
+}
+
+function playSegmentFull() {
+    if (!segmentInfo) return;
+    if (segmentPlayer) {
+        segmentPlayer.pause();
+        if (segmentPlayerUrl) { URL.revokeObjectURL(segmentPlayerUrl); }
+    }
+    const blob = bufferToWav(segmentInfo.buffer);
+    const url = URL.createObjectURL(blob);
+    segmentPlayerUrl = url;
+    segmentPlayer = new Audio(url);
+    segmentPlayer.onended = () => { URL.revokeObjectURL(url); segmentPlayerUrl = null; };
+    segmentPlayer.play();
+}
+
+async function exportSegmentsToProject() {
+    if (!segmentInfo) return;
+    for (const [lineStr, nums] of Object.entries(segmentAssignments)) {
+        const line = parseInt(lineStr);
+        if (!nums || nums.length===0) continue;
+        const first = segmentInfo.segments[nums[0]-1];
+        const last  = segmentInfo.segments[nums[nums.length-1]-1];
+        if (!first || !last) continue;
+        const buf = sliceBuffer(segmentInfo.buffer, first.start, last.end);
+        const relPath = getFullPath(files[line]);
+        await speichereUebersetzungsDatei(bufferToWav(buf), relPath);
+    }
+    updateStatus('Segmente importiert');
+    closeSegmentDialog();
+    renderFileTable();
+}
+// =========================== SEGMENT DIALOG END ============================
 // =========================== SHOWMISSINGFOLDERSDIALOG END ===================
 
 // =========================== GETBROWSERDEBUGPATHINFO START ===========================
@@ -9010,14 +9318,20 @@ function initiateEmoDubbing(fileId) {
 // Lädt eine Audiodatei (String-URL oder File) und liefert ein AudioBuffer
 async function loadAudioBuffer(source) {
     const ctx = new (window.AudioContext || window.webkitAudioContext)();
-    let arrayBuffer;
-    if (typeof source === 'string') {
-        const resp = await fetch(source);
-        arrayBuffer = await resp.arrayBuffer();
-    } else {
-        arrayBuffer = await source.arrayBuffer();
+    try {
+        let arrayBuffer;
+        if (typeof source === 'string') {
+            const resp = await fetch(source);
+            arrayBuffer = await resp.arrayBuffer();
+        } else {
+            arrayBuffer = await source.arrayBuffer();
+        }
+        // Kontext nach dem Dekodieren schließen, um Limits zu vermeiden
+        const buffer = await ctx.decodeAudioData(arrayBuffer);
+        return buffer;
+    } finally {
+        ctx.close();
     }
-    return await ctx.decodeAudioData(arrayBuffer);
 }
 
 // Ermittelt die Länge einer Audiodatei in Sekunden und nutzt einen Cache

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -3145,3 +3145,15 @@ th:nth-child(10) {
 @media (max-width:900px){
     .video-grid{ flex-direction:column; }
 }
+
+/* Stil fuer den Audio-Segmentierungsdialog */
+#segmentDialog .dialog { max-width: 900px; }
+.seg-line { display:flex; gap:10px; margin-bottom:4px; }
+.seg-line input { width:60px; }
+.seg-label { flex:1; color:#ccc; }
+.seg-play { background:#444; color:#fff; border:none; padding:2px 6px; cursor:pointer; }
+.seg-line input.error { border:1px solid red; }
+.segment-progress { display:none; padding:10px 0; }
+.segment-progress.active { display:block; }
+.segment-status { font-size:14px; color:#999; }
+#segmentWaveform { cursor:pointer; }


### PR DESCRIPTION
## Summary
- Segmentzuweisungen werden bei fehlerhaften Eingaben entfernt
- Analysefehler leeren den Segmentierungsdialog
- `loadAudioBuffer` schließt seinen AudioContext wieder
- Statusanzeige zeigt nach der Analyse "Fertig"
- README mit Hinweisen zu gelöschten Zuordnungen und Dialog-Reset ergänzt
- Player-URLs werden beim Schließen des Segmentdialogs freigegeben
- Fortschrittsanzeige wird durch `resetSegmentDialog` korrekt zurückgesetzt
- Wiedergabe beim Zurücksetzen beendet und Fehlermeldung bleibt sichtbar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870b5df9f5c8327982b5f7d117c75a3