### PR TITLE
Add ignore ranges in DE audio editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Hall-Standardwerte:** Im Hall-Bereich setzt **⟳ Hall-Standardwerte** alle Parameter auf ihre Ausgangswerte zurück.
 * **Verbessertes Speichern:** Nach dem Anwenden von Lautstärke angleichen oder Funkgerät‑Effekt bleiben die Änderungen nun zuverlässig erhalten.
 * **Vier Bearbeitungssymbole:** Der Status neben der Schere zeigt nun bis zu vier Icons in zwei Reihen für Trimmen, Lautstärkeangleichung, Funkgerät- und Hall-Effekt an.
+* **Ignorier-Bereiche im DE-Editor:** Mit gedrückter Umschalttaste lassen sich beliebige Abschnitte markieren, die beim Abspielen und Speichern übersprungen werden. Die Bereiche bleiben bearbeitbar und erscheinen in einer eigenen Liste.
 * **Bugfix beim Ziehen:** Ein versehentlicher Drag ohne den Griff löst keine Fehlermeldung mehr aus.
 * **Zurücksetzen nach Upload oder Dubbing:** Sowohl beim Hochladen als auch beim erneuten Erzeugen einer deutschen Audiodatei werden Lautstärkeangleichung, Funkgerät‑Effekt und Hall‑Effekt automatisch deaktiviert.
 * **Fehlerhinweise beim Speichern:** Tritt ein Problem auf, erscheint eine rote Toast-Meldung statt eines stummen Abbruchs.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -592,6 +592,10 @@
                 <label>Start (ms): <input type="number" id="editStart" value="0" step="100"></label>
                 <label>Ende (ms): <input type="number" id="editEnd" value="0" step="100"></label>
             </div>
+            <div class="ignore-container">
+                <h4>Ignorierbereiche</h4>
+                <div id="ignoreList"></div>
+            </div>
             <hr class="effect-separator">
             <fieldset class="effect-group">
                 <legend>📡 Funkgerät-Effekt</legend>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1115,6 +1115,10 @@ th:nth-child(10) {
     margin-bottom: 15px;
 }
 
+.ignore-container { margin-bottom: 15px; }
+.ignore-row { display:flex; gap:6px; margin-bottom:4px; }
+.ignore-row input { width:70px; }
+
 .radio-settings,
 .hall-settings {
     display: flex;


### PR DESCRIPTION
## Summary
- allow marking of skip regions inside DE audio clips
- show ignore ranges below the waveform
- draw ignore areas in the waveform display
- store ignore data per file and keep them editable
- document the new functionality in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872302b049c832799118d6e901b8577