### PR TITLE
Add progress bar for sound backup creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ Dort gibt es jetzt auch einen Bereich **ChatGPT API**. Der Schlüssel wird lokal
 
 ## 💾 Backup
 
-Mit dem Backup-Dialog lassen sich alle Projekt-Daten als JSON speichern. Neu ist die Option, die Ordner **Sounds/DE**, **DE-Backup** und **DE-History** als ZIP-Archiv zu sichern. Die ZIP-Dateien liegen im Benutzerordner unter `Backups/sounds`. Das Tool behält automatisch nur die fünf neuesten ZIP-Backups. Die Liste der Backups zeigt nun Datum und Uhrzeit an, sortiert mit dem aktuellsten Eintrag oben.
+Mit dem Backup-Dialog lassen sich alle Projekt-Daten als JSON speichern. Neu ist die Option, die Ordner **Sounds/DE**, **DE-Backup** und **DE-History** als ZIP-Archiv zu sichern. Die ZIP-Dateien liegen im Benutzerordner unter `Backups/sounds`. Das Tool behält automatisch nur die fünf neuesten ZIP-Backups. Die Liste der Backups zeigt nun Datum und Uhrzeit an, sortiert mit dem aktuellsten Eintrag oben. Beim Erstellen eines Sound-Backups erscheint jetzt ein Fortschrittsbalken und die Liste zeigt Datum sowie Dateigröße jeder ZIP-Datei an.
 
 
 ## 🗂️ Projektstruktur

--- a/electron/main.js
+++ b/electron/main.js
@@ -325,7 +325,18 @@ app.whenReady().then(() => {
 
   // Neues Sound-ZIP-Backup erstellen
   ipcMain.handle('create-sound-backup', async () => {
-    return await createSoundBackup(soundZipBackupPath, dePath, deBackupPath, deHistoryPath, 5);
+    return await createSoundBackup(
+      soundZipBackupPath,
+      dePath,
+      deBackupPath,
+      deHistoryPath,
+      5,
+      progress => {
+        if (mainWindow) {
+          mainWindow.webContents.send('sound-backup-progress', progress);
+        }
+      }
+    );
   });
 
   // Sound-ZIP-Backup löschen

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -52,6 +52,7 @@ if (typeof require !== 'function') {
     listSoundBackups: () => ipcRenderer.invoke('list-sound-backups'),
     createSoundBackup: () => ipcRenderer.invoke('create-sound-backup'),
     deleteSoundBackup: (name) => ipcRenderer.invoke('delete-sound-backup', name),
+    onSoundBackupProgress: cb => ipcRenderer.on('sound-backup-progress', (e, prog) => cb(prog)),
     openBackupFolder: () => ipcRenderer.invoke('open-backup-folder'),
     // Pfad der ZIP-Datei an den Main-Prozess schicken
     importZip: filePath => ipcRenderer.invoke('import-zip', filePath),

--- a/tests/soundBackupUtils.test.js
+++ b/tests/soundBackupUtils.test.js
@@ -19,8 +19,11 @@ describe('soundBackupUtils', () => {
 
     const list = listSoundBackups(backupRoot);
     expect(list.length).toBe(1);
+    expect(list[0]).toHaveProperty('name');
+    expect(list[0]).toHaveProperty('size');
+    expect(list[0]).toHaveProperty('mtime');
 
-    deleteSoundBackup(backupRoot, list[0]);
+    deleteSoundBackup(backupRoot, list[0].name);
     expect(listSoundBackups(backupRoot).length).toBe(0);
   });
 });

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -413,6 +413,10 @@
             <div id="backupList" style="margin-bottom:15px;"></div>
             <h4>Sound-ZIP-Backups</h4>
             <div id="soundBackupList" style="margin-bottom:15px;"></div>
+            <div class="translate-progress" id="soundBackupProgress">
+                <div class="translate-status" id="soundBackupStatus"></div>
+                <div class="progress-bar"><div class="progress-fill" id="soundBackupFill"></div></div>
+            </div>
             <div style="margin-bottom:15px;">
                 <label>Intervall (Minuten):
                     <input type="number" id="backupInterval" min="1" style="width:60px;">


### PR DESCRIPTION
## Summary
- zeigen während des Sound-Backups einen Fortschrittsbalken
- Rückgabe von Datum und Größe für Sound-Backups
- Metadaten im UI anzeigen
- neue API `onSoundBackupProgress`
- README aktualisiert
- Test angepasst

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687390233d248327b79abe40c760f443