### PR TITLE
Leere Ignorier-Liste nach Schnitt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@
 * Hall-Effekt wird beim Dubbing jetzt ebenfalls zurückgesetzt.
 ## 🛠️ Patch in 1.40.112
 * Neues Skript `update_repo.py` aktualisiert das Repository und zeigt die eingespielten Commits an.
+## 🛠️ Patch in 1.40.113
+* Beim Speichern leert der DE-Editor nun automatisch die Ignorier-Liste. Automatisch erkannte Pausen landen damit nicht mehr im Projekt.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Sanftere Pausenkürzung:** Beim Entfernen langer Pausen bleiben jetzt 2 ms an jedem Übergang stehen, damit die Schnitte nicht zu hart wirken.
 * **Längenvergleich visualisiert:** Unter der DE-Wellenform zeigt ein Tooltip die neue Dauer. Abweichungen über 5 % werden orange oder rot hervorgehoben.
 * **Effektparameter speicherbar:** Trimmen, Pausenkürzung und Tempo werden im Projekt gesichert und lassen sich über "🔄 Zurücksetzen" rückgängig machen.
+* **Automatisch entfernte Pausen werden nicht gespeichert:** Die Liste der Ignorier-Bereiche wird nach dem Speichern geleert.
 * **Bugfix beim Ziehen:** Ein versehentlicher Drag ohne den Griff löst keine Fehlermeldung mehr aus.
 * **Bugfix:** Die Tempoanpassung nutzte versehentlich "window" als Variablennamen, was einen Fehler auslöste. Jetzt funktioniert das Time‑Stretching wieder.
 * **Verbessertes Time‑Stretching:** Durch Einsatz von SoundTouchJS klingt die automatische Tempoanpassung ohne Roboter-Effekt.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -11738,6 +11738,11 @@ async function applyDeEdit() {
         let newBuffer = trimAndPadBuffer(baseBuffer, editStartTrim, editEndTrim);
         const adj = editIgnoreRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim }));
         newBuffer = removeRangesFromBuffer(newBuffer, adj);
+        // Automatisch entfernte Pausen nicht speichern und Anzeige aktualisieren
+        editIgnoreRanges = [];
+        currentEditFile.ignoreRanges = [];
+        refreshIgnoreList();
+        updateDeEditWaveforms();
         // Nur den Unterschied zum geladenen Faktor anwenden
         const relFactor = tempoFactor / loadedTempoFactor;
         newBuffer = await timeStretchBuffer(newBuffer, relFactor);
@@ -11806,6 +11811,11 @@ async function applyDeEdit() {
         let newBuffer = trimAndPadBuffer(baseBuffer, editStartTrim, editEndTrim);
         const adj = editIgnoreRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim }));
         newBuffer = removeRangesFromBuffer(newBuffer, adj);
+        // Automatisch entfernte Pausen nicht speichern und Anzeige aktualisieren
+        editIgnoreRanges = [];
+        currentEditFile.ignoreRanges = [];
+        refreshIgnoreList();
+        updateDeEditWaveforms();
         // Nur den Unterschied zum geladenen Faktor anwenden
         const relFactor = tempoFactor / loadedTempoFactor;
         newBuffer = await timeStretchBuffer(newBuffer, relFactor);


### PR DESCRIPTION
## Summary
- ignorierte Pausen nach dem Schnitt aus dem Puffer löschen
- README erklärt, dass automatisch entfernte Pausen nicht gespeichert werden
- Changelog ergänzt Patcheintrag 1.40.113

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68889ee5e3888327b93ce5a655e4e8c4