### PR TITLE
Verbessere GPT-Aufrufe mit Warteschlange

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Zweite Kopierhilfe:** Ein neuer Dialog blättert durch alle Einträge und zeigt Ordnernamen, deutschen Text und Emotionstext an. Ein Seitenzähler informiert über die aktuelle Position.
 * **Alle Emotionstexte kopieren:** Ein neuer Button sammelt alle Emotionstexte, entfernt darin Zeilenumbrüche und trennt die Blöcke jeweils mit einer Leerzeile.
 * **Stabile Base64-Kodierung:** Große Audiodateien werden beim Hochladen in handlichen Blöcken verarbeitet, sodass kein "Maximum call stack size exceeded" mehr auftritt.
+* **Warteschlange für GPT-Anfragen:** Mehrere Emotionstexte werden nacheinander an OpenAI geschickt, um HTTP‑429‑Fehler zu vermeiden.
 * **ZIP-Import mit Vorschau:** Die gewählte ZIP-Datei wird in einen temporären Ordner entpackt. Scheitert "unzipper", greift automatisch 7‑Zip als Fallback. Anschließend werden die Audios nach führender Nummer sortiert angezeigt und bei Übereinstimmung direkt zugeordnet.
 * **Projektkarten mit Rahmen:** Jede Karte besitzt einen grauen Rand und nutzt nun die volle Breite. Im geöffneten Level wird der Rand grün. Das aktuell gewählte Projekt hebt sich mit einem blauen Balken, leicht transparentem Hintergrund (rgba(33,150,243,0.2)) und weißer Schrift deutlich ab.
 * **Überarbeitete Seitenleiste:** Jede Projektkarte besteht aus zwei Zeilen mit einheitlich breiten Badges für EN, DE und Audio.


### PR DESCRIPTION
## Zusammenfassung
- Queue für GPT-Anfragen in `gptService.js`
- API-Aufrufe in `evaluateScene` und `generateEmotionText` über die neue Warteschlange
- Export der neuen Funktion
- README um Hinweis auf die Warteschlange ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873c5253e008327ab11ec00a5d18a63