### PR TITLE
Implement DE audio length tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Verbessertes Speichern:** Nach dem Anwenden von Lautstärke angleichen oder Funkgerät‑Effekt bleiben die Änderungen nun zuverlässig erhalten.
 * **Vier Bearbeitungssymbole:** Der Status neben der Schere zeigt nun bis zu vier Icons in zwei Reihen für Trimmen, Lautstärkeangleichung, Funkgerät- und Hall-Effekt an.
 * **Ignorier-Bereiche im DE-Editor:** Mit gedrückter Umschalttaste lassen sich beliebige Abschnitte markieren, die beim Abspielen und Speichern übersprungen werden. Die Bereiche bleiben bearbeitbar und erscheinen in einer eigenen Liste. Vorschau und Export überspringen diese Stellen automatisch.
+* **Manuelles Zuschneiden:** Start- und Endzeit lassen sich per Millisekundenfeld oder durch Ziehen der grünen Marker im Waveform-Editor setzen.
+* **Automatische Pausenkürzung und Time‑Stretching:** Längere Pausen erkennt das Tool auf Wunsch selbst. Mit einem Regler lässt sich das Tempo von 1,00–1,25 anpassen oder automatisch auf die EN-Länge setzen. Ein Button „🎯 Anpassen & Anwenden“ kombiniert beide Schritte und eine farbige Anzeige warnt bei Abweichungen.
+* **Längenvergleich visualisiert:** Unter der DE-Wellenform zeigt ein Tooltip die neue Dauer. Abweichungen über 5 % werden orange oder rot hervorgehoben.
+* **Effektparameter speicherbar:** Trimmen, Pausenkürzung und Tempo werden im Projekt gesichert und lassen sich über "🔄 Zurücksetzen" rückgängig machen.
 * **Bugfix beim Ziehen:** Ein versehentlicher Drag ohne den Griff löst keine Fehlermeldung mehr aus.
 * **Zurücksetzen nach Upload oder Dubbing:** Sowohl beim Hochladen als auch beim erneuten Erzeugen einer deutschen Audiodatei werden Lautstärkeangleichung, Funkgerät‑Effekt und Hall‑Effekt automatisch deaktiviert.
 * **Fehlerhinweise beim Speichern:** Tritt ein Problem auf, erscheint eine rote Toast-Meldung statt eines stummen Abbruchs.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -598,6 +598,15 @@
                 <h4>Ignorierbereiche</h4>
                 <div id="ignoreList"></div>
             </div>
+            <div class="trim-options">
+                <label><input type="checkbox" id="autoIgnoreChk"> Pausen &gt; <input type="number" id="autoIgnoreMs" value="400" step="100" style="width:70px;"> ms entfernen</label>
+            </div>
+            <div class="stretch-options">
+                <label><input type="checkbox" id="autoTempoChk"> Tempo automatisch an EN anpassen</label>
+                <label>Tempo: <input type="range" id="tempoRange" min="1" max="1.25" step="0.01" value="1"><span id="tempoDisplay">1.00</span></label>
+                <span id="tempoInfo" style="margin-left:10px;"></span>
+            </div>
+            <button class="btn btn-secondary" id="autoAdjustBtn" style="margin-top:5px;">🎯 Anpassen &amp; Anwenden</button>
             <hr class="effect-separator">
             <fieldset class="effect-group">
                 <legend>📡 Funkgerät-Effekt</legend>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -110,8 +110,11 @@ let editBlobUrl            = null; // aktuelle Blob-URL
 
 // Zusätzliche Marker für Ignorier-Bereiche
 let editIgnoreRanges      = [];    // Liste der zu überspringenden Bereiche
+let manualIgnoreRanges    = [];    // Merker für manuelle Bereiche
 let ignoreTempStart       = null;  // Startpunkt für neuen Bereich
 let ignoreDragging        = null;  // {index, side} beim Ziehen
+let tempoFactor           = 1.0;   // Faktor für Time-Stretching
+let autoIgnoreMs          = 400;   // Schwelle für Pausen in ms
 
 let draggedElement         = null;
 let currentlyPlaying       = null;
