### PR TITLE
Fix playback order verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@
 * Fehler behoben: Die Projekt-Wiedergabe hält jetzt immer die Positionsreihenfolge ein.
 ## 🛠️ Patch in 1.40.119
 * Sortierung bleibt bei der Projekt-Wiedergabe unverändert, dadurch werden keine Zeilen mehr übersprungen.
+## 🛠️ Patch in 1.40.120
+* Vor der Projekt-Wiedergabe wird die Reihenfolge der Dateien geprüft und bei Bedarf korrigiert.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.119-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.120-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -602,6 +602,7 @@ Seit Patch 1.40.114 erweitern oder verkleinern zwei neue Buttons alle Ignorier-B
 Seit Patch 1.40.115 lassen sich mit der Alt-Taste Stille-Bereiche einfügen, um Audios zeitlich zu verschieben.
 Seit Patch 1.40.118 spielt die Projekt-Wiedergabe alle Dateien wieder in korrekter Reihenfolge ab.
 Seit Patch 1.40.119 wird die Sortierung nicht mehr verändert und Zeilen werden nicht übersprungen.
+Seit Patch 1.40.120 prüft die Projekt-Wiedergabe vor dem Start die Reihenfolge und korrigiert sie falls nötig.
 
 Beispiel einer gültigen CSV:
 

--- a/tests/ensurePlaybackOrder.test.js
+++ b/tests/ensurePlaybackOrder.test.js
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+const { getProjectPlaybackList, ensurePlaybackOrder, __setFiles, __setDisplayOrder, __setDeAudioCache } = require('../web/src/main.js');
+
+test('ensurePlaybackOrder korrigiert die Reihenfolge', () => {
+    const testFiles = [
+        { id: 1, folder: 'f', filename: 'a.mp3' },
+        { id: 2, folder: 'f', filename: 'b.wav' },
+        { id: 3, folder: 'f', filename: 'c.mp3' }
+    ];
+    const cache = {
+        'f/a.mp3': true,
+        'f/b.wav': true,
+        'f/c.mp3': true
+    };
+    __setFiles(testFiles);
+    __setDeAudioCache(cache);
+    // Falsche Reihenfolge simulieren
+    __setDisplayOrder([
+        { file: testFiles[2], originalIndex: 2 },
+        { file: testFiles[0], originalIndex: 0 },
+        { file: testFiles[1], originalIndex: 1 }
+    ]);
+
+    ensurePlaybackOrder();
+    const order = getProjectPlaybackList().map(f => f.id);
+    expect(order).toEqual([1, 2, 3]);
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -5542,8 +5542,18 @@ function clearProjectRowHighlight() {
     document.querySelectorAll('tr.current-project-row').forEach(r => r.classList.remove('current-project-row'));
 }
 
+// Stellt sicher, dass die Wiedergabereihenfolge der aktuellen Dateireihenfolge entspricht
+function ensurePlaybackOrder() {
+    const mismatch = displayOrder.length !== files.length ||
+        displayOrder.some((item, idx) => item.file.id !== files[idx].id);
+    if (mismatch) {
+        displayOrder = files.map((file, index) => ({ file, originalIndex: index }));
+    }
+}
+
 // Gibt alle Dateien mit vorhandener DE-Version in Positionsreihenfolge zurück
 function getProjectPlaybackList() {
+    ensurePlaybackOrder();
     // Wenn eine Sortierung aktiv ist, enthält displayOrder die Originalreihenfolge
     if (displayOrder.length === files.length) {
         return [...displayOrder]
@@ -14192,6 +14202,7 @@ if (typeof module !== "undefined" && module.exports) {
         markDubAsReady,
         cleanupDubCache,
         getProjectPlaybackList,
+        ensurePlaybackOrder,
         applyDeEdit,
         speichereUebersetzungsDatei,
         // 🔄 Projektbereinigung & Dateiendungs-Reparatur
@@ -14211,6 +14222,8 @@ if (typeof module !== "undefined" && module.exports) {
         __setDeAudioCache: c => { deAudioCache = c; },
         __setRenderFileTable: fn => { renderFileTable = fn; },
         __setSaveCurrentProject: fn => { saveCurrentProject = fn; },
+        __setDisplayOrder: arr => { displayOrder = arr; },
+        __getDisplayOrder: () => displayOrder,
         __setProjects: p => { projects = p; },
         __setFilePathDatabase: db => { filePathDatabase = db; },
         __setTextDatabase: db => { textDatabase = db; },


### PR DESCRIPTION
## Summary
- validate playback order before project playback starts
- expose helper functions for tests
- test playback order fix
- document new playback check in README
- add changelog entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a7c7e7ed88327a74dcfb591cd1f8b