### PR TITLE
Add ignore ranges in DE audio editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Hall-Standardwerte:** Im Hall-Bereich setzt **⟳ Hall-Standardwerte** alle Parameter auf ihre Ausgangswerte zurück.
 * **Verbessertes Speichern:** Nach dem Anwenden von Lautstärke angleichen oder Funkgerät‑Effekt bleiben die Änderungen nun zuverlässig erhalten.
 * **Vier Bearbeitungssymbole:** Der Status neben der Schere zeigt nun bis zu vier Icons in zwei Reihen für Trimmen, Lautstärkeangleichung, Funkgerät- und Hall-Effekt an.
+* **Ignorier-Bereiche im DE-Editor:** Mit gedrückter Umschalttaste lassen sich beliebige Abschnitte markieren, die beim Abspielen und Speichern übersprungen werden. Die Bereiche bleiben bearbeitbar und erscheinen in einer eigenen Liste. Vorschau und Export überspringen diese Stellen automatisch.
 * **Bugfix beim Ziehen:** Ein versehentlicher Drag ohne den Griff löst keine Fehlermeldung mehr aus.
 * **Zurücksetzen nach Upload oder Dubbing:** Sowohl beim Hochladen als auch beim erneuten Erzeugen einer deutschen Audiodatei werden Lautstärkeangleichung, Funkgerät‑Effekt und Hall‑Effekt automatisch deaktiviert.
 * **Fehlerhinweise beim Speichern:** Tritt ein Problem auf, erscheint eine rote Toast-Meldung statt eines stummen Abbruchs.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -592,6 +592,10 @@
                 <label>Start (ms): <input type="number" id="editStart" value="0" step="100"></label>
                 <label>Ende (ms): <input type="number" id="editEnd" value="0" step="100"></label>
             </div>
+            <div class="ignore-container">
+                <h4>Ignorierbereiche</h4>
+                <div id="ignoreList"></div>
+            </div>
             <hr class="effect-separator">
             <fieldset class="effect-group">
                 <legend>📡 Funkgerät-Effekt</legend>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -108,6 +108,11 @@ let editOrigCursor         = 0;    // Position der EN-Wiedergabe in ms
 let editDeCursor           = 0;    // Position der DE-Wiedergabe in ms
 let editBlobUrl            = null; // aktuelle Blob-URL
 
+// Zusätzliche Marker für Ignorier-Bereiche
+let editIgnoreRanges      = [];    // Liste der zu überspringenden Bereiche
+let ignoreTempStart       = null;  // Startpunkt für neuen Bereich
+let ignoreDragging        = null;  // {index, side} beim Ziehen
+
 let draggedElement         = null;
 let currentlyPlaying       = null;
 let selectedRow            = null; // für Tastatur-Navigation
@@ -2145,6 +2150,7 @@ function selectProject(id){
         if(!f.hasOwnProperty('emoCompleted')){f.emoCompleted=false;}
         if(!f.hasOwnProperty('emoDubbingId')){f.emoDubbingId='';}
         if(!f.hasOwnProperty('emoDubReady')){f.emoDubReady=null;}
+        if(!f.hasOwnProperty('ignoreRanges')){f.ignoreRanges=[];migrated=true;}
         if(!f.hasOwnProperty('version')){f.version=1;migrated=true;}
     });
     if(migrated) isDirty=true;