@@ -6297,9 +6300,8 @@ function cleanupOrphanCustomizations() {
 
 // =========================== SEGMENT DIALOG START ==========================
 // Hilfsfunktionen zur Audio-Segmentierung direkt hier eingebunden
-// Erkennt Pausen im Audio und liefert die Zeitbereiche der Segmente
-async function detectSegments(file, silenceMs = 300, threshold = 0.01, onProgress) {
-    const buffer = await loadAudioBuffer(file);
+// Erkennt Pausen im AudioBuffer und liefert die Segmente zurueck
+function detectSegmentsInBuffer(buffer, silenceMs = 300, threshold = 0.01, onProgress) {
     const data = buffer.getChannelData(0);
     const sr = buffer.sampleRate;
     const windowSize = Math.round(sr * 0.03); // 30 ms
@@ -6340,6 +6342,12 @@ async function detectSegments(file, silenceMs = 300, threshold = 0.01, onProgres
     }
     if (onProgress) onProgress(1);
     return { buffer, segments };
+}
+
+// Variante, die direkt eine Datei laedt
+async function detectSegments(file, silenceMs = 300, threshold = 0.01, onProgress) {
+    const buffer = await loadAudioBuffer(file);
+    return detectSegmentsInBuffer(buffer, silenceMs, threshold, onProgress);
 }
 
 // Zeichnet die Segmente farbig in die Wellenform
@@ -6453,6 +6461,57 @@ function playbackToOriginal(ms, ranges, duration) {
         offset += r.end - r.start;
     }
     return ms + offset;
+}
+
+// Ermittelt Pausen ueber einer Mindestlaenge und gibt passende Ignorierbereiche zurueck
+function detectPausesInBuffer(buffer, minPauseMs = 400) {
+    const { segments } = detectSegmentsInBuffer(buffer, minPauseMs, 0.01);
+    const ranges = [];
+    for (let i = 1; i < segments.length; i++) {
+        const gap = segments[i].start - segments[i - 1].end;
+        if (gap >= minPauseMs) {
+            ranges.push({ start: segments[i - 1].end, end: segments[i].start });
+        }
+    }
+    return ranges;
+}
+
+// Einfache Time-Stretch-Implementierung mit Overlap-Add
+function timeStretchBuffer(buffer, factor) {
+    if (factor <= 1.001 && factor >= 0.999) return buffer;
+    const frame = 2048;
+    const hopIn = frame / 2;
+    const hopOut = Math.round(hopIn / factor);
+    const outLength = Math.round((buffer.length - frame) / hopIn * hopOut + frame);
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const out = ctx.createBuffer(buffer.numberOfChannels, outLength, buffer.sampleRate);
+    const norm = new Float32Array(outLength);
+    const window = new Float32Array(frame).map((_, i) => 0.5 * (1 - Math.cos(2 * Math.PI * i / (frame - 1))));
+    for (let ch = 0; ch < buffer.numberOfChannels; ch++) {
+        const input = buffer.getChannelData(ch);
+        const output = out.getChannelData(ch);
+        let inPos = 0;
+        let outPos = 0;
+        while (inPos + frame <= input.length) {
+            for (let i = 0; i < frame; i++) {
+                const sample = input[inPos + i] * window[i];
+                output[outPos + i] = (output[outPos + i] || 0) + sample;
+                norm[outPos + i] = (norm[outPos + i] || 0) + window[i];
+            }
+            inPos += hopIn;
+            outPos += hopOut;
+        }
+    }
+    for (let i = 0; i < outLength; i++) {
+        const n = norm[i];
+        if (n > 0) {
+            for (let ch = 0; ch < out.numberOfChannels; ch++) {
+                out.getChannelData(ch)[i] /= n;
+            }
+        }
+    }
+    ctx.close();
+    return out;
 }
 
 function toggleIgnoreSelectedSegments() {
@@ -10418,11 +10477,55 @@ async function openDeEdit(fileId) {
     editStartTrim = file.trimStartMs || 0;
     editEndTrim = file.trimEndMs || 0;
     editIgnoreRanges = Array.isArray(file.ignoreRanges) ? file.ignoreRanges.map(r => ({start:r.start,end:r.end})) : [];
+    manualIgnoreRanges = editIgnoreRanges.map(r => ({start:r.start,end:r.end}));
     ignoreTempStart = null;
     document.getElementById('editStart').value = editStartTrim;
     document.getElementById('editEnd').value = editEndTrim;
     document.getElementById('editStart').oninput = e => { editStartTrim = parseInt(e.target.value) || 0; updateDeEditWaveforms(); };
     document.getElementById('editEnd').oninput = e => { editEndTrim = parseInt(e.target.value) || 0; updateDeEditWaveforms(); };
+
+    tempoFactor = file.tempoFactor || 1.0;
+    autoIgnoreMs = 400;
+    const tempoRange = document.getElementById('tempoRange');
+    const tempoDisp  = document.getElementById('tempoDisplay');
+    if (tempoRange && tempoDisp) {
+        tempoRange.value = tempoFactor.toFixed(2);
+        tempoDisp.textContent = tempoFactor.toFixed(2);
+        tempoRange.oninput = async e => {
+            tempoFactor = parseFloat(e.target.value);
+            tempoDisp.textContent = tempoFactor.toFixed(2);
+            updateLengthInfo();
+        };
+    }
+    const autoChk = document.getElementById('autoIgnoreChk');
+    const autoMs  = document.getElementById('autoIgnoreMs');
+    if (autoChk && autoMs) {
+        autoChk.checked = false;
+        autoMs.value = 400;
+        autoChk.onchange = () => {
+            if (autoChk.checked) {
+                manualIgnoreRanges = editIgnoreRanges.map(r => ({ start: r.start, end: r.end }));
+                autoIgnoreMs = parseInt(autoMs.value) || 400;
+                editIgnoreRanges = detectPausesInBuffer(savedOriginalBuffer, autoIgnoreMs);
+            } else {
+                editIgnoreRanges = manualIgnoreRanges.map(r => ({ start: r.start, end: r.end }));
+            }
+            refreshIgnoreList();
+            updateDeEditWaveforms();
+        };
+        autoMs.oninput = () => {
+            if (autoChk.checked) {
+                autoIgnoreMs = parseInt(autoMs.value) || 400;
+                editIgnoreRanges = detectPausesInBuffer(savedOriginalBuffer, autoIgnoreMs);
+                refreshIgnoreList();
+                updateDeEditWaveforms();
+            }
+        };
+    }
+    const autoTempo = document.getElementById('autoTempoChk');
+    if (autoTempo) autoTempo.checked = false;
+    const autoBtn = document.getElementById('autoAdjustBtn');
+    if (autoBtn) autoBtn.onclick = () => autoAdjustLength();
     refreshIgnoreList();
 
     const deCanvas = document.getElementById('waveEdited');
@@ -10649,6 +10752,34 @@ function updateEffectButtons() {
     }
 }
 
+// Kombination aus Pausenkürzung und Tempoanpassung
+async function autoAdjustLength() {
+    const chk = document.getElementById('autoIgnoreChk');
+    const thr = document.getElementById('autoIgnoreMs');
+    const tempoChk = document.getElementById('autoTempoChk');
+    if (chk && chk.checked) {
+        autoIgnoreMs = parseInt(thr.value) || 400;
+        editIgnoreRanges = detectPausesInBuffer(savedOriginalBuffer, autoIgnoreMs);
+        refreshIgnoreList();
+    }
+    if (tempoChk && tempoChk.checked && editEnBuffer) {
+        const enMs = editEnBuffer.length / editEnBuffer.sampleRate * 1000;
+        let len = savedOriginalBuffer.length / savedOriginalBuffer.sampleRate * 1000;
+        len -= editStartTrim + editEndTrim;
+        for (const r of editIgnoreRanges) len -= (r.end - r.start);
+        tempoFactor = Math.min(Math.max(len / enMs, 1), 1.25);
+        const tempoRange = document.getElementById('tempoRange');
+        const tempoDisp = document.getElementById('tempoDisplay');
+        if (tempoRange && tempoDisp) {
+            tempoRange.value = tempoFactor.toFixed(2);
+            tempoDisp.textContent = tempoFactor.toFixed(2);
+        }
+    }
+    await recomputeEditBuffer();
+    updateLengthInfo();
+    updateDeEditWaveforms();
+}
+
 // =========================== APPLYVOLUMEMATCH START =======================
 // Führt den Lautstärkeabgleich einmalig aus
 // Beim ersten Aufruf wird das Original in die Historie geschrieben
@@ -10686,7 +10817,7 @@ async function recomputeEditBuffer() {
     if (isHallEffect) {
         buf = await applyReverbEffect(buf);
     }
-    originalEditBuffer = buf;
+    originalEditBuffer = timeStretchBuffer(buf, tempoFactor);
     editDurationMs = originalEditBuffer.length / originalEditBuffer.sampleRate * 1000;
     updateDeEditWaveforms();
 }
@@ -10840,6 +10971,7 @@ function updateDeEditWaveforms(progressOrig = null, progressDe = null) {
     }
     document.getElementById('editStart').value = Math.round(editStartTrim);
     document.getElementById('editEnd').value = Math.round(editEndTrim);
+    updateLengthInfo();
 }
 // Aktualisiert die Liste der Ignorier-Bereiche
 function refreshIgnoreList() {
@@ -10868,6 +11000,30 @@ function refreshIgnoreList() {
         };
         container.appendChild(row);
     });
