### PR TITLE
Fix module exports for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,12 @@
 * Beim Hochladen einer DE-Audiodatei wird der Tempo-Faktor wieder auf 1,0 gesetzt.
 ## 🛠 Patch in 1.40.139
 * Beim Kürzen eines Emotional-Texts bleiben abgebrochene Sätze und Fülllaute aus dem Original erhalten.
+## 🛠 Patch in 1.40.140
+* ZIP-Import aktualisiert nun den Ordner `DE-Backup`, sodass ein Zurücksetzen die importierte Datei wiederherstellt.
+## 🛠 Patch in 1.40.141
+* Fallback für `window` und `localStorage` sorgt für stabile Tests ohne Browser-API.
+## 🛠 Patch in 1.40.142
+* `gptService` nutzt im Electron-Renderer wieder `fetch`, wenn kein `require` verfügbar ist.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Stabile Base64-Kodierung:** Große Audiodateien werden beim Hochladen in handlichen Blöcken verarbeitet, sodass kein "Maximum call stack size exceeded" mehr auftritt.
 * **Warteschlange für GPT-Anfragen:** Mehrere Emotionstexte werden nacheinander an OpenAI geschickt, um HTTP‑429‑Fehler zu vermeiden.
 * **ZIP-Import mit Vorschau:** Die gewählte ZIP-Datei wird in einen temporären Ordner entpackt. Scheitert "unzipper", greift automatisch 7‑Zip als Fallback. Anschließend werden die Audios nach führender Nummer sortiert angezeigt und bei Übereinstimmung direkt zugeordnet.
+* **ZIP-Import speichert Originaldatei:** Importierte Audios landen direkt in `DE-Backup`, sodass ein Zurücksetzen immer die zuletzt importierte Version wiederherstellt.
 * **Projektkarten mit Rahmen:** Jede Karte besitzt einen grauen Rand und nutzt nun die volle Breite. Im geöffneten Level wird der Rand grün. Das aktuell gewählte Projekt hebt sich mit einem blauen Balken, leicht transparentem Hintergrund (rgba(33,150,243,0.2)) und weißer Schrift deutlich ab.
 * **Überarbeitete Seitenleiste:** Jede Projektkarte besteht aus zwei Zeilen mit einheitlich breiten Badges für EN, DE und Audio.
+* **Node-kompatibler Start:** Ohne Browser-API werden `window` und `localStorage` nur simuliert, wenn `require` verfügbar ist. Im Electron-Renderer lädt `gptService` seine Prompts weiterhin per Fetch.
 * **Breitere Projektleiste:** Die Sidebar ist jetzt 320 px breit, damit lange Einträge korrekt angezeigt werden.
 * **Aktiver Level hervorgehoben:** Geöffnete Level-Gruppen besitzen jetzt einen grünen Rahmen und einen leicht abgedunkelten Hintergrund.
 * **Dezente Level-Gruppen:** Geschlossene Level zeigen einen ganz leichten Hintergrund und nur beim Überfahren einen feinen Rahmen.

--- a/web/src/gptService.js
+++ b/web/src/gptService.js
@@ -25,7 +25,9 @@ function getEmotionPrompt() {
     return emotionPrompt;
 }
 
-if (typeof window !== 'undefined' && typeof fetch === 'function') {
+const hasRequire = typeof require === 'function';
+
+if (typeof window !== 'undefined' && typeof fetch === 'function' && !hasRequire) {
     // Im Browser: Prompts per Fetch laden
     const urlScore = '../prompts/gpt_score.txt';
     const urlEmo   = '../prompts/gpt_emotions.txt';

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,4 +1,17 @@
 // =========================== GLOBAL STATE START ===========================
+const window = typeof globalThis.window !== 'undefined' ? globalThis.window : (globalThis.window = {});
+let storage = window.localStorage || globalThis.localStorage;
+if (!storage) {
+    const store = {};
+    storage = {
+        getItem: k => (k in store ? store[k] : null),
+        setItem: (k, v) => { store[k] = String(v); },
+        removeItem: k => { delete store[k]; }
+    };
+}
+window.localStorage = storage;
+globalThis.localStorage = storage;
+const localStorage = storage;
 let projects               = [];
 let levelColors            = {}; // ⬅️ NEU: globale Level-Farben
 let levelOrders            = {}; // ⬅️ NEU: Reihenfolge der Level
@@ -24,7 +37,7 @@ let segmentPlayerUrl      = null;  // zuletzt erzeugte Object-URL
 let ignoredSegments       = new Set(); // ignorierte Segmente
 
 // Verfügbarkeit der Electron-API einmalig prüfen
-const isElectron = !!window.electronAPI;
+const isElectron = typeof window !== "undefined" && !!window.electronAPI;
 if (!isElectron) {
     console.warn('🚫 Electron-API nicht verfügbar – Fallback auf Browser-Modus');
 }
@@ -13962,10 +13975,41 @@ function quickAddLevel(chapterName) {
             if (window.electronAPI && window.electronAPI.saveDeFile) {
                 const buffer = await datei.arrayBuffer();
                 await window.electronAPI.saveDeFile(zielPfad, new Uint8Array(buffer));
+                // Bereits vorhandene Sicherung loeschen und aktuelle Datei sichern
+                if (window.electronAPI.deleteDeBackupFile) {
+                    await window.electronAPI.deleteDeBackupFile(zielPfad);
+                }
+                if (window.electronAPI.backupDeFile) {
+                    await window.electronAPI.backupDeFile(zielPfad);
+                }
                 deAudioCache[zielPfad] = `sounds/DE/${zielPfad}`;
                 await updateHistoryCache(zielPfad);
             } else {
                 await speichereUebersetzungsDatei(datei, zielPfad);
+                // Ohne Electron das Backup manuell aktualisieren
+                if (deOrdnerHandle) {
+                    try {
+                        const teile = zielPfad.split('/');
+                        const name = teile.pop();
+                        let ordner = deOrdnerHandle;
+                        for (const t of teile) {
+                            ordner = await ordner.getDirectoryHandle(t, { create: true });
+                        }
+                        const backupRoot = await deOrdnerHandle.getDirectoryHandle('..', {});
+                        const backupDir = await backupRoot.getDirectoryHandle('DE-Backup', { create: true });
+                        let ziel = backupDir;
+                        for (const t of teile) {
+                            ziel = await ziel.getDirectoryHandle(t, { create: true });
+                        }
+                        try { await ziel.removeEntry(name); } catch {}
+                        const orgFile = await ordner.getFileHandle(name);
+                        const orgData = await orgFile.getFile();
+                        const backupFile = await ziel.getFileHandle(name, { create: true });
+                        const w = await backupFile.createWritable();
+                        await w.write(orgData);
+                        await w.close();
+                    } catch {}
+                }
             }
             if (f) {
                 // Versionsnummer automatisch erhöhen, falls bereits Datei vorhanden


### PR DESCRIPTION
## Summary
- sichere LocalStorage- und Window-Fallbacks fuer Node
- verhindere Fetch-Aufruf im Node-Modus
- dokumentiere Node-kompatiblen Start im README
- ergaenze Changelog um Patch-Hinweis
- gptService prueft jetzt auch NodeIntegration und nutzt im Electron-Renderer wieder Fetch

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688bda80f0f083279c6b3db2018a68b9