### PR TITLE
Add audio runtime to emotion copy feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@
 * Der Dateiwächter importiert Dateien jetzt nur automatisch, wenn eine passende Dubbing-ID vorhanden ist. Unbekannte Dateien öffnen stattdessen den manuellen Import-Dialog.
 ## 🛠️ Patch in 1.40.36
 * Fehler behoben: Beim Einfügen von GPT-Ergebnissen erschien teilweise "applyEvaluationResults is not a function".
+## 🛠️ Patch in 1.40.37
+* "Emotionen kopieren" zeigt nun vor jedem Eintrag die Laufzeit der EN-Datei an, z.B. `[8,57sec]`.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Automatischer Voice-Abgleich:** Beim Öffnen der Kopierhilfe lädt das Tool die verfügbaren ElevenLabs-Stimmen und zeigt Namen und IDs korrekt an.
 * **Zusätzliche Zwischenablage-Prüfung:** Die Kopierhilfe stellt sicher, dass im ersten Schritt der Name und im zweiten der Emotionstext in der Zwischenablage liegt.
 * **Zweite Kopierhilfe:** Ein neuer Dialog blättert durch alle Einträge und zeigt Ordnernamen, deutschen Text und Emotionstext an. Ein Seitenzähler informiert über die aktuelle Position.
-* **Alle Emotionstexte kopieren:** Ein neuer Button sammelt alle Emotionstexte, entfernt darin Zeilenumbrüche und trennt die Blöcke jeweils mit einer Leerzeile.
+* **Alle Emotionstexte kopieren:** Der Button sammelt alle Emotionstexte, entfernt Zeilenumbrüche, trennt die Blöcke mit einer Leerzeile und stellt die Laufzeit der EN‑Datei im Format `[8,57sec]` voran.
 * **Stabile Base64-Kodierung:** Große Audiodateien werden beim Hochladen in handlichen Blöcken verarbeitet, sodass kein "Maximum call stack size exceeded" mehr auftritt.
 * **Warteschlange für GPT-Anfragen:** Mehrere Emotionstexte werden nacheinander an OpenAI geschickt, um HTTP‑429‑Fehler zu vermeiden.
 * **ZIP-Import mit Vorschau:** Die gewählte ZIP-Datei wird in einen temporären Ordner entpackt. Scheitert "unzipper", greift automatisch 7‑Zip als Fallback. Anschließend werden die Audios nach führender Nummer sortiert angezeigt und bei Übereinstimmung direkt zugeordnet.

--- a/tests/copyAllEmotions.test.js
+++ b/tests/copyAllEmotions.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-let copyAllEmotionsToClipboard, __setFiles;
+let copyAllEmotionsToClipboard, __setFiles, __setGetAudioDuration;
 
 function loadMain() {
     jest.resetModules();
@@ -11,7 +11,7 @@ function loadMain() {
     global.safeCopy = async text => { await navigator.clipboard.writeText(text); return true; };
     global.showToast = jest.fn();
     global.files = [];
-    ({ copyAllEmotionsToClipboard, __setFiles } = require('../web/src/main.js'));
+    ({ copyAllEmotionsToClipboard, __setFiles, __setGetAudioDuration } = require('../web/src/main.js'));
     // nach dem Laden die Toast-Funktion überschreiben und DOM vorbereiten
     global.showToast = jest.fn();
     document.body.innerHTML = '<div id="toastContainer"></div>';
@@ -22,11 +22,12 @@ describe('copyAllEmotionsToClipboard', () => {
 
     test('bereitet Emotionstexte auf und kopiert sie', async () => {
         const arr = [
-            { emotionalText: '[dankbar]\nDanke\n' },
-            { emotionalText: 'Hallo Welt!\nWie gehts?\n' }
+            { emotionalText: '[dankbar]\nDanke\n', filename: 'a.wav', folder: 'f1' },
+            { emotionalText: 'Hallo Welt!\nWie gehts?\n', filename: 'b.wav', folder: 'f1' }
         ];
         __setFiles(arr);
+        __setGetAudioDuration(() => 8.57);
         await copyAllEmotionsToClipboard();
-        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('[dankbar] Danke\n\nHallo Welt! Wie gehts?');
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('[8,57sec] [dankbar] Danke\n\n[8,57sec] Hallo Welt! Wie gehts?');
     });
 });


### PR DESCRIPTION
## Summary
- prepend the EN audio runtime before each emotion text when copying
- expose setter to mock `getAudioDuration` for tests
- update tests for new behavior
- document the new runtime prefix in README
- log in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c95a89dd483279df4335193885cd6