### PR TITLE
Improve DE folder init

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,8 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * ▶ **Fix:** Das Backup funktioniert jetzt auch über Laufwerksgrenzen hinweg, da beim Verschieben auf Kopieren mit anschließendem Löschen umgestellt wird.
 * ▶ **Neu:** Geänderte Dateiendungen werden erkannt und automatisch korrigiert.
 * ▶ **Fix:** Der 📋-Button kopiert den Text nun zuverlässig; das zugehörige Event wird korrekt verarbeitet.
+* **DE-Ordner nicht initialisiert**
+* ▶ **Lösung:** Beim Import oder Speichern fragt das Tool nun automatisch nach dem Projektordner und legt den DE-Ordner an.
 
 #### Häufige Crash-Stellen
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -6490,6 +6490,11 @@ function playSegmentFull() {
 
 async function exportSegmentsToProject() {
     if (!segmentInfo) return;
+    // Vor dem Speichern sicherstellen, dass der DE-Ordner bereitsteht
+    if (!await ensureDeOrdner()) {
+        alert('Bitte wählen Sie erst einen Projektordner aus.');
+        return;
+    }
     for (const [lineStr, nums] of Object.entries(segmentAssignments)) {
         const line = parseInt(lineStr);
         if (!nums || nums.length===0) continue;
@@ -9149,6 +9154,24 @@ async function scanDeOrdner() {
         });
     }
 }
+
+// Prüft, ob der DE-Ordner vorhanden ist und versucht ihn ggf. zu initialisieren
+async function ensureDeOrdner() {
+    if (deOrdnerHandle) return true;
+    try {
+        if (!projektOrdnerHandle) {
+            const choose = confirm('Kein Projektordner gewählt. Jetzt auswählen?');
+            if (!choose) return false;
+            await waehleProjektOrdner();
+            return !!deOrdnerHandle;
+        }
+        deOrdnerHandle = await projektOrdnerHandle.getDirectoryHandle('DE', { create: true });
+        return true;
+    } catch (err) {
+        console.error('DE-Ordner konnte nicht initialisiert werden', err);
+        return false;
+    }
+}
 // =========================== SCANDEORDNER END ===============================
 
 // =========================== VERARBEITEGESCANNTE START =====================
@@ -9198,7 +9221,7 @@ async function verarbeiteGescannteDateien(dateien) {
 
 // =========================== SPEICHEREUEBERSETZUNGSDATEI START ===============
 async function speichereUebersetzungsDatei(datei, relativerPfad) {
-    if (!deOrdnerHandle) {
+    if (!await ensureDeOrdner()) {
         console.error('DE-Ordner nicht initialisiert');
         return;
     }


### PR DESCRIPTION
## Summary
- prevent segment import when DE folder not ready
- add `ensureDeOrdner` helper to initialize the DE folder
- use new helper when saving translated audio
- document automatic DE folder initialization in Troubleshooting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68717f1ea1c083279a055fe55d0ee3aa