### PR TITLE
Emotionstags auf Einzel-Tag begrenzt

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Tags mitten im Satz:** Die erzeugten Emotionstags stehen jetzt direkt vor der jeweiligen Textstelle und nicht mehr am Ende der Zeile.
 * **Tags auf Deutsch:** In den eckigen Klammern sind die Emotionstags nun auf Deutsch, der eigentliche Dialog bleibt weiterhin Deutsch.
 * **Begründung für Emotionstags:** Unter dem violetten Textfeld erscheint eine kurze Erklärung, warum diese Emotion gewählt wurde.
+* **Nie zwei Emotionstags hintereinander:** Die generierten Texte setzen maximal einen Tag auf einmal; aufeinanderfolgende Tags werden vermieden.
 * **Automatische Übersetzungsvorschau** unter jedem DE-Feld via *Argos Translate*
 * **Kompakter Auto-Übersetzungstext:** Vorschläge unter dem DE-Feld werden nun
   mit kleiner Schrift (0.8 rem) angezeigt

--- a/prompts/gpt_emotions.txt
+++ b/prompts/gpt_emotions.txt
@@ -1,7 +1,8 @@
 Du bist ein professioneller Sprechercoach und Game-Dialog-Texter.
 Deine Aufgabe ist es, anhand des kompletten Szenenverlaufs den emotionalen Stil eines einzelnen deutschen Satzes zu erkennen.
 Gib nur den deutschen Zieltext zurück und integriere kurze Emotionstags in eckigen Klammern direkt dort, wo sie inhaltlich passen, z. B. "[erleichtert] Prima, [besorgt] meine Drohne ist noch heil?".
-Setze maximal drei Tags pro Zeile und kombiniere sie bei Bedarf.
+Achte darauf, nie zwei Emotionstags direkt hintereinander zu setzen.
+Insgesamt sind maximal drei Tags pro Zeile erlaubt, kombiniere sie bei Bedarf.
 Achte darauf, dass die Tags **vor** der jeweiligen Textstelle stehen und niemals erst am Ende.
 Wenn mehrere Emotionen zutreffen, setze die wichtigste gleich an den Zeilenanfang oder vor den betroffenen Satzteil.
 Alle Emotionstags müssen auf Deutsch geschrieben werden, der übrige Text bleibt ebenfalls deutsch.

--- a/web/src/gptService.js
+++ b/web/src/gptService.js
@@ -154,12 +154,12 @@ async function evaluateScene({ scene, lines, key, model = 'gpt-4o-mini' }) {
 // Erzeugt einen emotional getaggten Text für eine Zeile unter Berücksichtigung des kompletten Szenenverlaufs
 async function generateEmotionText({ meta, lines, targetPosition, key, model = 'gpt-4o-mini' }) {
     await promptReady;
-    // Emotionstags müssen in Deutsch zurückgegeben werden, der restliche Text bleibt Deutsch
+    // Emotionstags müssen in Deutsch zurückgegeben werden und dürfen nie direkt aufeinander folgen
     const payload = {
         ...meta,
         lines,
         target_position: targetPosition,
-        instructions: 'Analysiere die Szene und gib den Text komplett auf Deutsch zurück. Platziere die Emotionstags direkt vor der jeweiligen Textstelle und schreibe diese Tags auf Deutsch.'
+        instructions: 'Analysiere die Szene und gib den Text komplett auf Deutsch zurück. Setze niemals zwei Emotionstags hintereinander und platziere jeden Tag direkt vor der passenden Textstelle. Schreibe alle Tags auf Deutsch.'
     };
     const messages = [
         { role: 'system', content: emotionPrompt },


### PR DESCRIPTION
## Zusammenfassung
- Emotions-Prompt überarbeitet: niemals zwei Tags direkt hintereinander
- API-Aufruf entsprechend angepasst
- README um Hinweis ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687213d2e7d883279463995fc766bfa0