@@ -2363,6 +2369,7 @@ function addFiles() {
                 selected: true,
                 trimStartMs: 0,
                 trimEndMs: 0,
+                ignoreRanges: [],
                 volumeMatched: false,
                 radioEffect: false,
                 hallEffect: false,
@@ -6376,6 +6383,54 @@ function mergeSegments(buffer, segments) {
     return newBuf;
 }
 
+// Entfernt mehrere Bereiche aus einem Buffer
+// Hilfsfunktion: Bereiche sortieren und auf Grenzen prüfen
+function normalizeRanges(ranges, duration) {
+    return ranges
+        .map(r => ({ start: Math.max(0, r.start), end: Math.min(duration, r.end) }))
+        .filter(r => r.end > r.start)
+        .sort((a, b) => a.start - b.start);
+}
+
+// Entfernt mehrere Bereiche aus einem Buffer
+function removeRangesFromBuffer(buffer, ranges) {
+    if (!ranges || ranges.length === 0) return buffer;
+    const duration = buffer.length / buffer.sampleRate * 1000;
+    const valid = normalizeRanges(ranges, duration);
+    if (valid.length === 0) return buffer;
+    const segments = [];
+    let pos = 0;
+    for (const r of valid) {
+        if (r.start > pos) segments.push({ start: pos, end: r.start });
+        pos = Math.max(pos, r.end);
+    }
+    if (pos < duration) segments.push({ start: pos, end: duration });
+    return mergeSegments(buffer, segments) || buffer;
+}
+
+// Rechnet Originalposition auf Abspielposition um (nach Entfernen der Bereiche)
+function originalToPlayback(ms, ranges, duration) {
+    const valid = normalizeRanges(ranges, duration);
+    let offset = 0;
+    for (const r of valid) {
+        if (ms <= r.start) break;
+        const part = Math.min(ms, r.end) - r.start;
+        if (part > 0) offset += part;
+    }
+    return ms - offset;
+}
+
+// Rechnet Abspielposition wieder auf Originalzeit um
+function playbackToOriginal(ms, ranges, duration) {
+    const valid = normalizeRanges(ranges, duration);
+    let offset = 0;
+    for (const r of valid) {
+        if (ms + offset < r.start) break;
+        offset += r.end - r.start;
+    }
+    return ms + offset;
+}
+
 function toggleIgnoreSelectedSegments() {
     if (segmentSelection.length === 0) return;
     segmentSelection.forEach(i => {
@@ -9933,6 +9988,16 @@ function drawWaveform(canvas, buffer, opts = {}) {
     ctx.stroke();
 
     const durationMs = buffer.length / buffer.sampleRate * 1000;
+
+    // Ignorier-Bereiche halbtransparent darstellen
+    if (opts.ignore && Array.isArray(opts.ignore)) {
+        ctx.fillStyle = 'rgba(128,128,128,0.5)';
+        opts.ignore.forEach(r => {
+            const sx = (r.start / durationMs) * width;
+            const ex = (r.end   / durationMs) * width;
+            ctx.fillRect(sx, 0, ex - sx, height);
+        });
+    }
     if (opts.start !== undefined && opts.end !== undefined) {
         ctx.strokeStyle = '#0f0';
         ctx.lineWidth = 2;
@@ -10257,10 +10322,13 @@ async function openDeEdit(fileId) {
     if (editBlobUrl) { URL.revokeObjectURL(editBlobUrl); editBlobUrl = null; }
     editStartTrim = file.trimStartMs || 0;
     editEndTrim = file.trimEndMs || 0;
+    editIgnoreRanges = Array.isArray(file.ignoreRanges) ? file.ignoreRanges.map(r => ({start:r.start,end:r.end})) : [];
+    ignoreTempStart = null;
     document.getElementById('editStart').value = editStartTrim;
     document.getElementById('editEnd').value = editEndTrim;
     document.getElementById('editStart').oninput = e => { editStartTrim = parseInt(e.target.value) || 0; updateDeEditWaveforms(); };
     document.getElementById('editEnd').oninput = e => { editEndTrim = parseInt(e.target.value) || 0; updateDeEditWaveforms(); };
+    refreshIgnoreList();
 
     const deCanvas = document.getElementById('waveEdited');
     const origCanvas = document.getElementById('waveOriginal');
@@ -10402,15 +10470,40 @@ async function openDeEdit(fileId) {
         const rect = deCanvas.getBoundingClientRect();
         const x = e.clientX - rect.left;
         const width = rect.width;
+        const time = (x / width) * editDurationMs;
+
+        if (e.shiftKey) {
+            if (ignoreTempStart === null) {
+                ignoreTempStart = time;
+            } else {
+                const start = Math.min(ignoreTempStart, time);
+                const end = Math.max(ignoreTempStart, time);
+                editIgnoreRanges.push({ start, end });
+                ignoreTempStart = null;
+                refreshIgnoreList();
+            }
+            updateDeEditWaveforms();
+            return;
+        }
+
         const startX = (editStartTrim / editDurationMs) * width;
         const endX = ((editDurationMs - editEndTrim) / editDurationMs) * width;
+        // Prüfen, ob ein Ignoriermarker gezogen wird
+        for (let i = 0; i < editIgnoreRanges.length; i++) {
+            const r = editIgnoreRanges[i];
+            const sx = (r.start / editDurationMs) * width;
+            const ex = (r.end / editDurationMs) * width;
+            if (Math.abs(x - sx) < 5) { ignoreDragging = { index: i, side: 'start' }; return; }
+            if (Math.abs(x - ex) < 5) { ignoreDragging = { index: i, side: 'end' }; return; }
+        }
+
         if (Math.abs(x - startX) < 7) {
             editDragging = 'start';
         } else if (Math.abs(x - endX) < 7) {
             editDragging = 'end';
         } else {
             editDragging = null;
-            editDeCursor = (x / width) * editDurationMs;
+            editDeCursor = time;
             if (editPlaying === 'de') {
                 const audio = document.getElementById('audioPlayer');
                 const dur = editDurationMs - editStartTrim - editEndTrim;
@@ -10420,11 +10513,22 @@ async function openDeEdit(fileId) {
         }
     };
     window.onmousemove = e => {
-        if (!editDragging) return;
         const rect = deCanvas.getBoundingClientRect();
         const x = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
         const ratio = x / rect.width;
         const time = ratio * editDurationMs;
+        if (ignoreDragging) {
+            const r = editIgnoreRanges[ignoreDragging.index];
+            if (ignoreDragging.side === 'start') {
+                r.start = Math.min(time, r.end - 1);
+            } else {
+                r.end = Math.max(time, r.start + 1);
+            }
+            refreshIgnoreList();
+            updateDeEditWaveforms();
+            return;
+        }
+        if (!editDragging) return;
         if (editDragging === 'start') {
             editStartTrim = Math.min(time, editDurationMs - editEndTrim - 1);
         } else if (editDragging === 'end') {
@@ -10432,7 +10536,7 @@ async function openDeEdit(fileId) {
         }
         updateDeEditWaveforms();
     };
-window.onmouseup = () => { editDragging = null; };
+window.onmouseup = () => { editDragging = null; ignoreDragging = null; };
     updateEffectButtons();
 }
 // =========================== OPENDEEDIT END ================================
@@ -10633,10 +10737,42 @@ function updateDeEditWaveforms(progressOrig = null, progressDe = null) {
     }
     if (originalEditBuffer) {
         const endPos = editDurationMs - editEndTrim;
-        drawWaveform(document.getElementById('waveEdited'), originalEditBuffer, { start: editStartTrim, end: endPos, progress: showDe });
+        drawWaveform(
+            document.getElementById('waveEdited'),
+            originalEditBuffer,
+            { start: editStartTrim, end: endPos, progress: showDe, ignore: editIgnoreRanges }
+        );
     }
     document.getElementById('editStart').value = Math.round(editStartTrim);
     document.getElementById('editEnd').value = Math.round(editEndTrim);
+}
+// Aktualisiert die Liste der Ignorier-Bereiche
+function refreshIgnoreList() {
+    const container = document.getElementById('ignoreList');
+    if (!container) return;
+    container.innerHTML = '';
+    editIgnoreRanges.forEach((r, idx) => {
+        const row = document.createElement('div');
+        row.className = 'ignore-row';
+        row.innerHTML =
+            `<input type="number" value="${Math.round(r.start)}" step="100" class="ignore-start">` +
+            `<input type="number" value="${Math.round(r.end)}" step="100" class="ignore-end">` +
+            `<button class="btn btn-secondary">🗑️</button>`;
+        row.querySelector('.ignore-start').oninput = e => {
+            r.start = parseInt(e.target.value) || 0;
+            updateDeEditWaveforms();
+        };
+        row.querySelector('.ignore-end').oninput = e => {
+            r.end = parseInt(e.target.value) || 0;
+            updateDeEditWaveforms();
+        };
+        row.querySelector('button').onclick = () => {
+            editIgnoreRanges.splice(idx, 1);
+            refreshIgnoreList();
+            updateDeEditWaveforms();
+        };
+        container.appendChild(row);
+    });
 }
 // =========================== UPDATEDEEDITWAVEFORMS END ====================
 
@@ -10719,13 +10855,17 @@ function playDePreview() {
     const btn = document.getElementById('playDePreview');
     const audio = document.getElementById('audioPlayer');
     if (editPlaying === 'de') {
+        const trimmed = trimAndPadBuffer(originalEditBuffer, editStartTrim, editEndTrim);
+        const dur = trimmed.length / trimmed.sampleRate * 1000;
+        const adj = editIgnoreRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim }));
         if (editPaused) {
             audio.play().then(() => {
                 btn.classList.add('playing');
                 btn.textContent = '⏸';
                 editPaused = false;
                 editProgressTimer = setInterval(() => {
-                    updateDeEditWaveforms(null, audio.currentTime * 1000);
+                    const pos = playbackToOriginal(audio.currentTime * 1000, adj, dur);
+                    updateDeEditWaveforms(null, pos);
                 }, 50);
             });
         } else {
@@ -10733,8 +10873,8 @@ function playDePreview() {
             if (editProgressTimer) clearInterval(editProgressTimer);
             editProgressTimer = null;
             editPaused = true;
-            // Position für DE merken
-            editDeCursor = editStartTrim + audio.currentTime * 1000;
+            const pos = playbackToOriginal(audio.currentTime * 1000, adj, dur);
+            editDeCursor = editStartTrim + pos;
             btn.classList.remove('playing');
             btn.textContent = '▶';
             updateDeEditWaveforms();
@@ -10743,10 +10883,14 @@ function playDePreview() {
     }
     stopEditPlayback();
     const trimmed = trimAndPadBuffer(originalEditBuffer, editStartTrim, editEndTrim);
-    const blob = bufferToWav(trimmed);
+    const dur = trimmed.length / trimmed.sampleRate * 1000;
+    const adj = editIgnoreRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim }));
+    const finalBuf = removeRangesFromBuffer(trimmed, adj);
+    const blob = bufferToWav(finalBuf);
     editBlobUrl = URL.createObjectURL(blob);
     audio.src = editBlobUrl;
-    audio.currentTime = Math.max(editDeCursor - editStartTrim, 0) / 1000;
+    const start = originalToPlayback(Math.max(editDeCursor - editStartTrim, 0), adj, dur) / 1000;
+    audio.currentTime = start;
     audio.load();
     audio.play().then(() => {
         btn.classList.add('playing');
@@ -10754,7 +10898,8 @@ function playDePreview() {
         editPlaying = 'de';
         editPaused = false;
         editProgressTimer = setInterval(() => {
-            updateDeEditWaveforms(null, audio.currentTime * 1000);
+            const pos = playbackToOriginal(audio.currentTime * 1000, adj, dur);
+            updateDeEditWaveforms(null, pos);
         }, 50);
         audio.onended = () => { URL.revokeObjectURL(editBlobUrl); editBlobUrl = null; stopEditPlayback(); };
     }).catch(err => {
@@ -10781,6 +10926,9 @@ function closeDeEdit() {
     hallEffectBuffer = null;
     isHallEffect = false;
     editEnBuffer = null;
+    editIgnoreRanges = [];
+    ignoreTempStart = null;
+    ignoreDragging = null;
     window.onmousemove = null;
     window.onmouseup = null;
     updateEffectButtons();
@@ -10825,6 +10973,8 @@ async function resetDeEdit() {
         editEndTrim = 0;
         currentEditFile.trimStartMs = 0;
         currentEditFile.trimEndMs = 0;
+        editIgnoreRanges = [];
+        currentEditFile.ignoreRanges = [];
         currentEditFile.volumeMatched = false;
         currentEditFile.radioEffect = false;
         currentEditFile.hallEffect = false;
@@ -10839,6 +10989,7 @@ async function resetDeEdit() {
         isDirty = true;
         editDurationMs = originalEditBuffer.length / originalEditBuffer.sampleRate * 1000;
         updateDeEditWaveforms();
+        refreshIgnoreList();
         updateStatus('DE-Audio zurückgesetzt');
         // Tabelle neu zeichnen, damit der Play-Button die aktuelle Datei nutzt
         renderFileTable();
@@ -10880,7 +11031,9 @@ async function applyDeEdit() {
         if (isHallEffect) {
             baseBuffer = await applyReverbEffect(baseBuffer);
         }
-        const newBuffer = trimAndPadBuffer(baseBuffer, editStartTrim, editEndTrim);
+        let newBuffer = trimAndPadBuffer(baseBuffer, editStartTrim, editEndTrim);
+        const adj = editIgnoreRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim }));
+        newBuffer = removeRangesFromBuffer(newBuffer, adj);
         drawWaveform(document.getElementById('waveEdited'), newBuffer, { start: 0, end: newBuffer.length / newBuffer.sampleRate * 1000 });
         const blob = bufferToWav(newBuffer);
         const buf = await blob.arrayBuffer();
@@ -10943,7 +11096,9 @@ async function applyDeEdit() {
         if (isHallEffect) {
             baseBuffer = await applyReverbEffect(baseBuffer);
         }
-        const newBuffer = trimAndPadBuffer(baseBuffer, editStartTrim, editEndTrim);
+        let newBuffer = trimAndPadBuffer(baseBuffer, editStartTrim, editEndTrim);
+        const adj = editIgnoreRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim }));
+        newBuffer = removeRangesFromBuffer(newBuffer, adj);
         drawWaveform(document.getElementById('waveEdited'), newBuffer, { start: 0, end: newBuffer.length / newBuffer.sampleRate * 1000 });
         const blob = bufferToWav(newBuffer);
         await speichereUebersetzungsDatei(blob, relPath);
@@ -10953,6 +11108,7 @@ async function applyDeEdit() {
     }
         currentEditFile.trimStartMs = editStartTrim;
         currentEditFile.trimEndMs = editEndTrim;
+        currentEditFile.ignoreRanges = editIgnoreRanges;
         currentEditFile.volumeMatched = isVolumeMatched;
         currentEditFile.radioEffect = isRadioEffect;
         currentEditFile.hallEffect = isHallEffect;
@@ -13089,6 +13245,7 @@ if (typeof module !== "undefined" && module.exports) {
         exportSegmentsToProject,
         toggleIgnoreSelectedSegments,
         mergeSegments,
+        removeRangesFromBuffer,
         __setSegmentInfo: info => { segmentInfo = info; },
         __setSegmentAssignments: a => { segmentAssignments = a; },
         __getSegmentInfo: () => segmentInfo,

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1115,6 +1115,10 @@ th:nth-child(10) {
     margin-bottom: 15px;
 }
 
+.ignore-container { margin-bottom: 15px; }
+.ignore-row { display:flex; gap:6px; margin-bottom:4px; }
+.ignore-row input { width:70px; }
+
 .radio-settings,
 .hall-settings {
     display: flex;


### PR DESCRIPTION
## Summary
- allow marking of skip regions inside DE audio clips
- show ignore ranges below the waveform
- draw skip areas in the waveform display
- store ignore data per file and keep them editable
- preview and export now skip these sections automatically
- document the new functionality in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872302b049c832799118d6e901b8577