### PR TITLE
Verbesserter Tempo-Auto-Knopf

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Ignorier-Bereiche im DE-Editor:** Mit gedrückter Umschalttaste lassen sich beliebige Abschnitte markieren, die beim Abspielen und Speichern übersprungen werden. Die Bereiche bleiben bearbeitbar und erscheinen in einer eigenen Liste. Vorschau und Export überspringen diese Stellen automatisch.
 * **Manuelles Zuschneiden:** Start- und Endzeit lassen sich per Millisekundenfeld oder durch Ziehen der grünen Marker im Waveform-Editor setzen.
 * **Automatische Pausenkürzung und Time‑Stretching:** Längere Pausen erkennt das Tool auf Wunsch selbst. Mit einem Regler lässt sich das Tempo von 1,00–3,00 anpassen oder automatisch auf die EN-Länge setzen. Ein Button „🎯 Anpassen & Anwenden“ kombiniert beide Schritte und eine farbige Anzeige warnt bei Abweichungen.
-* **Neuer Tempo‑Auto‑Knopf:** Ein zusätzlicher "Auto"‑Button neben dem Tempo‑Regler setzt den Wert auf 1,00 und hebt die Anzeige gelb hervor.
+* **Verbesserter Tempo‑Auto‑Knopf:** Er setzt den Wert zunächst auf 1,00, färbt ihn gelb und erhöht ihn automatisch, bis „DE (bearbeiten)“ gelb wird.
 * **Sanftere Pausenkürzung:** Beim Entfernen langer Pausen bleiben jetzt 2 ms an jedem Übergang stehen, damit die Schnitte nicht zu hart wirken.
 * **Längenvergleich visualisiert:** Unter der DE-Wellenform zeigt ein Tooltip die neue Dauer. Abweichungen über 5 % werden orange oder rot hervorgehoben.
 * **Effektparameter speicherbar:** Trimmen, Pausenkürzung und Tempo werden im Projekt gesichert und lassen sich über "🔄 Zurücksetzen" rückgängig machen.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -10667,11 +10667,30 @@ async function openDeEdit(fileId) {
         };
         const tempoAuto = document.getElementById('tempoAutoBtn');
         if (tempoAuto) tempoAuto.onclick = () => {
+            // Startwert auf das Minimum setzen und gelb markieren
             tempoFactor = parseFloat(tempoRange.min);
             tempoRange.value = tempoFactor.toFixed(2);
             tempoDisp.textContent = tempoFactor.toFixed(2);
             tempoDisp.classList.add('tempo-auto');
             updateLengthInfo();
+
+            // Schrittweite und Ziel definieren
+            const step = parseFloat(tempoRange.step) || 0.01;
+            const max  = parseFloat(tempoRange.max);
+            const enMs = editEnBuffer.length / editEnBuffer.sampleRate * 1000;
+
+            // Erhöht den Faktor so lange, bis die Abweichung >= 5 % ist
+            const raise = () => {
+                const deMs = calcFinalLength();
+                const perc = Math.abs(deMs - enMs) / enMs * 100;
+                if (perc >= 5 || tempoFactor >= max) return;
+                tempoFactor = Math.min(tempoFactor + step, max);
+                tempoRange.value = tempoFactor.toFixed(2);
+                tempoDisp.textContent = tempoFactor.toFixed(2);
+                updateLengthInfo();
+                requestAnimationFrame(raise);
+            };
+            requestAnimationFrame(raise);
         };
     }
     const autoChk = document.getElementById('autoIgnoreChk');


### PR DESCRIPTION
## Zusammenfassung
- Tempo-Auto-Knopf erhöht nun automatisch den Wert, bis die Länge der bearbeiteten Datei deutlich vom EN abweicht
- README beschreibt die neue Funktion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873ab6d75888327b35c10497cff2456