### PR TITLE
Add ZIP import preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Zusätzliche Zwischenablage-Prüfung:** Die Kopierhilfe stellt sicher, dass im ersten Schritt der Name und im zweiten der Emotionstext in der Zwischenablage liegt.
 * **Alle Emotionstexte kopieren:** Ein neuer Button sammelt alle Emotionstexte, entfernt darin Zeilenumbrüche und trennt die Blöcke jeweils mit einer Leerzeile.
 * **Stabile Base64-Kodierung:** Große Audiodateien werden beim Hochladen in handlichen Blöcken verarbeitet, sodass kein "Maximum call stack size exceeded" mehr auftritt.
+* **ZIP-Import mit Vorschau:** Die gewählte ZIP-Datei wird direkt entpackt und die Audios nach führender Nummer sortiert angezeigt. Dank "unzipper" klappt das auch mit ZIP64-Archiven. Stimmen die Anzahl und Reihenfolge, werden die Dateien automatisch zugeordnet.
 * **Projektkarten mit Rahmen:** Jede Karte besitzt einen grauen Rand und nutzt nun die volle Breite. Im geöffneten Level wird der Rand grün. Das aktuell gewählte Projekt hebt sich mit einem blauen Balken, leicht transparentem Hintergrund (rgba(33,150,243,0.2)) und weißer Schrift deutlich ab.
 * **Überarbeitete Seitenleiste:** Jede Projektkarte besteht aus zwei Zeilen mit einheitlich breiten Badges für EN, DE und Audio.
 * **Breitere Projektleiste:** Die Sidebar ist jetzt 320 px breit, damit lange Einträge korrekt angezeigt werden.

--- a/electron/ipcContracts.ts
+++ b/electron/ipcContracts.ts
@@ -42,6 +42,7 @@ export type IpcChannels =
   | 'open-backup-folder'
   | 'get-download-path'
   | 'get-debug-info'
+  | 'import-zip'
   | 'backup-de-file'
   | 'delete-de-backup-file'
   | 'restore-de-file'

--- a/electron/main.js
+++ b/electron/main.js
@@ -27,6 +27,8 @@ const { saveSettings, loadSettings } = require('../settingsStore.ts');
 // Fortschrittsbalken und FFmpeg für MP3->WAV-Konvertierung
 const ProgressBar = require('progress');
 const ffmpeg = require('ffmpeg-static');
+// "unzipper" unterstuetzt auch ZIP64- und mehrteilige Archive
+const unzipper = require('unzipper');
 // Standbild-Erzeugung über ffmpeg
 const { ensureFrame } = require('../legacy/videoFrameUtils.js');
 // Pfad zum App-Icon (im Ordner 'assets' als 'app-icon.png' ablegen)
@@ -54,6 +56,9 @@ fs.mkdirSync(audioBackupPath, { recursive: true });
 // Ordner für ZIP-Sicherungen der Sounds anlegen
 const soundZipBackupPath = path.join(backupPath, 'sounds');
 fs.mkdirSync(soundZipBackupPath, { recursive: true });
+// Temporärer Ordner für ZIP-Importe
+const zipImportTempPath = path.join(userDataPath, 'ZipTemp');
+fs.mkdirSync(zipImportTempPath, { recursive: true });
 // Ordner für Segment-Audiodateien anlegen
 const segmentFolderPath = path.join(SOUNDS_BASE_PATH, 'Segments');
 fs.mkdirSync(segmentFolderPath, { recursive: true });
@@ -333,6 +338,50 @@ app.whenReady().then(() => {
     return true;
   });
 
