### PR TITLE
Tempo-Autoknopf stoppt im orangen Bereich

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Ignorier-Bereiche im DE-Editor:** Mit gedrückter Umschalttaste lassen sich beliebige Abschnitte markieren, die beim Abspielen und Speichern übersprungen werden. Die Bereiche bleiben bearbeitbar und erscheinen in einer eigenen Liste. Vorschau und Export überspringen diese Stellen automatisch.
 * **Manuelles Zuschneiden:** Start- und Endzeit lassen sich per Millisekundenfeld oder durch Ziehen der grünen Marker im Waveform-Editor setzen.
 * **Automatische Pausenkürzung und Time‑Stretching:** Längere Pausen erkennt das Tool auf Wunsch selbst. Mit einem Regler lässt sich das Tempo von 1,00–3,00 anpassen oder automatisch auf die EN-Länge setzen. Ein Button „🎯 Anpassen & Anwenden“ kombiniert beide Schritte und eine farbige Anzeige warnt bei Abweichungen.
-* **Verbesserter Tempo‑Auto‑Knopf:** Er setzt den Wert zunächst auf 1,00, färbt ihn gelb und erhöht ihn automatisch, bis „DE (bearbeiten)“ gelb wird.
+* **Verbesserter Tempo‑Auto‑Knopf:** Er setzt den Wert zunächst auf 1,00, markiert ihn gelb und erhöht das Tempo automatisch, bis „DE (bearbeiten)“ orange leuchtet (Abweichung unter 10 %).
 * **Sanftere Pausenkürzung:** Beim Entfernen langer Pausen bleiben jetzt 2 ms an jedem Übergang stehen, damit die Schnitte nicht zu hart wirken.
 * **Längenvergleich visualisiert:** Unter der DE-Wellenform zeigt ein Tooltip die neue Dauer. Abweichungen über 5 % werden orange oder rot hervorgehoben.
 * **Effektparameter speicherbar:** Trimmen, Pausenkürzung und Tempo werden im Projekt gesichert und lassen sich über "🔄 Zurücksetzen" rückgängig machen.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -10667,23 +10667,23 @@ async function openDeEdit(fileId) {
         };
         const tempoAuto = document.getElementById('tempoAutoBtn');
         if (tempoAuto) tempoAuto.onclick = () => {
-            // Startwert auf das Minimum setzen und gelb markieren
+            // Startwert auf Minimum setzen und Eingabe hervorheben
             tempoFactor = parseFloat(tempoRange.min);
             tempoRange.value = tempoFactor.toFixed(2);
             tempoDisp.textContent = tempoFactor.toFixed(2);
             tempoDisp.classList.add('tempo-auto');
             updateLengthInfo();
 
-            // Schrittweite und Ziel definieren
+            // Schrittweite und Ziel festlegen
             const step = parseFloat(tempoRange.step) || 0.01;
             const max  = parseFloat(tempoRange.max);
             const enMs = editEnBuffer.length / editEnBuffer.sampleRate * 1000;
 
-            // Erhöht den Faktor so lange, bis die Abweichung >= 5 % ist
+            // Erhöht den Faktor, bis die Differenz < 10 % aber > 5 % beträgt
             const raise = () => {
                 const deMs = calcFinalLength();
                 const perc = Math.abs(deMs - enMs) / enMs * 100;
-                if (perc >= 5 || tempoFactor >= max) return;
+                if ((perc <= 10 && perc > 5) || tempoFactor >= max) return;
                 tempoFactor = Math.min(tempoFactor + step, max);
                 tempoRange.value = tempoFactor.toFixed(2);
                 tempoDisp.textContent = tempoFactor.toFixed(2);


### PR DESCRIPTION
## Zusammenfassung
- passt den Auto-Knopf so an, dass das Tempo bis maximal 10 % Abweichung erhöht wird
- README entsprechend aktualisiert

## Testanweisungen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873b2e4cdf48327aadbe103a74b79c7