### PR TITLE
Improve resilience to OpenAI rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Auswahl des GPT-Modells:** Im ChatGPT-Dialog lässt sich das Modell wählen. Die Liste wird auf Wunsch vom Server geladen und für 24&nbsp;Stunden gespeichert
 * **Automatisch geladene GPT-Einstellungen:** Gespeicherter Key und gewähltes Modell stehen nach dem Start sofort zur Verfügung
 * **Robuste GPT-Antworten:** Entfernt ```json-Blöcke``` automatisch und verhindert so Parsefehler
+* **Automatische Wiederholung bei 429:** Schlägt eine Anfrage fehl, wird sie bis zu drei Mal erneut gesendet
 * **Charaktername im GPT-Prompt:** Das Feld `character` nutzt nun den Ordnernamen
 * **Bugfix:** Scores werden korrekt eingefügt, auch wenn ID und Score als Zeichenketten geliefert werden
 * **Robustere Zuordnung:** GPT-Ergebnisse finden jetzt auch dann die richtige Zeile, wenn die ID leicht abweicht

--- a/tests/gptService.test.js
+++ b/tests/gptService.test.js
@@ -101,3 +101,14 @@ test('generateEmotionText liefert Objekt mit Begründung', async () => {
   const res = await generateEmotionText({ meta: {}, lines: [], targetPosition: 1, key: 'key', model: 'gpt' });
   expect(res).toEqual({ text: 'hi', reason: 'ok' });
 });
+
+test('wiederholt bei HTTP 429', async () => {
+  const { evaluateScene } = require('../web/src/gptService.js');
+  const lines = [{ id: 1, character: '', en: 'a', de: 'b' }];
+  jestFetch
+    .mockResolvedValueOnce({ ok: false, status: 429 })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ choices: [{ message: { content: '[{"id":1}]' } }] }) });
+  const res = await evaluateScene({ scene: 's', lines, key: 'k', model: 'gpt' });
+  expect(jestFetch).toHaveBeenCalledTimes(2);
+  expect(res).toEqual([{ id: 1 }]);
+});


### PR DESCRIPTION
## Summary
- retry API-Aufrufe bei `429` und `503`
- neue Hilfsfunktion `fetchWithRetry` in `gptService.js`
- Tests fuer das erneute Senden bei `429`
- Dokumentation erweitert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872378ea13c8327b33f63f75ef1a49d