+  // ZIP-Import: Archiv wird entpackt und die enthaltenen Audios werden zurückgegeben
+  // Empfaengt den Pfad zur ZIP-Datei und entpackt sie in ZipTemp
+  ipcMain.handle('import-zip', async (event, zipPath) => {
+    try {
+      // Temporären Ordner leeren
+      fs.rmSync(zipImportTempPath, { recursive: true, force: true });
+      fs.mkdirSync(zipImportTempPath, { recursive: true });
+
+      // ZIP entpacken; "unzipper" unterstuetzt auch ZIP64 und Mehrteiler
+      await new Promise((resolve, reject) => {
+        fs.createReadStream(zipPath)
+          .pipe(unzipper.Extract({ path: zipImportTempPath }))
+          .on('close', resolve)
+          .on('error', reject);
+      });
+
+      // Audiodateien rekursiv sammeln
+      const audioFiles = [];
+      const exts = ['.mp3', '.wav', '.ogg'];
+      const collect = dir => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) collect(full);
+          else if (exts.includes(path.extname(entry.name).toLowerCase())) {
+            audioFiles.push(full);
+          }
+        }
+      };
+      collect(zipImportTempPath);
+
+      // Nach führender Zahl sortieren
+      const num = n => {
+        const m = /^(\d+)/.exec(path.basename(n));
+        return m ? parseInt(m[1], 10) : 0;
+      };
+      audioFiles.sort((a, b) => num(a) - num(b));
+
+      const rel = audioFiles.map(f => path.relative(zipImportTempPath, f));
+      return { files: rel };
+    } catch (err) {
+      return { error: err.message || String(err) };
+    }
+  });
+
   // Beliebige URL im Standardbrowser öffnen
   ipcMain.handle('open-external', async (event, url) => {
     shell.openExternal(url);
@@ -522,6 +571,7 @@ app.whenReady().then(() => {
       existsBackupsPath: fs.existsSync(backupsPath),
       userDataPath,
       backupPath,
+      zipImportTempPath,
       oldBackupPath,
       downloadWatchPath: DL_WATCH_PATH,
       appVersion: app.getVersion(),

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -53,6 +53,8 @@ if (typeof require !== 'function') {
     createSoundBackup: () => ipcRenderer.invoke('create-sound-backup'),
     deleteSoundBackup: (name) => ipcRenderer.invoke('delete-sound-backup', name),
     openBackupFolder: () => ipcRenderer.invoke('open-backup-folder'),
+    // Pfad der ZIP-Datei an den Main-Prozess schicken
+    importZip: filePath => ipcRenderer.invoke('import-zip', filePath),
     moveFile: (src, dest) => ipcRenderer.invoke('move-file', /** @type {MoveFileArgs} */({ src, dest })),
     onManualFile: (cb) => ipcRenderer.on('manual-file', (e, file) => cb(file)),
     onDubDone: cb => ipcRenderer.on('dub-done', (e, info) => cb(info)),

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "play-dl": "^1.9.7",
         "playwright": "^1.42.1",
         "progress": "^2.0.3",
+        "unzipper": "^0.12.3",
         "ytdl-core": "^4.11.5"
       },
       "devDependencies": {
@@ -1795,6 +1796,12 @@
       "license": "Apache-2.0",
       "optional": true
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2251,6 +2258,45 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.166",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.166.tgz",
@@ -2483,6 +2529,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/fs.realpath": {
@@ -3869,6 +3929,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4124,7 +4196,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
@@ -5099,6 +5170,28 @@
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "^11.2.0",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "play-dl": "^1.9.7",
     "playwright": "^1.42.1",
     "progress": "^2.0.3",
+    "unzipper": "^0.12.3",
     "ytdl-core": "^4.11.5"
   }
 }

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -113,6 +113,7 @@
                     <button id="generateEmotionsButton" class="btn btn-blue" title="Erzeugt deutsche Emotionstags für alle Zeilen">Emotionen (DE) generieren</button>
                     <button id="sendTextV2Button" class="btn btn-blue" title="Alle Emotional-Texte an ElevenLabs senden">An ElevenLabs schicken</button>
                     <button class="btn btn-secondary" onclick="openSegmentDialog()">🔊 Audio-Datei zuordnen</button>
+                    <button class="btn btn-secondary" onclick="showZipImportDialog()">ZIP importieren</button>
                     <button id="copyAssistantButton" class="btn btn-secondary">Kopierhilfe</button>
                     <button id="copyAllEmosButton" class="btn btn-secondary">Emotionen kopieren</button>
                 </div>
@@ -771,9 +772,11 @@
         </div>
     </div>
 
+
     <!-- Audio Player -->
     <audio id="audioPlayer"></audio>
     <input type="file" id="deUploadInput" style="display:none" accept=".mp3,.wav,.ogg" onchange="handleDeUpload(this)">
+    <input type="file" id="zipImportInput" style="display:none" accept=".zip" onchange="handleZipImport(this)">
     <input type="file" id="backupUploadInput" style="display:none" accept=".json" onchange="handleBackupUpload(this)">
 
     <!-- Umschaltbare Debug-Konsole -->

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -9796,6 +9796,77 @@ async function handleDeUpload(input) {
 }
 // =========================== HANDLEDEUPLOAD END ==============================
 
+// =========================== HANDLEZIPIMPORT START ===========================
+function showZipImportDialog() {
+    if (!currentProject) {
+        alert('Bitte zuerst ein Projekt auswählen.');
+        return;
+    }
+    document.getElementById('zipImportInput').click();
+}
+
+// Liest eine ZIP-Datei ein und zeigt eine Zuordnungsvorschau an
+async function handleZipImport(input) {
+    const file = input.files[0];
+    input.value = '';
+    if (!file || !window.electronAPI?.importZip) return;
+    try {
+        // Pfad direkt an Electron uebergeben, vermeidet Groessenprobleme
+        const result = await window.electronAPI.importZip(file.path);
+        if (result?.error) {
+            alert('Fehler beim Entpacken: ' + result.error);
+            return;
+        }
+        if (!result?.files || result.files.length === 0) {
+            alert('Keine Audiodateien gefunden.');
+            return;
+        }
+        showZipPreview(result.files);
+    } catch (err) {
+        alert('Fehler beim Import: ' + err.message);
+    }
+}
+
+// Zeigt Tabelle mit Zuordnung und übernimmt die Dateien bei Bestätigung
+async function showZipPreview(zipFiles) {
+    const countOk = zipFiles.length === files.length;
+    let rows = '';
+    for (let i = 0; i < files.length; i++) {
+        const name = zipFiles[i] || '-';
+        rows += `<tr><td>${i + 1}</td><td>${escapeHtml(files[i].filename)}</td><td>${escapeHtml(name)}</td></tr>`;
+    }
+    const html = `
+        <h3>ZIP-Import</h3>
+        <p>${zipFiles.length} Dateien im Archiv, ${files.length} Zeilen im Projekt.</p>
+        <table class="zip-preview-table"><thead><tr><th>Zeile</th><th>Projektdatei</th><th>ZIP-Datei</th></tr></thead><tbody>${rows}</tbody></table>
+        <div class="dialog-buttons">
+            <button class="btn btn-secondary" id="zipCancel">Abbrechen</button>
+            <button class="btn btn-success" id="zipConfirm" ${countOk ? '' : 'disabled'}>Importieren</button>
+        </div>`;
+    const ov = showModal(html);
+    ov.querySelector('#zipCancel').onclick = () => ov.remove();
+    ov.querySelector('#zipConfirm').onclick = async () => {
+        ov.remove();
+        if (countOk) await applyZipImport(zipFiles);
+    };
+}
+
+async function applyZipImport(zipFiles) {
+    if (!window.electronAPI?.fsReadFile) return;
+    const info = await window.electronAPI.getDebugInfo();
+    for (let i = 0; i < zipFiles.length && i < files.length; i++) {
+        const rel = getFullPath(files[i]);
+        const full = window.electronAPI.join(info.zipImportTempPath, zipFiles[i]);
+        if (!window.electronAPI.fsExists(full)) continue;
+        const data = window.electronAPI.fsReadFile(full);
+        const blob = new Blob([new Uint8Array(data)]);
+        await uploadDeFile(blob, rel);
+    }
+    showToast(`${zipFiles.length} Dateien importiert`);
+    updateStatus('ZIP-Import abgeschlossen');
+}
+// =========================== HANDLEZIPIMPORT END ============================
+
 // =========================== INITIATEDUBBING START ==========================
 function initiateDubbing(fileId, lang = 'de') {
     if (lang === 'emo') {
@@ -13090,7 +13161,7 @@ function quickAddLevel(chapterName) {
             saveCurrentProject();
         }
 
-        window.ui = { getActiveDubItem, markDubAsReady, notify: showToast, showModal, showInputDialog, setActiveDubItem, showErrorBanner, hideErrorBanner, toggleEmoCompletion };
+        window.ui = { getActiveDubItem, markDubAsReady, notify: showToast, showModal, showInputDialog, setActiveDubItem, showErrorBanner, hideErrorBanner, toggleEmoCompletion, showZipImportDialog, handleZipImport };
 
         function updateCounts() {
             const fileCount = document.getElementById('fileCount');

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -3178,3 +3178,19 @@ th:nth-child(10) {
 .segment-status { font-size:14px; color:#999; }
 #segmentWaveform { cursor:pointer; }
 #copyAssistantDialog .dialog { max-width: 500px; }
+
+/* Tabelle für den ZIP-Import */
+.zip-preview-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+.zip-preview-table th,
+.zip-preview-table td {
+    border: 1px solid #444;
+    padding: 4px 6px;
+}
+.zip-preview-table th {
+    background: #2a2a2a;
+    color: #ff6b1a;
+}


### PR DESCRIPTION
## Summary
- entpacke ZIP-Datei jetzt mit `unzipper`
- gebe Pfad `zipImportTempPath` an den Renderer weiter
- zeige im Frontend eine Vorschau-Tabelle aller ZIP-Dateien im Vergleich zu den Projektzeilen
- importiere die Audios nach Bestätigung automatisch
- ergänze Stile und README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68727ea68ac883279ecd121cc71885dd