### PR TITLE
Add playback protocol log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@
 * Wiedergabeliste zeigt nun zusätzliche Pfadinformationen zu jeder Datei.
 ## 🛠 Patch in 1.40.124
 * Wiedergabeliste prüft jede Datei und zeigt Icons für Existenz, Abspielstatus und korrekte Reihenfolge.
+## 🛠 Patch in 1.40.125
+* Wiedergabeliste erzeugt nun ein Protokoll der erwarteten und der tatsächlichen Abspielreihenfolge.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ Seit Patch 1.40.121 zeigt ein kleines Wiedergabe-Fenster die aktuelle Reihenfolg
 Seit Patch 1.40.122 zeigt die Wiedergabeliste nun die Positionsnummern der Dateien.
 Seit Patch 1.40.123 zeigt die Wiedergabeliste zusätzliche Pfadinformationen an.
 Seit Patch 1.40.124 zeigt die Wiedergabeliste kleine Icons für Dateiexistenz, Wiedergabe-Erfolg und Reihenfolge.
+Seit Patch 1.40.125 führt ein Protokoll neben der Wiedergabeliste die erwartete und die tatsächliche Reihenfolge auf.
 
 Beispiel einer gültigen CSV:
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla-translation-desktop",
-  "version": "1.40.124",
+  "version": "1.40.125",
   "main": "main.js",
   "scripts": {
     "start": "electron ."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.40.124",
+  "version": "1.40.125",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/tests/playbackProtocol.test.js
+++ b/tests/playbackProtocol.test.js
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+
+let startProjectPlayback, stopProjectPlayback, __setFiles, __setDeAudioCache, __getPlaybackProtocol;
+
+function loadMain() {
+    jest.resetModules();
+    const doc = global.document;
+    doc.getElementById = jest.fn(id => {
+        if (id === 'projectPlayPauseBtn' || id === 'playbackPlayBtn') return { textContent: '' };
+        if (id === 'playbackList') return { innerHTML: '' };
+        if (id === 'playbackProtocol') return { textContent: '', scrollTop: 0, scrollHeight: 0 };
+        if (id === 'playbackListDialog') return { classList: { remove: jest.fn(), add: jest.fn() } };
+        if (id === 'audioPlayer') return { play: jest.fn(() => Promise.resolve()), pause: jest.fn(), addEventListener: jest.fn(), src: '' };
+        return null;
+    });
+    doc.querySelectorAll = jest.fn(() => []);
+    doc.querySelector = jest.fn(() => null);
+    global.window = { addEventListener: jest.fn() };
+    global.URL = { createObjectURL: jest.fn(()=>'blob:'), revokeObjectURL: jest.fn() };
+    global.localStorage = { getItem: () => null };
+    ({ startProjectPlayback, stopProjectPlayback, __setFiles, __setDeAudioCache, __getPlaybackProtocol } = require('../web/src/main.js'));
+}
+
+beforeEach(loadMain);
+
+test('playback protocol logs expected order', () => {
+    const files = [
+        { id: 1, folder: 'f', filename: 'a.mp3' },
+        { id: 2, folder: 'f', filename: 'b.wav' }
+    ];
+    const cache = { 'f/a.mp3': true, 'f/b.wav': true };
+    __setFiles(files);
+    __setDeAudioCache(cache);
+    startProjectPlayback();
+    stopProjectPlayback();
+    const protocol = __getPlaybackProtocol();
+    expect(protocol.startsWith('Erwartete Reihenfolge:\n1. a.mp3\n2. b.wav\nAbspielreihenfolge:\n1. a.mp3')).toBe(true);
+});

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -831,6 +831,7 @@
             <button class="dialog-close-btn" onclick="closePlaybackList()">×</button>
             <h3>🔊 Wiedergabeliste</h3>
             <ul id="playbackList" class="playback-list"></ul>
+            <pre id="playbackProtocol" class="playback-protocol"></pre>
             <div class="dialog-buttons">
                 <button class="btn" id="playbackPlayBtn" onclick="toggleProjectPlayback()">▶</button>
                 <button class="btn btn-secondary" onclick="closePlaybackList()">Schließen</button>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -3211,6 +3211,7 @@ th:nth-child(10) {
 .playback-list li.current { background: #333; }
 .playback-list li small { color: #999; }
 .playback-list li .icon { margin-right: 4px; }
+.playback-protocol { background:#111; color:#eee; padding:4px; max-height:100px; overflow-y:auto; }
 
 /* Tabelle für den ZIP-Import */
 .zip-preview-table {


### PR DESCRIPTION
## Summary
- create playback protocol showing expected and actual order
- add protocol output element and style
- introduce helper for protocol logging
- export project playback helpers for tests
- bump version to 1.40.125
- document new playback protocol feature
- add unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a8dcbaf7c8327ae7d1997372c241d