### PR TITLE
Aktionsspalte überarbeitet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,18 @@
 * Beim Kürzen eines Emotional-Texts darf die Übersetzung nun leicht verändert werden, um sehr kurze EN-Zeilen besser abzudecken.
 ## 🛠 Patch in 1.40.127
 * DE-Audio-Editor mit verbesserten Buttons und erläuternden Tooltips.
+## 🛠 Patch in 1.40.128
+* Tabelle vereint EN- und DE-Spalte sowie alle Aktionen in zwei übersichtlichen Feldern.
+## 🛠 Patch in 1.40.129
+* Spaltenbreiten korrigiert: Ordnertext überlappt nicht mehr und Aktions-Symbole sind gruppiert.
+## 🛠 Patch in 1.40.130
+* Aktions-Symbole besitzen nun Tooltips mit kurzen Erklärungen.
+## 🛠 Patch in 1.40.131
+* Versions- und Score-Spalte sind nun schmaler: Überschrift und Werte werden untereinander dargestellt.
+## 🛠 Patch in 1.40.132
+* Neue Aktionsleiste mit runden Symbolknöpfen, die alle Funktionen übersichtlich in Zeilen gruppiert.
+## 🛠 Patch in 1.40.133
+* Einheitliche Icon-Größen, dunkler Hintergrund und klare Abstände machen die Aktionsspalte übersichtlicher.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,12 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Fehlerhinweise beim Speichern:** Tritt ein Problem auf, erscheint eine rote Toast-Meldung statt eines stummen Abbruchs.
 * **Neue Meldung:** Scheitert das Anlegen einer History-Version, wird "Fehler beim Anlegen der History-Version" ausgegeben.
 * **Kompaktere Dubbing-Spalte:** Der Statuspunkt und der Download-Pfeil stehen jetzt direkt neben dem Dubbing-Button in einer gemeinsamen Spalte.
+* **Einheitliche Tabellenspalten:** EN- und DE-Text erscheinen untereinander, alle Aktions-Buttons bilden eine vertikale Spalte.
+* **Optimierte Tabelle:** Ordnernamen sind korrekt ausgerichtet, schmale UT- und Pfad-Spalten lassen mehr Platz für die Texte und die Aktionssymbole sind gruppiert.
+* **Erklärende Tooltips:** In der Aktionenspalte zeigt jedes Symbol beim Überfahren mit der Maus seinen Zweck an.
+* **Schmalere Versionsspalte:** "Version" und "Score" stehen im Kopf sowie in jeder Zeile untereinander, wodurch die Tabelle breiterem Text mehr Platz lässt.
+* **Modernisierte Aktionsleiste:** Alle Bedienknöpfe erscheinen als runde Symbole und sind in klaren Zeilen gruppiert.
+* **Verbesserte Aktionsspalte:** Einheitliche Icon-Größe mit dunklem Hintergrund und deutlichen Abständen erleichtern die Bedienung.
 * **Bugfix:** Ein Klick auf den Download-Pfeil öffnet jetzt zuverlässig die korrekte V1-Dubbing-Seite.
 * **Automatik-Button für halbautomatisches Dubbing:** Per Playwright werden alle notwendigen Klicks im ElevenLabs-Studio ausgeführt.
 * **Neuer Button „Dubbing (Emo)“:** Öffnet ein eigenes Fenster und erzeugt über die Text‑to‑Speech‑API (V3) eine emotionale Spur. Halbautomatik steht hier nicht zur Verfügung.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -176,18 +176,12 @@
         <th width="50" title="Doppelklick auf Nummer um Position zu ändern">#</th>
         <th class="sortable">Dateiname</th>
         <th class="sortable">Ordner</th>
-        <th>Version</th>
-        <th>Score</th>
-        <th>EN Text</th>
-        <th>DE Text</th>
-        <th width="40">UT-Suche</th>
-        <th width="120" title="Pfad der EN- und DE-Datei">Pfad</th>
-        <th width="60">Upload</th>
-        <th width="120">Dubbing</th>
+        <th width="60"><div class="version-score-header">Version<br>Score</div></th>
+        <th>EN/DE Text</th>
+        <th width="50">UT-Suche</th>
+        <th width="90" title="Pfad der EN- und DE-Datei">Pfad</th>
         <th width="40" title="Längenvergleich">Länge</th>
