### PR TITLE
Fix playback order and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@
 * Uploads ersetzen nun die Sicherungsdatei in `DE-Backup`, sodass "Zurücksetzen" die zuletzt geladene Version wiederherstellt.
 ## 🛠️ Patch in 1.40.117
 * Beim Speichern wird die Sicherung nicht mehr überschrieben, damit stets die ursprünglich hochgeladene Datei wiederhergestellt werden kann.
+## 🛠️ Patch in 1.40.118
+* Fehler behoben: Die Projekt-Wiedergabe hält jetzt immer die Positionsreihenfolge ein.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.117-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.118-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -600,6 +600,7 @@ Seit Patch 1.40.105 begrenzt `mergeSegments` die Segmentgrenzen auf die Pufferl�
 Seit Patch 1.40.106 stellt ein Auto-Knopf im DE-Audio-Editor Anfangs- und Endstille automatisch ein.
 Seit Patch 1.40.114 erweitern oder verkleinern zwei neue Buttons alle Ignorier-Bereiche in 50‑ms-Schritten.
 Seit Patch 1.40.115 lassen sich mit der Alt-Taste Stille-Bereiche einfügen, um Audios zeitlich zu verschieben.
+Seit Patch 1.40.118 spielt die Projekt-Wiedergabe alle Dateien wieder in korrekter Reihenfolge ab.
 
 Beispiel einer gültigen CSV:
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla-translation-desktop",
-  "version": "1.40.117",
+  "version": "1.40.118",
   "main": "main.js",
   "scripts": {
     "start": "electron ."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.40.117",
+  "version": "1.40.118",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.40.117",
+      "version": "1.40.118",
       "dependencies": {
         "7zip-bin": "^5.2.0",
         "archiver": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.40.117",
+  "version": "1.40.118",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -868,7 +868,7 @@
 
     <!-- Versionsanzeige -->
     <!-- Verlinkung zur aktuellen Version -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.40.117</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.40.118</a>
 
     <script src="src/colorUtils.js"></script>
     <script src="src/main.js"></script>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -259,7 +259,7 @@ let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
 // Aktuelle Programmversion
-const APP_VERSION = '1.40.117';
+const APP_VERSION = '1.40.118';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 
@@ -5542,8 +5542,16 @@ function clearProjectRowHighlight() {
     document.querySelectorAll('tr.current-project-row').forEach(r => r.classList.remove('current-project-row'));
 }
 
-// Liefert alle Dateien mit vorhandener DE-Version in aktueller Reihenfolge
+// Gibt alle Dateien mit vorhandener DE-Version in Positionsreihenfolge zurück
 function getProjectPlaybackList() {
+    // Wenn eine Sortierung aktiv ist, enthält displayOrder die Originalreihenfolge
+    if (displayOrder.length === files.length) {
+        return displayOrder
+            .sort((a, b) => a.originalIndex - b.originalIndex)
+            .map(item => item.file)
+            .filter(f => getDeFilePath(f));
+    }
+    // Ohne Sortierung ist die Reihenfolge der files bereits korrekt
     return files.filter(f => getDeFilePath(f));
 }
 


### PR DESCRIPTION
## Summary
- ensure project playback uses original order when sorted
- document the bugfix in README and CHANGELOG
- bump version to 1.40.118

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a65dde3988327ad37315077fc45ab