### PR TITLE
Fix: Tempo-Regler beim ZIP-Import zurücksetzen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,8 @@
 * "Verbessern" berücksichtigt nun den gesamten Kontext, zeigt eine Ladeanimation am Knopf und der Dialog besitzt ein überarbeitetes Layout.
 ## 🛠 Patch in 1.40.144
 * Anpassen-Kürzen sorgt nun dafür, dass die deutsche Variante die Länge der EN-Aufnahme nie unterschreitet.
+## 🛠 Patch in 1.40.145
+* ZIP-Import setzt den Tempo-Regler jeder importierten Zeile wieder auf 1,0.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Bugfix:** Wird eine Audiodatei stärker gekürzt als ihre Länge, führt dies nicht mehr zu einer DOMException.
 * **Zurücksetzen nach Upload oder Dubbing:** Sowohl beim Hochladen als auch beim erneuten Erzeugen einer deutschen Audiodatei werden Lautstärkeangleichung, Funkgerät‑Effekt und Hall‑Effekt automatisch deaktiviert.
 * **Tempo-Regler zurückgesetzt:** Nach einem Upload steht der Geschwindigkeitsregler wieder auf 1,00.
+* **Tempo-Regler auch beim ZIP-Import auf 1,00:** Beim Import mehrerer Dateien per ZIP wird der Geschwindigkeitsregler jeder Zeile auf den Standardwert gesetzt.
 * **Backup bleibt beim Speichern erhalten:** Nur ein neuer Upload ersetzt die Sicherung in `DE-Backup`. "🔄 Zurücksetzen" stellt dadurch stets die zuletzt geladene Originaldatei wieder her.
 * **ZIP-Import aktualisiert das Backup:** Auch importierte ZIP-Dateien gelten nun als Original und lassen sich über "🔄 Zurücksetzen" wiederherstellen.
 * **Hall-Effekt wird beim Dubbing zurückgesetzt.**

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -10501,6 +10501,8 @@ async function applyZipImport(zipFiles) {
         if (!window.electronAPI.fsExists(full)) continue;
         const data = window.electronAPI.fsReadFile(full);
         const blob = new Blob([new Uint8Array(data)]);
+        // Tempo-Faktor der Zeile zurücksetzen, damit der Regler nach dem Import auf 1,0 steht
+        files[i].tempoFactor = 1.0;
         await uploadDeFile(blob, rel);
     }
     showToast(`${zipFiles.length} Dateien importiert`);


### PR DESCRIPTION
## Zusammenfassung
- Setzt bei ZIP-Import den Tempo-Faktor jeder Zeile auf 1,0
- Ergänzt Dokumentation zu zurückgesetztem Tempo-Regler bei ZIP-Import
- Vermerkt Bugfix im Changelog

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688deba9c6a083279aef26b7e674ea70