### PR TITLE
Tempo-Regler wird beim Upload zurückgesetzt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,8 @@
 * Jede Aktionsgruppe steckt nun in einem eigenen Block mit Abstand; der Löschknopf ist deutlich nach unten versetzt.
 ## 🛠 Patch in 1.40.137
 * Aktionsknöpfe besitzen nun abgerundete Ecken und passen optisch zu den anderen Buttons.
+## 🛠 Patch in 1.40.138
+* Beim Hochladen einer DE-Audiodatei wird der Tempo-Faktor wieder auf 1,0 gesetzt.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Bugfix:** Beim erneuten Öffnen und Speichern wird nur noch die Differenz zum gespeicherten Tempo angewendet. Unveränderte Werte schneiden jetzt nichts mehr ab.
 * **Bugfix:** Wird eine Audiodatei stärker gekürzt als ihre Länge, führt dies nicht mehr zu einer DOMException.
 * **Zurücksetzen nach Upload oder Dubbing:** Sowohl beim Hochladen als auch beim erneuten Erzeugen einer deutschen Audiodatei werden Lautstärkeangleichung, Funkgerät‑Effekt und Hall‑Effekt automatisch deaktiviert.
+* **Tempo-Regler zurückgesetzt:** Nach einem Upload steht der Geschwindigkeitsregler wieder auf 1,00.
 * **Backup bleibt beim Speichern erhalten:** Nur ein neuer Upload ersetzt die Sicherung in `DE-Backup`. "🔄 Zurücksetzen" stellt dadurch stets die zuletzt geladene Originaldatei wieder her.
 * **Hall-Effekt wird beim Dubbing zurückgesetzt.**
 * **Fehlerhinweise beim Speichern:** Tritt ein Problem auf, erscheint eine rote Toast-Meldung statt eines stummen Abbruchs.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -13978,6 +13978,8 @@ function quickAddLevel(chapterName) {
                 f.volumeMatched = false;
                 f.radioEffect = false;
                 f.hallEffect = false;
+                // Tempo bei neuem Upload auf Standard zurücksetzen
+                f.tempoFactor = 1.0;
                 // Fertig-Status ergibt sich nun automatisch
             }
             isDirty = true;


### PR DESCRIPTION
## Zusammenfassung
- Tempo-Faktor beim Upload einer neuen DE-Datei auf 1.0 setzen
- README um Hinweis auf das Zurücksetzen des Tempo-Reglers ergänzen
- Changelog-Eintrag für Patch 1.40.138 hinzufügen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bc327f9548327803665bb19de921d