### PR TITLE
Add ZIP import preview dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Zusätzliche Zwischenablage-Prüfung:** Die Kopierhilfe stellt sicher, dass im ersten Schritt der Name und im zweiten der Emotionstext in der Zwischenablage liegt.
 * **Alle Emotionstexte kopieren:** Ein neuer Button sammelt alle Emotionstexte, entfernt darin Zeilenumbrüche und trennt die Blöcke jeweils mit einer Leerzeile.
 * **Stabile Base64-Kodierung:** Große Audiodateien werden beim Hochladen in handlichen Blöcken verarbeitet, sodass kein "Maximum call stack size exceeded" mehr auftritt.
+* **ZIP-Import mit Vorschau:** Ein neues Dialogfenster listet nach dem Entpacken jeder ZIP-Datei alle enthaltenen Audios nebeneinander mit den entsprechenden Projektzeilen auf. Die Gesamtzahl muss übereinstimmen, sonst bleibt der Import-Button deaktiviert. Mehrteilige Archive werden übersprungen. Nach Bestätigung werden die Dateien Zeile für Zeile übernommen.
 * **Projektkarten mit Rahmen:** Jede Karte besitzt einen grauen Rand und nutzt nun die volle Breite. Im geöffneten Level wird der Rand grün. Das aktuell gewählte Projekt hebt sich mit einem blauen Balken, leicht transparentem Hintergrund (rgba(33,150,243,0.2)) und weißer Schrift deutlich ab.
 * **Überarbeitete Seitenleiste:** Jede Projektkarte besteht aus zwei Zeilen mit einheitlich breiten Badges für EN, DE und Audio.
 * **Breitere Projektleiste:** Die Sidebar ist jetzt 320 px breit, damit lange Einträge korrekt angezeigt werden.

--- a/electron/ipcContracts.ts
+++ b/electron/ipcContracts.ts
@@ -42,6 +42,7 @@ export type IpcChannels =
   | 'open-backup-folder'
   | 'get-download-path'
   | 'get-debug-info'
+  | 'import-zip'
   | 'backup-de-file'
   | 'delete-de-backup-file'
   | 'restore-de-file'

--- a/electron/main.js
+++ b/electron/main.js
@@ -27,6 +27,7 @@ const { saveSettings, loadSettings } = require('../settingsStore.ts');
 // Fortschrittsbalken und FFmpeg für MP3->WAV-Konvertierung
 const ProgressBar = require('progress');
 const ffmpeg = require('ffmpeg-static');
+const extract = require('extract-zip');
 // Standbild-Erzeugung über ffmpeg
 const { ensureFrame } = require('../legacy/videoFrameUtils.js');
 // Pfad zum App-Icon (im Ordner 'assets' als 'app-icon.png' ablegen)
