### PR TITLE
Verbesserungsvorschläge berücksichtigen EN-Länge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,8 @@
 * Anpassen-Kürzen sorgt nun dafür, dass die deutsche Variante die Länge der EN-Aufnahme nie unterschreitet.
 ## 🛠 Patch in 1.40.145
 * ZIP-Import setzt den Tempo-Regler jeder importierten Zeile wieder auf 1,0.
+## 🛠 Patch in 1.40.146
+* Button "Verbesserungsvorschläge" öffnet einen Dialog mit drei Alternativen, die Länge und Sprechzeit des englischen Originals berücksichtigen.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Direkter Daten-Refresh:** Nach jeder Bewertung wird die Tabelle mit den aktualisierten Dateien neu gerendert
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
 * **Feste Schriftfarben:** Gelber Score nutzt schwarze Schrift, rot und gruen weiss
+* **Verbesserungsvorschläge berücksichtigen Länge:** Der Knopf "Verbesserungsvorschläge" öffnet einen Dialog mit drei Alternativen, die sich an Länge und geschätzter Sprechzeit des englischen Originals orientieren
 * **Bereinigte Vorschau-Anzeige:** Leere GPT-Vorschläge lassen keinen zusätzlichen Abstand mehr
 * **Kommentar über dem Vorschlag:** Ist ein Kommentar vorhanden, erscheint er in weißer Schrift direkt über der farbigen Box
 * **Einheitliche GPT-Vorschau:** Der farbige Vorschlagsbalken ist nun direkt klickbar und es gibt nur noch einen Tooltip

--- a/web/src/gptService.js
+++ b/web/src/gptService.js
@@ -270,7 +270,8 @@ async function improveEmotionText({ meta, lines, targetPosition, currentText, cu
         target_position: targetPosition,
         current_text: currentText,
         current_translation: currentTranslation,
-        instructions: 'Analysiere die gesamte Übersetzung und schlage genau drei alternative deutsche Fassungen vor. Jede Variante soll den englischen Originaltext besser wiedergeben, alle Emotionstags beibehalten und nicht kürzer sein. Gib ein Array [{"text":"...","reason":"..."}] zurück und begründe kurz die Verbesserungen.'
+        // LLM soll Alternativen liefern, die Länge und Sprechzeit des EN-Texts beachten
+        instructions: 'Analysiere die gesamte Übersetzung und schlage genau drei alternative deutsche Fassungen vor. Jede Variante soll den englischen Originaltext besser wiedergeben, alle Emotionstags beibehalten und ungefähr die gleiche Länge sowie geschätzte Sprechdauer wie der englische Text haben. Vermeide längere Formulierungen. Gib ein Array [{"text":"...","reason":"..."}] zurück und begründe kurz die Verbesserungen.'
     };
     const messages = [
         { role: 'system', content: emotionPrompt },

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -3075,7 +3075,7 @@ function addFiles() {
             btn.disabled = false;
         }
 
-        // Analysiert Übersetzung und Emotional-Text und schlägt Alternativen vor
+        // Analysiert Übersetzung und Emotional-Text und zeigt Verbesserungsvorschläge im Dialog
         async function improveEmotionalText(rowId) {
             const row = document.querySelector(`tr[data-id='${rowId}']`);
             const area = row?.querySelector('textarea.emotional-text');
@@ -3715,7 +3715,7 @@ return `
                 <div class="btn-column">
                     <button class="generate-emotions-btn" onclick="generateEmotionalText(${file.id})">Emotional-Text (DE) generieren</button>
                     <button class="adjust-emotions-btn" onclick="adjustEmotionalText(${file.id})">Anpassen-Kürzen</button>
-                    <button class="improve-emotions-btn" onclick="improveEmotionalText(${file.id})">Verbessern</button>
+                    <button class="improve-emotions-btn" onclick="improveEmotionalText(${file.id})">Verbesserungsvorschläge</button>
                     <button class="copy-emotional-text" onclick="copyEmotionalText(${file.id})" title="In Zwischenablage kopieren">📋</button>
                 </div>
             </div>


### PR DESCRIPTION
## Zusammenfassung
- Verbessertes LLM-Prompt: Vorschläge halten nun Länge und Sprechzeit des englischen Textes ein
- Button in der Oberfläche als "Verbesserungsvorschläge" umbenannt
- Dokumentation und Changelog angepasst

## Testen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e3fe244c883278bf10ccd6a274417