### PR TITLE
Enhance playback list info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@
 * Wiedergabeliste zeigt während der Projekt-Wiedergabe alle Dateinamen in korrekter Reihenfolge an.
 ## 🛠️ Patch in 1.40.122
 * Wiedergabeliste zeigt nun die Positionsnummern statt fortlaufender Zählung.
+## 🛠 Patch in 1.40.123
+* Wiedergabeliste zeigt nun zusätzliche Pfadinformationen zu jeder Datei.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.122-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.123-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -605,6 +605,7 @@ Seit Patch 1.40.119 wird die Sortierung nicht mehr verändert und Zeilen werden 
 Seit Patch 1.40.120 prüft die Projekt-Wiedergabe vor dem Start die Reihenfolge und korrigiert sie falls nötig.
 Seit Patch 1.40.121 zeigt ein kleines Wiedergabe-Fenster die aktuelle Reihenfolge samt Dateinamen an.
 Seit Patch 1.40.122 zeigt die Wiedergabeliste nun die Positionsnummern der Dateien.
+Seit Patch 1.40.123 zeigt die Wiedergabeliste zusätzliche Pfadinformationen an.
 
 Beispiel einer gültigen CSV:
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla-translation-desktop",
-  "version": "1.40.122",
+  "version": "1.40.123",
   "main": "main.js",
   "scripts": {
     "start": "electron ."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.40.122",
+  "version": "1.40.123",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.40.122",
+      "version": "1.40.123",
       "dependencies": {
         "7zip-bin": "^5.2.0",
         "archiver": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.40.122",
+  "version": "1.40.123",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -881,7 +881,7 @@
 
     <!-- Versionsanzeige -->
     <!-- Verlinkung zur aktuellen Version -->
-    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.40.122</a>
+    <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.40.123</a>
 
     <script src="src/colorUtils.js"></script>
     <script src="src/main.js"></script>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -259,7 +259,7 @@ let redoStack          = [];
 
 // Version wird zur Laufzeit ersetzt
 // Aktuelle Programmversion
-const APP_VERSION = '1.40.122';
+const APP_VERSION = '1.40.123';
 // Basis-URL der API
 const API = 'https://api.elevenlabs.io/v1';
 
@@ -5552,9 +5552,13 @@ function getFilePosition(fileId) {
 function updatePlaybackList() {
     const list = document.getElementById('playbackList');
     if (!list) return;
-    list.innerHTML = playbackFiles.map((f, idx) =>
-        `<li class="${idx === projectPlayIndex ? 'current' : ''}">${getFilePosition(f.id)}. ${escapeHtml(f.filename)}</li>`
-    ).join('');
+    // Zeige Positionsnummer, Dateiname und Pfade der gefundenen Audiodateien an
+    list.innerHTML = playbackFiles.map((f, idx) => {
+        const dePath = getDeFilePath(f);
+        const fullPath = getFullPath(f);
+        const pathInfo = `${escapeHtml(fullPath)} ➜ ${dePath ? escapeHtml(dePath) : 'kein DE-Audio'}`;
+        return `<li class="${idx === projectPlayIndex ? 'current' : ''}">${getFilePosition(f.id)}. ${escapeHtml(f.filename)}<br><small>${pathInfo}</small></li>`;
+    }).join('');
     updateProjectPlaybackButtons();
 }
 

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -3209,6 +3209,7 @@ th:nth-child(10) {
 .playback-list { list-style: none; padding: 0; margin: 0 0 15px; max-height: 200px; overflow-y: auto; }
 .playback-list li { padding: 2px 4px; border-bottom: 1px solid #444; }
 .playback-list li.current { background: #333; }
+.playback-list li small { color: #999; }
 
 /* Tabelle für den ZIP-Import */
 .zip-preview-table {


### PR DESCRIPTION
## Summary
- show path info for each entry in the playback list
- style small info text
- note new feature in README and CHANGELOG
- bump version to 1.40.123

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a8826f0508327944344029b63c9d8