+}
+
+// Berechnet die finale Laenge nach Schnitt, Ignorierbereichen und Tempo
+function calcFinalLength() {
+    let len = editDurationMs - editStartTrim - editEndTrim;
+    for (const r of editIgnoreRanges) {
+        len -= Math.max(0, r.end - r.start);
+    }
+    return len / tempoFactor;
+}
+
+// Aktualisiert Anzeige und Farbe je nach Abweichung zur EN-Laenge
+function updateLengthInfo() {
+    if (!editEnBuffer) return;
+    const enMs = editEnBuffer.length / editEnBuffer.sampleRate * 1000;
+    const deMs = calcFinalLength();
+    const diff = deMs - enMs;
+    const perc = Math.abs(diff) / enMs * 100;
+    const info = document.getElementById('tempoInfo');
+    const lbl = document.getElementById('waveLabelEdited');
+    if (!info || !lbl) return;
+    info.textContent = `${(deMs/1000).toFixed(2)}s`;
+    lbl.title = (diff > 0 ? '+' : '') + Math.round(diff) + 'ms';
+    lbl.style.color = perc > 10 ? 'red' : (perc > 5 ? '#ff8800' : '');
 }
 // =========================== UPDATEDEEDITWAVEFORMS END ====================
 
@@ -11069,7 +11225,10 @@ async function resetDeEdit() {
         currentEditFile.trimStartMs = 0;
         currentEditFile.trimEndMs = 0;
         editIgnoreRanges = [];
+        manualIgnoreRanges = [];
         currentEditFile.ignoreRanges = [];
+        tempoFactor = 1.0;
+        currentEditFile.tempoFactor = 1.0;
         currentEditFile.volumeMatched = false;
         currentEditFile.radioEffect = false;
         currentEditFile.hallEffect = false;
@@ -11129,6 +11288,7 @@ async function applyDeEdit() {
         let newBuffer = trimAndPadBuffer(baseBuffer, editStartTrim, editEndTrim);
         const adj = editIgnoreRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim }));
         newBuffer = removeRangesFromBuffer(newBuffer, adj);
