### PR TITLE
Handle missing segment dialog elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Eigenes Wörterbuch:** Der 📚-Knopf speichert nun sowohl englisch‑deutsche Übersetzungen als auch Lautschrift.
-* **Audio-Datei zuordnen:** Lange Aufnahmen lassen sich automatisch in Segmente teilen, per Klick auswählen, farblich passenden Textzeilen zuweisen und direkt ins Projekt importieren. Fehlhafte Eingaben löschen die Zuordnung automatisch, laufende Wiedergaben stoppen beim Neu‑Upload. Die gewählte Datei und alle Zuordnungen werden im Projekt gespeichert und sind Teil des Backups. Beim Klicken werden ausgewählte Segmente sofort abgespielt. Die Segmentierungslogik ist fest im Hauptskript verankert. Der Datei‑Input besitzt zusätzlich ein `onchange`-Attribut und der Listener wird beim Öffnen des Dialogs neu gesetzt, sodass der Upload immer reagiert.
+* **Audio-Datei zuordnen:** Lange Aufnahmen lassen sich automatisch in Segmente teilen, per Klick auswählen, farblich passenden Textzeilen zuweisen und direkt ins Projekt importieren. Fehlhafte Eingaben löschen die Zuordnung automatisch, laufende Wiedergaben stoppen beim Neu‑Upload. Die gewählte Datei und alle Zuordnungen werden im Projekt gespeichert und sind Teil des Backups. Beim Klicken werden ausgewählte Segmente sofort abgespielt. Die Segmentierungslogik ist fest im Hauptskript verankert. Der Datei‑Input besitzt zusätzlich ein `onchange`-Attribut und der Listener wird beim Öffnen des Dialogs neu gesetzt, sodass der Upload immer reagiert. Der Dialog setzt die HTML‑Elemente `segmentFileInput` und `segmentWaveform` voraus.
 * **Projektkarten mit Rahmen:** Jede Karte besitzt einen grauen Rand und nutzt nun die volle Breite. Im geöffneten Level wird der Rand grün. Das aktuell gewählte Projekt hebt sich mit einem blauen Balken, leicht transparentem Hintergrund (rgba(33,150,243,0.2)) und weißer Schrift deutlich ab.
 * **Überarbeitete Seitenleiste:** Jede Projektkarte besteht aus zwei Zeilen mit einheitlich breiten Badges für EN, DE und Audio.
 * **Breitere Projektleiste:** Die Sidebar ist jetzt 320 px breit, damit lange Einträge korrekt angezeigt werden.
@@ -552,6 +552,7 @@ Seit Patch 1.40.100 erlaubt die Content Security Policy nun Verbindungen zu `api
 Seit Patch 1.40.102 besitzt das Wörterbuch zwei Bereiche: Englisch‑Deutsch und Englisch‑Phonetisch.
 Seit Patch 1.40.102 stehen die Segmentierungsfunktionen global zur Verfügung. Dadurch funktioniert der Upload auch nach dem Auslagern in einzelne Module zuverlässig.
 Seit Patch 1.40.103 prüft das Tool vor dem Öffnen des Segmentdialogs, ob ein Projekt ausgewählt wurde.
+Seit Patch 1.40.104 meldet der Segmentdialog fehlende HTML-Elemente in der Konsole.
 
 Beispiel einer gültigen CSV:
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -6131,8 +6131,16 @@ async function openSegmentDialog() {
     const dlg = document.getElementById('segmentDialog');
     dlg.classList.remove('hidden');
     const canvas = document.getElementById('segmentWaveform');
+    if (!canvas) {
+        console.error("Segmentdialog ben\xF6tigt ein Element mit der ID 'segmentWaveform'.");
+        return;
+    }
     canvas.width = canvas.clientWidth; // Canvas-Breite ans Layout anpassen
     const input = document.getElementById('segmentFileInput');
+    if (!input) {
+        console.error("Segmentdialog ben\xF6tigt ein Element mit der ID 'segmentFileInput'.");
+        return;
+    }
     // Listener vorsichtshalber neu setzen, falls der Dialog dynamisch erzeugt wurde
     input.onchange = analyzeSegmentFile;
     // Wert leeren, damit auch dieselbe Datei erneut erkannt wird
@@ -6155,7 +6163,12 @@ async function openSegmentDialog() {
 }
 
 function closeSegmentDialog() {
-    document.getElementById('segmentDialog').classList.add('hidden');
+    const dlg = document.getElementById('segmentDialog');
+    if (!dlg) {
+        console.error("Segmentdialog konnte nicht geschlossen werden: Element 'segmentDialog' fehlt.");
+    } else {
+        dlg.classList.add('hidden');
+    }
     if (segmentPlayer) {
         segmentPlayer.pause();
         // beim Schließen auch die erzeugte URL freigeben
@@ -6165,7 +6178,12 @@ function closeSegmentDialog() {
         }
         segmentPlayer = null;
     }
-    document.getElementById('segmentWaveform').removeEventListener('click', handleSegmentCanvasClick);
+    const canvas = document.getElementById('segmentWaveform');
+    if (!canvas) {
+        console.error("Segmentdialog: Element 'segmentWaveform' fehlt.");
+    } else {
+        canvas.removeEventListener('click', handleSegmentCanvasClick);
+    }
     segmentSelection = [];
     storeSegmentState();
 }
@@ -6173,12 +6191,21 @@ function closeSegmentDialog() {
 // Setzt den Dialog zurück und beendet eine laufende Wiedergabe
 // Ist keepStatus=true, bleibt der aktuelle Meldungstext erhalten
 function resetSegmentDialog(keepStatus=false) {
-    document.getElementById('segmentFileInput').value = '';
+    const input = document.getElementById('segmentFileInput');
+    if (input) {
+        input.value = '';
+    } else {
+        console.error("Segmentdialog ben\xF6tigt ein Element mit der ID 'segmentFileInput'.");
+    }
     document.getElementById('segmentTextList').innerHTML = '';
     const canvas = document.getElementById('segmentWaveform');
-    canvas.width = canvas.clientWidth; // Canvas-Breite ans Layout anpassen
-    const ctx = canvas.getContext('2d');
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (canvas) {
+        canvas.width = canvas.clientWidth; // Canvas-Breite ans Layout anpassen
+        const ctx = canvas.getContext('2d');
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+    } else {
+        console.error("Segmentdialog ben\xF6tigt ein Element mit der ID 'segmentWaveform'.");
+    }
     segmentInfo = null;
     segmentAssignments = {};
     segmentSelection = [];


### PR DESCRIPTION
## Summary
- add checks for `segmentFileInput` und `segmentWaveform`
- log Fehler falls sie fehlen
- erwähne die benötigten Elemente im README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687179c0ebd883279aadb3748dbc0ae0