### PR TITLE
Emotionale Texte immer neu generieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Tab/Shift+Tab Navigation** zwischen Textfeldern und Zeilen
 * **Ctrl+Leertaste:** Audio‑Playback direkt im Textfeld
 * **Copy‑Buttons:** 📋 neben jedem Textfeld für direktes Kopieren
-* **Emotionaler DE‑Text:** Unter jedem deutschen Textfeld befindet sich ein eigenes Feld mit violettem Hintergrund. Ein Button "Emotional-Text generieren" füllt es automatisch, ein 📋‑Knopf kopiert den Inhalt.
-* **Emotionen generieren:** Der Button oberhalb der Tabelle füllt nun alle leeren Emotional-Text-Felder des gesamten Projekts auf einmal – unabhängig von der aktuellen Filterung.
+* **Emotionaler DE‑Text:** Unter jedem deutschen Textfeld befindet sich ein eigenes Feld mit violettem Hintergrund. Der Button „Emotional-Text generieren“ erstellt den Inhalt nun stets neu; ein 📋‑Knopf kopiert ihn.
+* **Emotionen generieren:** Der Button oberhalb der Tabelle erstellt jetzt für alle Zeilen neue Emotional-Text-Felder – vorhandene Inhalte werden überschrieben.
 * **Kontextvolle Emotionstags:** Beim Generieren eines Emotional-Texts wird nun der komplette Dialog des Levels an ChatGPT gesendet, damit der Tonfall korrekt erkannt wird.
 * **Tags mitten im Satz:** Die erzeugten Emotionstags stehen jetzt direkt vor der jeweiligen Textstelle und nicht mehr am Ende der Zeile.
 * **Tags auf Englisch:** In den eckigen Klammern sind die Emotionstags nun auf Englisch, der eigentliche Dialog bleibt Deutsch.

--- a/web/src/gptService.js
+++ b/web/src/gptService.js
@@ -159,7 +159,7 @@ async function generateEmotionText({ meta, lines, targetPosition, key, model = '
         ...meta,
         lines,
         target_position: targetPosition,
-        instructions: 'Analysiere die Szene und gib den deutschen Text zurück. Platziere die Emotionstags direkt vor der jeweiligen Textstelle und formuliere sie auf Englisch.'
+        instructions: 'Analysiere die Szene und gib den Text komplett auf Deutsch zurück. Platziere die Emotionstags direkt vor der jeweiligen Textstelle und schreibe diese Tags auf Englisch.'
     };
     const messages = [
         { role: 'system', content: emotionPrompt },

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2704,7 +2704,7 @@ function addFiles() {
             const area = row?.querySelector('textarea.emotional-text');
             const btn  = row?.querySelector('button.generate-emotions-btn');
             if (!row || !area || !btn) return;
-            if (area.value.trim()) return; // nichts überschreiben
+            // Bisherigen Inhalt immer verwerfen
             if (!openaiApiKey) { updateStatus('GPT-Key fehlt'); return; }
             btn.disabled = true;
             area.value = '...';
@@ -2744,11 +2744,8 @@ function addFiles() {
         async function generateEmotionsForAll() {
             const btn = document.getElementById('generateEmotionsButton');
             if (!btn || !openaiApiKey) { updateStatus('GPT-Key fehlt'); return; }
-            // IDs aller Dateien sammeln, die noch keinen Emotional-Text haben
-            const ids = files.map(f => f.id).filter(id => {
-                const area = document.querySelector(`tr[data-id='${id}'] textarea.emotional-text`);
-                return area && !area.value.trim();
-            });
+            // IDs aller Dateien sammeln – vorhandener Text wird überschrieben
+            const ids = files.map(f => f.id);
             if (ids.length === 0) return;
             btn.disabled = true;
             btn.textContent = 'Generiere...';


### PR DESCRIPTION
## Zusammenfassung
- Emotionstexte und Begründungen werden stets neu erzeugt
- Prompt angepasst: Rückgabe jetzt explizit komplett auf Deutsch
- README aktualisiert

## Testanweisungen
- `npm test` ausführen und sicherstellen, dass alle Tests erfolgreich sind

------
https://chatgpt.com/codex/tasks/task_e_68719989de6c8327a05283f802e4fca0