### PR TITLE
Improve retry logic for OpenAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Auswahl des GPT-Modells:** Im ChatGPT-Dialog lässt sich das Modell wählen. Die Liste wird auf Wunsch vom Server geladen und für 24&nbsp;Stunden gespeichert
 * **Automatisch geladene GPT-Einstellungen:** Gespeicherter Key und gewähltes Modell stehen nach dem Start sofort zur Verfügung
 * **Robuste GPT-Antworten:** Entfernt ```json-Blöcke``` automatisch und verhindert so Parsefehler
-* **Automatische Wiederholung bei 429:** Schlägt eine Anfrage fehl, wird sie bis zu drei Mal erneut gesendet
+* **Automatische Wiederholung bei 429:** Nutzt jetzt den `Retry-After`-Header und versucht es bis zu fünf Mal erneut
 * **Charaktername im GPT-Prompt:** Das Feld `character` nutzt nun den Ordnernamen
 * **Bugfix:** Scores werden korrekt eingefügt, auch wenn ID und Score als Zeichenketten geliefert werden
 * **Robustere Zuordnung:** GPT-Ergebnisse finden jetzt auch dann die richtige Zeile, wenn die ID leicht abweicht


### PR DESCRIPTION
## Summary
- enhance retry mechanism to respect `Retry-After` and use exponential backoff
- allow custom retry count for GPT functions and adjust tests
- document new behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68737f45531c8327ac6b439ef27235dc