+        newBuffer = timeStretchBuffer(newBuffer, tempoFactor);
         drawWaveform(document.getElementById('waveEdited'), newBuffer, { start: 0, end: newBuffer.length / newBuffer.sampleRate * 1000 });
         const blob = bufferToWav(newBuffer);
         const buf = await blob.arrayBuffer();
@@ -11194,6 +11354,7 @@ async function applyDeEdit() {
         let newBuffer = trimAndPadBuffer(baseBuffer, editStartTrim, editEndTrim);
         const adj = editIgnoreRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim }));
         newBuffer = removeRangesFromBuffer(newBuffer, adj);
+        newBuffer = timeStretchBuffer(newBuffer, tempoFactor);
         drawWaveform(document.getElementById('waveEdited'), newBuffer, { start: 0, end: newBuffer.length / newBuffer.sampleRate * 1000 });
         const blob = bufferToWav(newBuffer);
         await speichereUebersetzungsDatei(blob, relPath);
@@ -11207,6 +11368,7 @@ async function applyDeEdit() {
         currentEditFile.volumeMatched = isVolumeMatched;
         currentEditFile.radioEffect = isRadioEffect;
         currentEditFile.hallEffect = isHallEffect;
+        currentEditFile.tempoFactor = tempoFactor;
         // Änderungen sichern
         isDirty = true;
         renderFileTable();

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1118,6 +1118,18 @@ th:nth-child(10) {
 .ignore-container { margin-bottom: 15px; }
 .ignore-row { display:flex; gap:6px; margin-bottom:4px; }
 .ignore-row input { width:70px; }
+.trim-options,
+.stretch-options {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 10px;
+    align-items: center;
+}
+
+.stretch-options span {
+    min-width: 80px;
+    display: inline-block;
+}
 
 .radio-settings,
 .hall-settings {


### PR DESCRIPTION
## Summary
- add manuelles Zuschneiden & length info in README
- auto ignore checkbox now updates ranges live and restores manual values
- reset also clears Tempo-Faktor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872b1fed1c8832796f88e180d43f872