-        <th width="60">Historie</th>
-        <th width="60">Bearbeiten</th>
-        <th width="60">Löschen</th>
+        <th width="130">Aktionen</th>
     </tr>
 </thead>
                     <tbody id="fileTableBody"></tbody>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -3585,7 +3585,7 @@ return `
         <td class="drag-handle" draggable="true">↕</td>
         <td class="row-number" data-file-id="${file.id}" onclick="changeRowNumber(${file.id}, ${originalIndex + 1})" title="Klick um Position zu ändern">${originalIndex + 1}</td>
         <td class="filename-cell clickable" onclick="checkFilename(${file.id}, event)">${file.filename}</td>
-        <td>
+        <td class="folder-cell">
             <span class="folder-badge clickable"
                   style="background: ${folderColor}; color: white;"
                   title="Ordner: ${file.folder} - Klick für Datei-Austausch"
@@ -3593,41 +3593,52 @@ return `
                 ${folderIcon} ${lastFolder}
             </span>
         </td>
-        <td>
+        <td class="version-score-cell">
             ${hasDeAudio ? `<span class="version-badge" style="background:${getVersionColor(file.version ?? 1)}" onclick="openVersionMenu(event, ${file.id})">${file.version ?? 1}</span>` : ''}
+            ${(() => {
+                const cls = scoreClass(file.score);
+                const color = getContrastingTextColor(SCORE_COLORS[cls]);
+                const sug = escapeHtml(file.suggestion || '');
+                const com = escapeHtml(file.comment || '');
+                const scoreText = file.score === undefined || file.score === null ? '0' : file.score;
+                return `<span class="score-cell ${cls}" title="${com}" style="color:${color}" data-suggestion="${sug}" data-comment="${com}">${scoreText}%</span>`;
+            })()}
         </td>
-        ${scoreCellTemplate(file, escapeHtml)}
-        <td><div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
-            <textarea class="text-input"
-                 onchange="updateText(${file.id}, 'en', this.value)"
-                 oninput="autoResizeInput(this)">${escapeHtml(file.enText)}</textarea>
-            <div class="btn-column">
-                <button class="copy-btn" onclick="copyTextToClipboard(${file.id}, 'en', event)" title="EN Text kopieren">📋</button>
-                <button class="play-btn" onclick="playAudio(${file.id})">▶</button>
-            </div>
-        </div></td>
         <td>
-        <div class="comment-box" data-file-id="${file.id}">${escapeHtml(file.comment || '')}</div>
-        <div class="suggestion-box ${scoreClass(file.score)}" style="color:${getContrastingTextColor(SCORE_COLORS[scoreClass(file.score)])}" data-file-id="${file.id}">${escapeHtml(file.suggestion || '')}</div>
-        <div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
-            <textarea class="text-input"
-                 onchange="updateText(${file.id}, 'de', this.value)"
-                 oninput="autoResizeInput(this)">${escapeHtml(file.deText)}</textarea>
-            <div class="btn-column">
-                <button class="copy-btn" onclick="copyTextToClipboard(${file.id}, 'de', event)" title="DE Text kopieren">📋</button>
-                ${hasDeAudio ? `<button class="de-play-btn" onclick="playDeAudio(${file.id})">▶</button>` : ''}
+        <div style="display:flex;flex-direction:column;gap:6px;">
+            <div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
+                <textarea class="text-input"
+                     onchange="updateText(${file.id}, 'en', this.value)"
+                     oninput="autoResizeInput(this)">${escapeHtml(file.enText)}</textarea>
+                <div class="btn-column">
+                    <button class="copy-btn" onclick="copyTextToClipboard(${file.id}, 'en', event)" title="EN Text kopieren">📋</button>
+                    <button class="play-btn" onclick="playAudio(${file.id})">▶</button>
+                </div>
+            </div>
+            <div>
+            <div class="comment-box" data-file-id="${file.id}">${escapeHtml(file.comment || '')}</div>
+            <div class="suggestion-box ${scoreClass(file.score)}" style="color:${getContrastingTextColor(SCORE_COLORS[scoreClass(file.score)])}" data-file-id="${file.id}">${escapeHtml(file.suggestion || '')}</div>
+            <div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
+                <textarea class="text-input"
+                     onchange="updateText(${file.id}, 'de', this.value)"
+                     oninput="autoResizeInput(this)">${escapeHtml(file.deText)}</textarea>
+                <div class="btn-column">
+                    <button class="copy-btn" onclick="copyTextToClipboard(${file.id}, 'de', event)" title="DE Text kopieren">📋</button>
+                    ${hasDeAudio ? `<button class="de-play-btn" onclick="playDeAudio(${file.id})">▶</button>` : ''}
+                </div>
+            </div>
+            <div class="auto-trans" data-file-id="${file.id}">${escapeHtml(file.autoTranslation || '')}</div>
+            <div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
+                <textarea class="emotional-text" placeholder="Mit Emotionen getaggter deutscher Text…" onchange="updateText(${file.id}, 'emo', this.value)" oninput="autoResizeInput(this)">${escapeHtml(file.emotionalText || '')}</textarea>
+                <div class="btn-column">
+                    <button class="generate-emotions-btn" onclick="generateEmotionalText(${file.id})">Emotional-Text (DE) generieren</button>
+                    <button class="adjust-emotions-btn" onclick="adjustEmotionalText(${file.id})">Anpassen-Kürzen</button>
+                    <button class="copy-emotional-text" onclick="copyEmotionalText(${file.id})" title="In Zwischenablage kopieren">📋</button>
+                </div>
+            </div>
+            <div class="emo-reason-box" data-file-id="${file.id}">${escapeHtml(file.emoReason || '')}</div>
             </div>
         </div>
