### PR TITLE
Add reason text for emotion tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Kontextvolle Emotionstags:** Beim Generieren eines Emotional-Texts wird nun der komplette Dialog des Levels an ChatGPT gesendet, damit der Tonfall korrekt erkannt wird.
 * **Tags mitten im Satz:** Die erzeugten Emotionstags stehen jetzt direkt vor der jeweiligen Textstelle und nicht mehr am Ende der Zeile.
 * **Tags auf Englisch:** In den eckigen Klammern sind die Emotionstags nun auf Englisch, der eigentliche Dialog bleibt Deutsch.
+* **Begründung für Emotionstags:** Unter dem violetten Textfeld erscheint eine kurze Erklärung, warum diese Emotion gewählt wurde.
 * **Automatische Übersetzungsvorschau** unter jedem DE-Feld via *Argos Translate*
 * **Kompakter Auto-Übersetzungstext:** Vorschläge unter dem DE-Feld werden nun
   mit kleiner Schrift (0.8 rem) angezeigt

--- a/prompts/gpt_emotions.txt
+++ b/prompts/gpt_emotions.txt
@@ -5,4 +5,11 @@ Setze maximal drei Tags pro Zeile und kombiniere sie bei Bedarf.
 Achte darauf, dass die Tags **vor** der jeweiligen Textstelle stehen und niemals erst am Ende.
 Wenn mehrere Emotionen zutreffen, setze die wichtigste gleich an den Zeilenanfang oder vor den betroffenen Satzteil.
 Alle Emotionstags müssen in Englisch geschrieben werden, der übrige Text bleibt deutsch.
-Keine weiteren Kommentare.
+Gib **zusätzlich eine kurze Begründung** zurück, warum diese Tags gewählt wurden.
+Erkläre knapp den emotionalen Kontext anhand der vorherigen und folgenden Zeilen.
+
+### Ausgabeformat
+Antwort ausschließlich als JSON-Objekt mit den Feldern `text` und `reason`:
+```json
+{ "text": "<Deutsch mit Emotionstags>", "reason": "<knapper Kontext>" }
+```

--- a/tests/gptService.test.js
+++ b/tests/gptService.test.js
@@ -91,3 +91,13 @@ test('fasst doppelte Zeilen zusammen', async () => {
     { id: 2, score: 5 }
   ]);
 });
+
+test('generateEmotionText liefert Objekt mit Begründung', async () => {
+  const { generateEmotionText } = require('../web/src/gptService.js');
+  jestFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ choices: [{ message: { content: '{"text":"hi","reason":"ok"}' } }] })
+  });
+  const res = await generateEmotionText({ meta: {}, lines: [], targetPosition: 1, key: 'key', model: 'gpt' });
+  expect(res).toEqual({ text: 'hi', reason: 'ok' });
+});

--- a/web/src/gptService.js
+++ b/web/src/gptService.js
@@ -175,7 +175,9 @@ async function generateEmotionText({ meta, lines, targetPosition, key, model = '
     });
     if (!res.ok) throw new Error('HTTP ' + res.status);
     const data = await res.json();
-    return data.choices[0].message.content.trim();
+    const clean = sanitizeJSONResponse(data.choices[0].message.content);
+    const obj = JSON.parse(clean);
+    return obj;
 }
 
 function createProgressDialog(total) {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1969,6 +1969,7 @@ function selectProject(id){
         if(!f.hasOwnProperty('autoTranslation')){f.autoTranslation='';}
         if(!f.hasOwnProperty('autoSource')){f.autoSource='';}
         if(!f.hasOwnProperty('emotionalText')){f.emotionalText='';}
+        if(!f.hasOwnProperty('emoReason')){f.emoReason='';}
         if(!f.hasOwnProperty('emoCompleted')){f.emoCompleted=false;}
         if(!f.hasOwnProperty('emoDubbingId')){f.emoDubbingId='';}
         if(!f.hasOwnProperty('emoDubReady')){f.emoDubReady=null;}
@@ -2718,9 +2719,11 @@ function addFiles() {
                     text_de: f.deText || ''
                 }));
                 const targetPosition = files.indexOf(file) + 1;
