### PR TITLE
Implement length difference display

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Verbessertes Speichern:** Nach dem Anwenden von Lautstärke angleichen oder Funkgerät‑Effekt bleiben die Änderungen nun zuverlässig erhalten.
 * **Vier Bearbeitungssymbole:** Der Status neben der Schere zeigt nun bis zu vier Icons in zwei Reihen für Trimmen, Lautstärkeangleichung, Funkgerät- und Hall-Effekt an.
 * **Ignorier-Bereiche im DE-Editor:** Mit gedrückter Umschalttaste lassen sich beliebige Abschnitte markieren, die beim Abspielen und Speichern übersprungen werden. Die Bereiche bleiben bearbeitbar und erscheinen in einer eigenen Liste. Vorschau und Export überspringen diese Stellen automatisch.
+* **Zeitdifferenz-Anzeige im DE-Editor:** Unter den Wellenformen zeigt eine farbige Meldung, ob das bearbeitete DE-Audio kürzer oder länger als das Original ist.
+* **Automatisches Kürzen:** Ein neuer Button berechnet anhand stiller Passagen einen Schnittvorschlag und zeigt ihn als blauen Marker an. Optional wird das Audio leicht gestretcht, um genau die EN-Länge zu treffen.
+* **Endpunkt auf EN-Länge setzen:** Mit "An EN-Länge anpassen" wird das bearbeitete Audio exakt auf die Länge des englischen Originals gekürzt.
 * **Bugfix beim Ziehen:** Ein versehentlicher Drag ohne den Griff löst keine Fehlermeldung mehr aus.
 * **Zurücksetzen nach Upload oder Dubbing:** Sowohl beim Hochladen als auch beim erneuten Erzeugen einer deutschen Audiodatei werden Lautstärkeangleichung, Funkgerät‑Effekt und Hall‑Effekt automatisch deaktiviert.
 * **Fehlerhinweise beim Speichern:** Tritt ein Problem auf, erscheint eine rote Toast-Meldung statt eines stummen Abbruchs.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -590,6 +590,12 @@
                     </div>
                 </div>
             </div>
+            <div id="lengthDiffInfo" class="length-diff-display"></div>
+            <div class="auto-trim-buttons">
+                <button class="btn btn-secondary" onclick="showAutoTrimSuggestion()">🛠 Kürzen (automatisch)</button>
+                <button id="applyAutoTrimBtn" class="btn btn-secondary hidden" onclick="applyAutoTrim()">Anwenden</button>
+                <button class="btn btn-secondary" onclick="fitToEnLength()">An EN-Länge anpassen</button>
+            </div>
             <div class="edit-range">
                 <label>Start (ms): <input type="number" id="editStart" value="0" step="100"></label>
                 <label>Ende (ms): <input type="number" id="editEnd" value="0" step="100"></label>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -877,6 +877,15 @@ th:nth-child(10) {
     color: #ffc107;
 }
 
+/* Anzeige der Zeitdifferenz im DE-Editor */
+.length-diff-display {
+    font-size: 14px;
+    margin-top: 4px;
+}
+.length-diff-display.good { color: #4caf50; }
+.length-diff-display.warn { color: #ffc107; }
+.length-diff-display.bad  { color: #f44336; }
+
         /* Raster-Anordnung der Bearbeitungs-Symbole (maximal zwei pro Zeile) */
         .edit-column {
             display: flex;
@@ -1113,6 +1122,11 @@ th:nth-child(10) {
     display: flex;
     gap: 10px;
     margin-bottom: 15px;
+}
+.auto-trim-buttons {
+    display: flex;
+    gap: 10px;
+    margin-top: 4px;
 }
 
 .ignore-container { margin-bottom: 15px; }


### PR DESCRIPTION
## Summary
- show EN/DE length difference below DE waveforms
- style new indicator with warning colors
- compute difference during editing
- add automatic shortening suggestion with blue marker
- document the new length difference display
- add button to match DE end with EN length

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68729a81b09c8327a56bb9df532d6980