### PR TITLE
Improve segment import workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * ▶ **Fix:** Das Backup funktioniert jetzt auch über Laufwerksgrenzen hinweg, da beim Verschieben auf Kopieren mit anschließendem Löschen umgestellt wird.
 * ▶ **Neu:** Geänderte Dateiendungen werden erkannt und automatisch korrigiert.
 * ▶ **Fix:** Der 📋-Button kopiert den Text nun zuverlässig; das zugehörige Event wird korrekt verarbeitet.
+* ▶ **Neu:** Segment-Import ohne Ordnerauswahl – in der Desktop-Version landen zugeschnittene Segmente jetzt direkt per `saveDeFile` am richtigen Ort.
 
 #### Häufige Crash-Stellen
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -6498,7 +6498,16 @@ async function exportSegmentsToProject() {
         if (!first || !last) continue;
         const buf = sliceBuffer(segmentInfo.buffer, first.start, last.end);
         const relPath = getFullPath(files[line]);
-        await speichereUebersetzungsDatei(bufferToWav(buf), relPath);
+        const wavBlob = bufferToWav(buf);
+        if (window.electronAPI && window.electronAPI.saveDeFile) {
+            // In der Desktop-Version direkt über den Hauptprozess speichern
+            const arr = new Uint8Array(await wavBlob.arrayBuffer());
+            await window.electronAPI.saveDeFile(relPath, arr);
+            deAudioCache[relPath] = `sounds/DE/${relPath}`;
+            await updateHistoryCache(relPath);
+        } else {
+            await speichereUebersetzungsDatei(wavBlob, relPath);
+        }
     }
     updateStatus('Segmente importiert');
     closeSegmentDialog();


### PR DESCRIPTION
## Summary
- revert misguided DE folder prompt
- import segments via `saveDeFile` when running in Electron
- document automatic segment import in README

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717f1ea1c083279a055fe55d0ee3aa