### PR TITLE
Add refined emotion clipboard helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Aufgeräumte Filter-Leiste:** GPT-, Emotions- und Kopierhilfe-Knöpfe stehen jetzt direkt neben der Suche in einer Zeile.
 * **Automatischer Voice-Abgleich:** Beim Öffnen der Kopierhilfe lädt das Tool die verfügbaren ElevenLabs-Stimmen und zeigt Namen und IDs korrekt an.
 * **Zusätzliche Zwischenablage-Prüfung:** Die Kopierhilfe stellt sicher, dass im ersten Schritt der Name und im zweiten der Emotionstext in der Zwischenablage liegt.
+* **Alle Emotionstexte kopieren:** Ein neuer Button sammelt alle Emotionstexte, entfernt darin Zeilenumbrüche und trennt die Blöcke jeweils mit einer Leerzeile.
 * **Stabile Base64-Kodierung:** Große Audiodateien werden beim Hochladen in handlichen Blöcken verarbeitet, sodass kein "Maximum call stack size exceeded" mehr auftritt.
 * **Projektkarten mit Rahmen:** Jede Karte besitzt einen grauen Rand und nutzt nun die volle Breite. Im geöffneten Level wird der Rand grün. Das aktuell gewählte Projekt hebt sich mit einem blauen Balken, leicht transparentem Hintergrund (rgba(33,150,243,0.2)) und weißer Schrift deutlich ab.
 * **Überarbeitete Seitenleiste:** Jede Projektkarte besteht aus zwei Zeilen mit einheitlich breiten Badges für EN, DE und Audio.

--- a/tests/copyAllEmotions.test.js
+++ b/tests/copyAllEmotions.test.js
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment jsdom
+ */
+
+let copyAllEmotionsToClipboard, __setFiles;
+
+function loadMain() {
+    jest.resetModules();
+    if (!global.navigator) global.navigator = {};
+    global.navigator.clipboard = { writeText: jest.fn().mockResolvedValue() };
+    global.safeCopy = async text => { await navigator.clipboard.writeText(text); return true; };
+    global.showToast = jest.fn();
+    global.files = [];
+    ({ copyAllEmotionsToClipboard, __setFiles } = require('../web/src/main.js'));
+    // nach dem Laden die Toast-Funktion überschreiben und DOM vorbereiten
+    global.showToast = jest.fn();
+    document.body.innerHTML = '<div id="toastContainer"></div>';
+}
+
+describe('copyAllEmotionsToClipboard', () => {
+    beforeEach(loadMain);
+
+    test('bereitet Emotionstexte auf und kopiert sie', async () => {
+        const arr = [
+            { emotionalText: '[dankbar]\nDanke\n' },
+            { emotionalText: 'Hallo Welt!\nWie gehts?\n' }
+        ];
+        __setFiles(arr);
+        await copyAllEmotionsToClipboard();
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('[dankbar] Danke\n\nHallo Welt! Wie gehts?');
+    });
+});

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -114,6 +114,7 @@
                     <button id="sendTextV2Button" class="btn btn-blue" title="Alle Emotional-Texte an ElevenLabs senden">An ElevenLabs schicken</button>
                     <button class="btn btn-secondary" onclick="openSegmentDialog()">🔊 Audio-Datei zuordnen</button>
                     <button id="copyAssistantButton" class="btn btn-secondary">Kopierhilfe</button>
+                    <button id="copyAllEmosButton" class="btn btn-secondary">Emotionen kopieren</button>
                 </div>
                 <div class="sort-controls">
                     <span style="color: #999;">Sortierung:</span>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -408,6 +408,7 @@ if (typeof document !== "undefined" && typeof document.getElementById === "funct
     const emoBtn = document.getElementById("generateEmotionsButton");
     const sendBtn = document.getElementById("sendTextV2Button");
     const copyBtn = document.getElementById("copyAssistantButton");
+    const copyAllEmosBtn = document.getElementById("copyAllEmosButton"); // sammelt alle Emotionstexte
     if (gptBtn) {
         gptBtn.addEventListener("click", () => {
             if (currentProject?.gptTests?.length) {
@@ -425,6 +426,9 @@ if (typeof document !== "undefined" && typeof document.getElementById === "funct
     }
     if (copyBtn) {
         copyBtn.addEventListener("click", openCopyAssistant);
+    }
+    if (copyAllEmosBtn) {
+        copyAllEmosBtn.addEventListener("click", copyAllEmotionsToClipboard);
     }
 }
 
@@ -1004,6 +1008,26 @@ function showCopyAssistant() {
     verifyCopyAssistClipboard();
 }
 // =========================== COPY ASSISTANT END ============================
+
+// Kopiert alle Emotionstexte nacheinander in die Zwischenablage
+function normalizeEmotionalText(text) {
+    if (!text) return '';
+    // Zeilenumbrüche entfernen und mehrfaches Leerzeichen reduzieren
+    let cleaned = text.replace(/[\r\n]+/g, ' ');
+    cleaned = cleaned.replace(/(\[[^\]]+\])(?!\s)/g, '$1 ');
+    cleaned = cleaned.replace(/\s{2,}/g, ' ');
+    return cleaned.trim();
+}
+
+// Kopiert alle Emotionstexte nacheinander in die Zwischenablage
+function copyAllEmotionsToClipboard() {
+    const texts = files.map(f => normalizeEmotionalText(f.emotionalText || ''))
+        .join('\n\n');
+    safeCopy(texts);
+    if (typeof showToast === 'function') {
+        showToast('Alle Emotionstexte kopiert');
+    }
+}
 
 // Stoppt aktuell laufende Wiedergabe und setzt alle Buttons zurück
 function stopCurrentPlayback() {
@@ -13222,6 +13246,7 @@ if (typeof module !== "undefined" && module.exports) {
         calculateTextSimilarity,
         copyFolderName,
         copyDownloadFolder,
+        copyAllEmotionsToClipboard,
         toggleEmoCompletion,
         __setFiles: f => { files = f; },
         __setDeAudioCache: c => { deAudioCache = c; },


### PR DESCRIPTION
## Zusammenfassung
- Emotionstexte beim Kopieren von Zeilenumbrüchen bereinigen
- Funktion `copyAllEmotionsToClipboard` exportiert
- neuen Test für das Kopieren aller Emotionen hinzufügen
- Dokumentation im README aktualisieren

## Testanweisungen
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872475060c48327b0c1e502ff7b778c