### PR TITLE
Kopierknopf ergänzt Laufzeit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@
 * Preset-Verwaltung für den Funkgeräte-Effekt. Einstellungen lassen sich speichern und löschen.
 ## 🛠️ Patch in 1.40.109
 * Speichern eines Funkgeräte-Presets öffnet nun einen eigenen Dialog, da `prompt()` in Electron nicht unterstützt wird.
+## 🛠️ Patch in 1.40.110
+* Der 📋-Knopf unter dem Emotional-Text kopiert jetzt zusätzlich die Laufzeit der EN-Datei im Format `[8,57sec]`.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Emotionaler DE‑Text:** Unter jedem deutschen Textfeld befindet sich ein eigenes Feld mit violettem Hintergrund. Der Button „Emotional-Text (DE) generieren“ erstellt den Inhalt nun stets neu; ein 📋‑Knopf kopiert ihn.
 * **Emotionen (DE) generieren:** Der Button oberhalb der Tabelle erstellt jetzt für alle Zeilen neue Emotional-Text-Felder – vorhandene Inhalte werden überschrieben.
 * **Anpassen‑Kürzen:** Direkt neben dem Generieren-Knopf passt ein weiterer Button den Emotional-Text auf die Länge der englischen Originalaufnahme an. Die Begründung unter dem violetten Feld erklärt nun kurz, wie der Text auf z. B. "8,57 s" gekürzt wurde.
+* **Laufzeit vor Emotional-Text:** Der 📋-Knopf schreibt beim Kopieren jetzt die Dauer der EN-Datei im Format `[8,57sec]` vor den Text.
 * **Kontextvolle Emotionstags:** Beim Generieren eines Emotional-Texts wird nun der komplette Dialog des Levels an ChatGPT gesendet, damit der Tonfall korrekt erkannt wird.
 * **Tags mitten im Satz:** Die erzeugten Emotionstags stehen jetzt direkt vor der jeweiligen Textstelle und nicht mehr am Ende der Zeile.
 * **Tags auf Deutsch:** In den eckigen Klammern sind die Emotionstags nun auf Deutsch, der eigentliche Dialog bleibt weiterhin Deutsch.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2964,7 +2964,15 @@ function addFiles() {
                 updateStatus('Emotionaler Text ist leer');
                 return;
             }
-            if (await safeCopy(area.value)) {
+            const file = files.find(f => f.id === fileId);
+            let dur = null;
+            if (file && file.filename && file.folder) {
+                const enSrc = `sounds/EN/${getFullPath(file)}`;
+                dur = await getAudioDurationFn(enSrc);
+            }
+            const durStr = dur != null ? dur.toFixed(2).replace('.', ',') + 'sec' : '?sec';
+            const text = `[${durStr}] ${normalizeEmotionalText(area.value)}`;
+            if (await safeCopy(text)) {
                 updateStatus(`Emotionaler Text kopiert: ${fileId}`);
             }
         }


### PR DESCRIPTION
## Summary
- setze beim Einzelkopieren des Emotional-Texts die EN-Laufzeit voran
- ergänze README um Hinweis auf neue Funktion
- führe neuen Patcheintrag 1.40.110 ein

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888849a102483279c3ba2ee748cc3c5