-        <div class="auto-trans" data-file-id="${file.id}">${escapeHtml(file.autoTranslation || '')}</div>
-        <div style="position: relative; display: flex; align-items: flex-start; gap: 5px;">
-            <textarea class="emotional-text" placeholder="Mit Emotionen getaggter deutscher Text…" onchange="updateText(${file.id}, 'emo', this.value)" oninput="autoResizeInput(this)">${escapeHtml(file.emotionalText || '')}</textarea>
-            <div class="btn-column">
-                <button class="generate-emotions-btn" onclick="generateEmotionalText(${file.id})">Emotional-Text (DE) generieren</button>
-                <button class="adjust-emotions-btn" onclick="adjustEmotionalText(${file.id})">Anpassen-Kürzen</button>
-                <button class="copy-emotional-text" onclick="copyEmotionalText(${file.id})" title="In Zwischenablage kopieren">📋</button>
-            </div>
-        </div>
-        <div class="emo-reason-box" data-file-id="${file.id}">${escapeHtml(file.emoReason || '')}</div>
         </td>
         <!-- Untertitel-Suche Knopf -->
         <td><div class="btn-column">
@@ -3641,30 +3652,38 @@ return `
             </div>
             <span class="path-detail">EN: sounds/EN/${relPath}<br>DE: ${dePath ? `sounds/DE/${dePath}` : 'fehlend'}</span>
         </td>
-        <td><button class="upload-btn" onclick="initiateDeUpload(${file.id})">⬆️</button></td>
+        <td><span class="length-diff ${lengthClass}">${lengthIndicator}</span></td>
         <td>
-            <div class="dubbing-cell">
-                <button class="dubbing-btn" onclick="initiateDubbing(${file.id})">🔈</button>
-                ${file.emotionalText && file.emotionalText.trim() ? `<button class="dubbing-btn emo" onclick="initiateEmoDubbing(${file.id})">🟣</button>` : ''}
-                <span class="dub-status ${!file.dubbingId ? 'none' : (file.dubReady ? 'done' : 'pending')}" title="${!file.dubbingId ? 'kein Dubbing' : (file.dubReady ? 'fertig' : 'Studio generiert noch')}" ${(!file.dubbingId || file.dubReady) ? '' : `onclick=\"dubStatusClicked(${file.id})\"`}>●</span>
-                ${file.dubbingId ? `<button class="download-de-btn" data-file-id="${file.id}" title="Dubbing-ID: ${file.dubbingId}" onclick="openDubbingPage(${file.id})">⬇️</button>` : ''}
-                ${file.emotionalText && file.emotionalText.trim() ? `<span class="emo-dub-status ${!file.emoDubbingId ? 'none' : (file.emoDubReady ? 'done' : 'pending')}" title="${!file.emoDubbingId ? 'kein Dubbing' : (file.emoDubReady ? 'fertig' : 'Studio generiert noch')}" ${(!file.emoDubbingId || file.emoDubReady) ? '' : `onclick=\"dubStatusClicked(${file.id})\"`}>●</span>` : ''}
-                ${file.emoDubbingId ? `<button class="download-emo-btn" data-file-id="${file.id}" title="Emo-ID: ${file.emoDubbingId}" onclick="openDubbingPage(${file.id}, 'emo')">⬇️</button>` : ''}
+            <div class="action-toolbar">
+                <div class="action-row">
+                    <button class="icon-btn upload-btn" onclick="initiateDeUpload(${file.id})" title="DE-Audio hochladen">⬆️</button>
+                    ${hasHistory ? `<button class="icon-btn history-btn" onclick="openHistory(${file.id})" title="Historie anzeigen">🕒</button>` : ''}
+                </div>
+                <div class="action-row">
+                    <div class="dubbing-cell">
+                        <button class="icon-btn dubbing-btn" onclick="initiateDubbing(${file.id})" title="Dubbing starten">🔈</button>
+                        ${file.emotionalText && file.emotionalText.trim() ? `<button class="icon-btn dubbing-btn emo" onclick="initiateEmoDubbing(${file.id})" title="Emotionales Dubbing starten">🟣</button>` : ''}
+                        <span class="dub-status ${!file.dubbingId ? 'none' : (file.dubReady ? 'done' : 'pending')}" title="${!file.dubbingId ? 'kein Dubbing' : (file.dubReady ? 'fertig' : 'Studio generiert noch')}" ${(!file.dubbingId || file.dubReady) ? '' : `onclick=\"dubStatusClicked(${file.id})\"`}>●</span>
+                        ${file.dubbingId ? `<button class="icon-btn download-de-btn" data-file-id="${file.id}" title="Dubbing herunterladen (ID: ${file.dubbingId})" onclick="openDubbingPage(${file.id})">⬇️</button>` : ''}
+                        ${file.emotionalText && file.emotionalText.trim() ? `<span class="emo-dub-status ${!file.emoDubbingId ? 'none' : (file.emoDubReady ? 'done' : 'pending')}" title="${!file.emoDubbingId ? 'kein Dubbing' : (file.emoDubReady ? 'fertig' : 'Studio generiert noch')}" ${(!file.emoDubbingId || file.emoDubReady) ? '' : `onclick=\"dubStatusClicked(${file.id})\"`}>●</span>` : ''}
+                        ${file.emoDubbingId ? `<button class="icon-btn download-emo-btn" data-file-id="${file.id}" title="Emo-Dubbing herunterladen (ID: ${file.emoDubbingId})" onclick="openDubbingPage(${file.id}, 'emo')">⬇️</button>` : ''}
+                    </div>
+                </div>
+                <div class="action-row">
+                    <button class="icon-btn edit-audio-btn" onclick="openDeEdit(${file.id})" title="DE-Audio bearbeiten">✂️</button>
+                    <div class="edit-column">
+                        ${file.trimStartMs !== 0 || file.trimEndMs !== 0 ? '<span class="edit-status-icon" title="Audio gekürzt">✂️</span>' : ''}
+                        ${file.volumeMatched ? '<span class="edit-status-icon" title="Lautstärke angepasst">🔊</span>' : ''}
+                        ${file.radioEffect ? '<span class="edit-status-icon" title="Funkgerät-Effekt">📻</span>' : ''}
+                        ${file.hallEffect ? '<span class="edit-status-icon" title="Hall-Effekt">🏛️</span>' : ''}
+                    </div>
+                    ${file.emotionalText && file.emotionalText.trim() ? `<button class="icon-btn emo-done-btn" onclick="toggleEmoCompletion(${file.id})" title="Zeile fertig vertont">✅</button>` : ''}
+                </div>
+                <div class="action-row">
+                    <button class="icon-btn delete-row-btn" onclick="deleteFile(${file.id})" title="Zeile löschen">🗑️</button>
+                </div>
             </div>
         </td>
-        <td><span class="length-diff ${lengthClass}">${lengthIndicator}</span></td>
-        <td>${hasHistory ? `<button class="history-btn" onclick="openHistory(${file.id})">🕒</button>` : ''}</td>
-        <td><div style="display:flex;align-items:flex-start;gap:5px;">
-            <button class="edit-audio-btn" onclick="openDeEdit(${file.id})">✂️</button>
-            <div class="edit-column">
-                ${file.trimStartMs !== 0 || file.trimEndMs !== 0 ? '<span class="edit-status-icon">✂️</span>' : ''}
-                ${file.volumeMatched ? '<span class="edit-status-icon">🔊</span>' : ''}
-                ${file.radioEffect ? '<span class="edit-status-icon">📻</span>' : ''}
-                ${file.hallEffect ? '<span class="edit-status-icon">🏛️</span>' : ''}
-            </div>
-            ${file.emotionalText && file.emotionalText.trim() ? `<button class="emo-done-btn" onclick="toggleEmoCompletion(${file.id})">Fertig (DE)</button>` : ''}
-        </div></td>
-        <td><button class="delete-row-btn" onclick="deleteFile(${file.id})">🗑️</button></td>
     </tr>
 `;
     }));

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -58,7 +58,7 @@
 		
 		/* Debug column styling */
 /* Stil der Pfad-Spalte */
-td:nth-child(10) {
+td:nth-child(8) {
     max-width: 200px;
     font-size: 11px;
     color: #666;
@@ -66,7 +66,7 @@ td:nth-child(10) {
     line-height: 1.2;
 }
 
-th:nth-child(10) {
+th:nth-child(8) {
     max-width: 200px;
     font-size: 12px;
 }
@@ -646,15 +646,13 @@ th:nth-child(10) {
 
         /* Flexible Spaltenbreite für EN und DE */
         /* Spaltenbreite für EN- und DE-Text nach neuer Score-Spalte */
-        td:nth-child(7), td:nth-child(8) {
-            width: 25%;
-            min-width: 200px;
+        td:nth-child(6) {
+            min-width: 250px;
             vertical-align: top;
         }
 
-        th:nth-child(7), th:nth-child(8) {
-            width: 25%;
-            min-width: 200px;
+        th:nth-child(6) {
+            min-width: 250px;
         }
 
         /* Ordner-Spalte so schmal wie möglich halten */
@@ -665,16 +663,14 @@ th:nth-child(10) {
 
 /* Make table responsive - aktualisierte Spalten-Nummern */
 @media (max-width: 1200px) {
-    td:nth-child(7), td:nth-child(8) {
-        width: 25%;
+    td:nth-child(6) {
         min-width: 180px;
     }
-    th:nth-child(7), th:nth-child(8) {
-        width: 25%;
+    th:nth-child(6) {
         min-width: 180px;
     }
     /* Debug-Spalte (UT-Suche) bei kleinen Bildschirmen ausblenden */
-    td:nth-child(9), th:nth-child(9) {
+    td:nth-child(7), th:nth-child(7) {
         display: none;
     }
 }
@@ -729,15 +725,13 @@ th:nth-child(10) {
 }
 
 @media (max-width: 900px) {
-    td:nth-child(7), td:nth-child(8) {
-        width: 30%;
+    td:nth-child(6) {
         min-width: 160px;
     }
-    th:nth-child(7), th:nth-child(8) {
-        width: 30%;
+    th:nth-child(6) {
         min-width: 160px;
     }
-    td:nth-child(9), th:nth-child(9) {
+    td:nth-child(7), th:nth-child(7) {
         display: none;
     }
 }
@@ -887,9 +881,11 @@ th:nth-child(10) {
         /* Raster-Anordnung der Bearbeitungs-Symbole (maximal zwei pro Zeile) */
         .edit-column {
             display: flex;
-            flex-wrap: wrap;
-            gap: 3px;
-            width: 54px; /* 2 Symbole à 24px + Zwischenraum */
+            flex-direction: column;
+            gap: 5px;
+            align-items: center;
+            justify-content: center;
+            margin-left: 10px;
         }
 
         .upload-btn {
@@ -1001,7 +997,7 @@ th:nth-child(10) {
         }
 
         .delete-row-btn:hover {
-            background: #ff4444;
+            background-color: rgba(255,0,0,0.2);
             color: white;
         }
 
@@ -1089,6 +1085,77 @@ th:nth-child(10) {
     display: flex;
     flex-direction: column;
     gap: 3px;
+}
+
+/* Vertikale Anordnung der Aktions-Buttons */
+.action-toolbar {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 10px;
+    padding: 10px;
+    background-color: #2B2D30;
+    border-radius: 6px;
+}
+
+/* Zeile innerhalb der Aktionsleiste */
+.action-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+}
+
+/* Einheitliches Aussehen aller Aktions-Buttons */
+.icon-btn {
+    background: #444;
+    border: none;
+    color: #e0e0e0;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s, transform 0.1s;
+}
+
+.icon-btn:hover {
+    background: #555;
+    transform: scale(1.1);
+    color: #fff;
+}
+
+
+.icon-btn:active {
+    transform: scale(0.95);
+}
+
+/* Ordner-Badge sauber platzieren */
+.folder-cell {
+    white-space: nowrap;
+    vertical-align: top;
+}
+
+/* Version und Score untereinander */
+.version-score-cell {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+
+/* Ueberschrift mit wenig Breite: Version und Score untereinander */
+.version-score-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    line-height: 1.1;
 }
 
 /* Buttons für Effekte im Audio-Editor */


### PR DESCRIPTION
## Zusammenfassung
- Aktionsbuttons besitzen nun ein dunkles Hintergrundfeld mit einheitlichen Abständen
- die Bearbeitungs-Symbole stehen vertikal in `.edit-column`
- README und CHANGELOG listen die optisch überarbeitete Aktionsspalte

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b5e7a35688327808a91f2c0340143