@@ -331,6 +332,37 @@ app.whenReady().then(() => {
   ipcMain.handle('open-backup-folder', async () => {
     shell.openPath(backupPath);
     return true;
+  });
+
+  // ZIP-Import für Serien von Audiodateien
+  ipcMain.handle('import-zip', async (event, data) => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hla_zip_'));
+    const zipFile = path.join(tmp, 'import.zip');
+    try {
+      fs.writeFileSync(zipFile, Buffer.from(data));
+      await extract(zipFile, { dir: tmp });
+      fs.unlinkSync(zipFile);
+      const result = [];
+      (function walk(dir) {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) walk(full);
+          else if (/\.(mp3|wav|ogg)$/i.test(entry.name)) {
+            result.push({ name: entry.name, data: fs.readFileSync(full) });
+          }
+        }
+      })(tmp);
+      return { files: result.map(f => ({ name: f.name, data: new Uint8Array(f.data) })) };
+    } catch (err) {
+      // Fehlermeldung für den Renderer aufbereiten
+      let msg = err.message || String(err);
+      if (msg.includes('multi-disk zip files are not supported')) {
+        msg = 'Mehrteilige ZIP-Archive werden nicht unterstützt.';
+      }
+      return { error: msg };
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   // Beliebige URL im Standardbrowser öffnen

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -53,6 +53,7 @@ if (typeof require !== 'function') {
     createSoundBackup: () => ipcRenderer.invoke('create-sound-backup'),
     deleteSoundBackup: (name) => ipcRenderer.invoke('delete-sound-backup', name),
     openBackupFolder: () => ipcRenderer.invoke('open-backup-folder'),
+    importZip: data => ipcRenderer.invoke('import-zip', data),
     moveFile: (src, dest) => ipcRenderer.invoke('move-file', /** @type {MoveFileArgs} */({ src, dest })),
     onManualFile: (cb) => ipcRenderer.on('manual-file', (e, file) => cb(file)),
     onDubDone: cb => ipcRenderer.on('dub-done', (e, info) => cb(info)),

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "archiver": "^6.0.2",
         "chokidar": "^4.0.3",
+        "extract-zip": "^2.0.1",
         "ffmpeg-static": "^5.2.0",
         "node-easyocr": "^1.0.9",
         "play-dl": "^1.9.7",
@@ -1465,7 +1466,7 @@
       "version": "24.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
       "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
@@ -1501,6 +1502,16 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
@@ -2278,6 +2289,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -2394,6 +2414,41 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -2415,6 +2470,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/ffmpeg-static": {
@@ -4348,6 +4412,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4518,6 +4588,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -5097,7 +5177,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -5359,6 +5439,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "archiver": "^6.0.2",
     "chokidar": "^4.0.3",
+    "extract-zip": "^2.0.1",
     "ffmpeg-static": "^5.2.0",
     "node-easyocr": "^1.0.9",
     "play-dl": "^1.9.7",

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -113,6 +113,7 @@
                     <button id="generateEmotionsButton" class="btn btn-blue" title="Erzeugt deutsche Emotionstags für alle Zeilen">Emotionen (DE) generieren</button>
                     <button id="sendTextV2Button" class="btn btn-blue" title="Alle Emotional-Texte an ElevenLabs senden">An ElevenLabs schicken</button>
                     <button class="btn btn-secondary" onclick="openSegmentDialog()">🔊 Audio-Datei zuordnen</button>
+                    <button class="btn btn-secondary" onclick="showZipImportDialog()">ZIP importieren</button>
                     <button id="copyAssistantButton" class="btn btn-secondary">Kopierhilfe</button>
                     <button id="copyAllEmosButton" class="btn btn-secondary">Emotionen kopieren</button>
                 </div>
@@ -771,9 +772,30 @@
         </div>
     </div>
 
+    <!-- ZIP Preview Dialog -->
+    <div class="dialog-overlay hidden" id="zipPreviewDialog">
+        <div class="dialog">
+            <h3>📦 ZIP-Import prüfen</h3>
+            <p id="zipPreviewInfo" style="margin-bottom:15px;"></p>
+            <div style="max-height:300px;overflow:auto;border:1px solid #444;border-radius:4px;">
+                <table style="width:100%;font-size:12px;">
+                    <thead>
+                        <tr><th>Zeile</th><th>Projektdatei</th><th>ZIP-Datei</th></tr>
+                    </thead>
+                    <tbody id="zipPreviewTableBody"></tbody>
+                </table>
+            </div>
+            <div class="dialog-buttons">
+                <button class="btn btn-secondary" onclick="closeZipPreview()">Abbrechen</button>
+                <button class="btn btn-success" id="zipImportConfirm" onclick="confirmZipImport()">Import starten</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Audio Player -->
     <audio id="audioPlayer"></audio>
     <input type="file" id="deUploadInput" style="display:none" accept=".mp3,.wav,.ogg" onchange="handleDeUpload(this)">
+    <input type="file" id="zipImportInput" style="display:none" accept=".zip" onchange="handleZipImport(this)">
     <input type="file" id="backupUploadInput" style="display:none" accept=".json" onchange="handleBackupUpload(this)">
 
     <!-- Umschaltbare Debug-Konsole -->

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -9796,6 +9796,91 @@ async function handleDeUpload(input) {
 }
 // =========================== HANDLEDEUPLOAD END ==============================
 
+// =========================== HANDLEZIPIMPORT START ===========================
+function showZipImportDialog() {
+    if (!currentProject) {
+        alert('Bitte zuerst ein Projekt auswählen.');
+        return;
+    }
+    document.getElementById('zipImportInput').click();
+}
+
+// Zwischenspeicher für entpackte Dateien
+let pendingZipImport = null;
+
+// Liest die ZIP-Datei ein und zeigt eine Vorschau an
+async function handleZipImport(input) {
+    const file = input.files[0];
+    input.value = '';
+    if (!file || !window.electronAPI || !window.electronAPI.importZip) return;
+    try {
+        const buffer = await file.arrayBuffer();
+        const result = await window.electronAPI.importZip(new Uint8Array(buffer));
+        if (result.error) {
+            alert('Import abgebrochen: ' + result.error);
+            return;
+        }
+        const entries = result.files || result;
+        const valid = entries.filter(e => /\.(mp3|wav|ogg)$/i.test(e.name) && /^\d+/.test(e.name));
+        valid.sort((a,b)=>parseInt(a.name,10)-parseInt(b.name,10));
+        const active = files.filter(f => !f.isIgnored);
+        const ok = valid.length === active.length;
+
+        pendingZipImport = { active, valid };
+        const info = document.getElementById('zipPreviewInfo');
+        info.textContent = ok
+            ? `✅ ${valid.length} Dateien gefunden, entspricht ${active.length} Zeilen.`
+            : `⚠️ ${valid.length} Dateien gefunden, erwartet ${active.length}.`;
+        const tbody = document.getElementById('zipPreviewTableBody');
+        tbody.innerHTML = '';
+        const len = Math.max(active.length, valid.length);
+        for (let i = 0; i < len; i++) {
+            const row = document.createElement('tr');
+            const proj = active[i];
+            const zip = valid[i];
+            row.innerHTML = `<td>${i + 1}</td>` +
+                            `<td>${proj ? escapeHtml(getFullPath(proj)) : ''}</td>` +
+                            `<td>${zip ? escapeHtml(zip.name) : ''}</td>`;
+            tbody.appendChild(row);
+        }
+        document.getElementById('zipImportConfirm').disabled = !ok;
+        document.getElementById('zipPreviewDialog').classList.remove('hidden');
+    } catch (err) {
+        alert('Fehler beim Import: ' + err.message);
+    }
+}
+
+// Übernimmt die Dateien aus der Vorschau ins Projekt
+async function confirmZipImport() {
+    if (!pendingZipImport) return;
+    const { active, valid } = pendingZipImport;
+    document.getElementById('zipPreviewDialog').classList.add('hidden');
+    for (let i = 0; i < active.length; i++) {
+        const rel = getFullPath(active[i]);
+        await window.electronAPI.saveDeFile(rel, valid[i].data);
+        deAudioCache[rel] = `sounds/DE/${rel}`;
+        await updateHistoryCache(rel);
+        active[i].trimStartMs = 0;
+        active[i].trimEndMs = 0;
+        active[i].volumeMatched = false;
+        active[i].radioEffect = false;
+        active[i].hallEffect = false;
+    }
+    isDirty = true;
+    saveCurrentProject();
+    renderFileTable();
+    showToast(`${valid.length} Dateien wurden erfolgreich zugeordnet und eingefügt.`);
+    updateStatus('ZIP-Import abgeschlossen');
+    pendingZipImport = null;
+}
+
+// Bricht den Import ab
+function closeZipPreview() {
+    pendingZipImport = null;
+    document.getElementById('zipPreviewDialog').classList.add('hidden');
+}
+// =========================== HANDLEZIPIMPORT END ============================
+
 // =========================== INITIATEDUBBING START ==========================
 function initiateDubbing(fileId, lang = 'de') {
     if (lang === 'emo') {
@@ -13090,7 +13175,7 @@ function quickAddLevel(chapterName) {
             saveCurrentProject();
         }
 
-        window.ui = { getActiveDubItem, markDubAsReady, notify: showToast, showModal, showInputDialog, setActiveDubItem, showErrorBanner, hideErrorBanner, toggleEmoCompletion };
+        window.ui = { getActiveDubItem, markDubAsReady, notify: showToast, showModal, showInputDialog, setActiveDubItem, showErrorBanner, hideErrorBanner, toggleEmoCompletion, showZipImportDialog, handleZipImport, confirmZipImport, closeZipPreview };
 
         function updateCounts() {
             const fileCount = document.getElementById('fileCount');


### PR DESCRIPTION
## Summary
- support previewing ZIP imports before applying
- handle extraction errors in `import-zip` IPC
- show ZIP preview dialog in UI
- document new preview workflow in README
- handle multi-volume ZIP errors gracefully

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68727ea68ac883279ecd121cc71885dd