### PR TITLE
Implement ElevenLabs v2 send

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 28. `node dev_info.js` gibt alle relevanten Systemdaten sowie die Versionen von `ffmpeg`, `ytdl-core`, `play-dl` und `yt-dlp` aus.
 29. Das Debug-Fenster zeigt jetzt zusätzlich den Pfad zum VideoFrame-Ordner und die installierten Versionen der Video-Abhängigkeiten.
 30. Ein neuer Netztest im Debug-Fenster prüft die Erreichbarkeit von YouTube.
+31. `cliSendTextV2.js` schickt Textzeilen an ElevenLabs (v2) und überspringt doppelten Inhalt.
 
 ### ElevenLabs-Dubbing
 
@@ -388,7 +389,7 @@ if (await isDubReady(job.dubbing_id, 'de', apiKey)) {
     // blob speichern ...
 }
 ```
-Die Datei `elevenlabs.js` stellt aktuell folgende Funktionen bereit: `createDubbing`, `getDubbingStatus`, `downloadDubbingAudio`, `getDefaultVoiceSettings`, `waitForDubbing`, `isDubReady`, `renderLanguage` und `pollRender`. Auskommentierte Alt-Funktionen wie `dubSegments`, `renderDubbingResource` oder `getDubbingResource` sind entfernt worden.
+Die Datei `elevenlabs.js` stellt aktuell folgende Funktionen bereit: `createDubbing`, `getDubbingStatus`, `downloadDubbingAudio`, `getDefaultVoiceSettings`, `waitForDubbing`, `isDubReady`, `renderLanguage`, `pollRender` und `sendTextV2`. Auskommentierte Alt-Funktionen wie `dubSegments`, `renderDubbingResource` oder `getDubbingResource` sind entfernt worden.
 Das komplette Workflow-Skript für den Upload, die Statusabfrage und das erneute
 Herunterladen befindet sich nun in `web/src/dubbing.js`.
 Im Desktop-Modus wird dieses Modul beim Start dynamisch geladen und stellt seine Funktionen sowohl für Node-Tests als auch im Browser global bereit. Fehlen im Importobjekt die Funktionsreferenzen, greift `main.js` auf die globalen `window`-Varianten zurück. Zusätzlich exportiert `dubbing.js` die Variable `waitDialogFileId`, über die `main.js` erkennt, zu welcher Datei der Download-Dialog gehört.

--- a/cliSendTextV2.js
+++ b/cliSendTextV2.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// cliSendTextV2.js
+// Sendet mehrere Texte nacheinander an die Text-to-Speech API v2.
+
+const fs = require('fs');
+const { sendTextV2 } = require('./elevenlabs');
+
+const [,, apiKey, voiceId, filePath] = process.argv;
+
+if (!apiKey || !voiceId || !filePath) {
+    console.log('Aufruf: node cliSendTextV2.js <API-Key> <Voice-ID> <Datei>');
+    process.exit(1);
+}
+
+const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/).filter(l => l.trim().length > 0);
+const seen = new Set();
+
+(async () => {
+    for (const line of lines) {
+        const text = line.trim();
+        if (seen.has(text)) continue; // Doppelte Zeilen überspringen
+        await sendTextV2(apiKey, voiceId, text).catch(err => {
+            console.error('Fehler bei', text, '-', err.message);
+        });
+        seen.add(text);
+    }
+    console.log('Daten an die API geschickt');
+})();

--- a/elevenlabs.js
+++ b/elevenlabs.js
@@ -234,6 +234,30 @@ async function pollRender(id, lang = 'de', apiKey, logger = () => {}) {
 }
 // =========================== RENDERLANGUAGE END ============================
 
+// =========================== SENDTEXTV2 START =============================
+/**
+ * Sendet einen Text an das Text-to-Speech-Endpunkt der Version 2.
+ * Der Audio-Stream wird verworfen, es wird nur der Status geprüft.
+ * @param {string} apiKey  Eigener API-Schlüssel.
+ * @param {string} voiceId Gewählte Stimme.
+ * @param {string} text    Zu generierender Text.
+ */
+async function sendTextV2(apiKey, voiceId, text, logger = () => {}) {
+    const body = { text, model_id: 'eleven_multilingual_v2' };
+    const url = `${API}/text-to-speech/${voiceId}`;
+    logger(`POST ${url}`);
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'xi-api-key': apiKey, 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+    logger(`Antwort (${res.status})`);
+    if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(`Text-to-Speech fehlgeschlagen: ${res.status} ${errText}`);
+    }
+}
+// =========================== SENDTEXTV2 END ===============================
 
 // =========================== DOWNLOADFROMURL START =======================
 // Hilfsfunktion zum Speichern eines Response-Streams
@@ -261,5 +285,6 @@ module.exports = {
     waitForDubbing,
     isDubReady,
     renderLanguage,
-    pollRender
+    pollRender,
+    sendTextV2
 };

--- a/tests/sendTextV2.test.js
+++ b/tests/sendTextV2.test.js
@@ -1,0 +1,27 @@
+const nock = require('nock');
+const { sendTextV2 } = require('../elevenlabs');
+
+const API = 'https://api.elevenlabs.io/v1';
+
+afterEach(() => {
+    nock.cleanAll();
+});
+
+describe('sendTextV2', () => {
+    test('sendet Text erfolgreich', async () => {
+        const scope = nock(API)
+            .post('/text-to-speech/abc', body => body.text === 'Hallo' && body.model_id === 'eleven_multilingual_v2')
+            .reply(200, '');
+
+        await sendTextV2('key', 'abc', 'Hallo');
+        expect(scope.isDone()).toBe(true);
+    });
+
+    test('wirft Fehler bei HTTP-Fehler', async () => {
+        nock(API)
+            .post('/text-to-speech/abc')
+            .reply(400, 'Fehler');
+
+        await expect(sendTextV2('key', 'abc', 'Test')).rejects.toThrow('Text-to-Speech fehlgeschlagen');
+    });
+});


### PR DESCRIPTION
## Summary
- add `sendTextV2` to `elevenlabs.js` for sending text without downloading audio
- provide CLI helper `cliSendTextV2.js`
- describe new helper in README
- cover new function with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68718fd882548327b5f9a0a1fe8ba19a