-                const text = await generateEmotionText({ meta, lines, targetPosition, key: openaiApiKey, model: openaiModel });
-                area.value = text;
-                updateText(file.id, 'emo', text, true);
+                const res = await generateEmotionText({ meta, lines, targetPosition, key: openaiApiKey, model: openaiModel });
+                area.value = res.text || '';
+                file.emoReason = res.reason || '';
+                updateText(file.id, 'emo', area.value, true);
+                updateEmoReasonDisplay(file.id);
                 updateStatus(`Emotionen generiert: ${file.filename}`);
             } catch (e) {
                 console.error('Emotionen fehlgeschlagen', e);
@@ -3228,6 +3231,7 @@ return `
                 <button class="copy-emotional-text" onclick="copyEmotionalText(${file.id})" title="In Zwischenablage kopieren">📋</button>
             </div>
         </div>
+        <div class="emo-reason-box" data-file-id="${file.id}">${escapeHtml(file.emoReason || '')}</div>
         </td>
         <!-- Untertitel-Suche Knopf -->
         <td><div class="btn-column">
@@ -3286,6 +3290,7 @@ return `
             updateTranslationDisplay(f.id);
             updateCommentDisplay(f.id);
             updateSuggestionDisplay(f.id);
+            updateEmoReasonDisplay(f.id);
         });
         // GPT-Vorschlag per Klick übernehmen
         document.querySelectorAll('.suggestion-box').forEach(div => {
@@ -4487,6 +4492,16 @@ function updateCommentDisplay(fileId) {
     if (box && file) {
         box.textContent = file.comment || '';
         box.style.display = file.comment ? 'block' : 'none';
+    }
+}
+
+// Zeigt die Begründung unter dem Emotional-Text an
+function updateEmoReasonDisplay(fileId) {
+    const box = document.querySelector(`.emo-reason-box[data-file-id="${fileId}"]`);
+    const file = files.find(f => f.id === fileId);
+    if (box && file) {
+        box.textContent = file.emoReason || '';
+        box.style.display = file.emoReason ? 'block' : 'none';
     }
 }
 
@@ -6977,6 +6992,7 @@ function addFileFromFolderBrowser(filename, folder, fullPath) {
         enText: textDatabase[fileKey]?.en || '',
         deText: textDatabase[fileKey]?.de || '',
         emotionalText: textDatabase[fileKey]?.emo || '',
+        emoReason: '',
         autoTranslation: '',
         autoSource: '',
         // Bewertungsergebnisse von GPT
@@ -11540,6 +11556,7 @@ function addFileToProject(filename, folder, originalResult) {
         enText: textDatabase[fileKey]?.en || '',
         deText: textDatabase[fileKey]?.de || '',
         emotionalText: textDatabase[fileKey]?.emo || '',
+        emoReason: '',
         autoTranslation: '',
         autoSource: '',
         // Bewertungsergebnisse von GPT

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2872,6 +2872,11 @@ th:nth-child(10) {
     color: #fff;
     margin-bottom: 2px;
 }
+.emo-reason-box {
+    font-size: 0.8rem;
+    color: #ccc;
+    margin-top: 2px;
+}
 .auto-trans {
     font-size: 0.8rem;
     color: #999;
@@ -2881,6 +2886,9 @@ th:nth-child(10) {
     display: none;
 }
 .comment-box:empty {
+    display: none;
+}
+.emo-reason-box:empty {
     display: none;
 }
 .suggestion-box.score-low,


### PR DESCRIPTION
## Summary
- prompt now requests a JSON object with a short reason
- parse emotion result and store explanation per file
- show explanation below each emotional text field
- new CSS for `.emo-reason-box`
- adjust project migration and file creation
- document feature in README
- test coverage for the new gptService function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871888d025883279153fa5f0b6f317f