### PR TITLE
Zeilennavigation über neue ▲/▼-Knöpfe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,8 @@
 * ZIP-Import setzt den Tempo-Regler jeder importierten Zeile wieder auf 1,0.
 ## 🛠 Patch in 1.40.146
 * Button "Verbesserungsvorschläge" öffnet einen Dialog mit drei Alternativen, die Länge und Sprechzeit des englischen Originals berücksichtigen.
+## 🛠 Patch in 1.40.147
+* ▲/▼-Knöpfe neben ▶/⏹ springen zur nächsten oder vorherigen Nummer und merken die letzte Position.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Fortschrittsanzeige** beim automatischen Übersetzen aller fehlenden Texte
 * **Lade-Indikator für Übersetzungen:** Jede Anfrage zeigt nun einen Spinner und das Ergebnis kommt über das IPC-Event `translate-finished`
 * **Projekt-Playback:** ▶/⏸/⏹ spielt verfügbare DE-Dateien nacheinander ab
+* **Numerische Navigation:** ▲/▼ neben den Playback-Knöpfen springen zur nächsten oder vorherigen Nummer und merken die Position
 * **Feste Reihenfolge:** Beim Projekt-Playback wird die Dateiliste strikt von oben nach unten abgespielt, unabhängig vom Dateityp
 * **Stabileres Audio-Playback:** Unterbrochene Wiedergabe erzeugt keine Fehlermeldungen mehr
 * **Fehlerhinweis bei der Bearbeitungs-Vorschau:** Schlägt das Abspielen fehl, erscheint jetzt eine Meldung
@@ -663,6 +664,7 @@ Auch Kapitel und Level bieten dieses Rechtsklick-Menü.
 | -------------------------- | ----------------------------------------------- |
 | **Audio abspielen**       | ▶ Button oder Leertaste (bei ausgewaehlter Zeile) |
 | **Projekt-Playback**      | ▶/⏸/⏹ spielt vorhandene DE-Dateien der Reihe nach |
+| **Zur nächsten Nummer**   | ▲/▼ neben ▶/⏹ springen eine Zeile weiter oder zurück |
 | **Audio im Textfeld**     | `Ctrl + Leertaste` |
 | **Text kopieren**         | 📋 Button neben Textfeld |
 | **Zwischen Feldern**      | `Tab` / `Shift + Tab` |

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -137,6 +137,8 @@
                 <div class="project-playback">
                     <button id="projectPlayPauseBtn" onclick="toggleProjectPlayback()">▶</button>
                     <button id="projectStopBtn" onclick="stopProjectPlayback()">⏹</button>
+                    <button id="numberPrevBtn" onclick="goToPreviousNumber()" title="Eine Nummer zurück">▲</button>
+                    <button id="numberNextBtn" onclick="goToNextNumber()" title="Eine Nummer weiter">▼</button>
                 </div>
             </div>
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -136,6 +136,7 @@ let levelChapters         = {}; // Zuordnung Level → Kapitel
 let chapterOrders         = {}; // Reihenfolge der Kapitel
 let expandedChapter       = null; // aktuell geöffnetes Kapitel
 let chapterColors         = {}; // Farbe pro Kapitel
+let currentRowNumber      = 1;  // Merkt die aktuelle Zeilennummer im Projekt
 
 // Status für Projekt-Wiedergabe
 let projectPlayState       = 'stopped'; // 'playing', 'paused'
@@ -1415,6 +1416,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
 });
+// Scroll-Listener zur Aktualisierung der aktuellen Zeilennummer
+document.addEventListener('DOMContentLoaded', () => {
+    const container = document.querySelector('.table-container');
+    if (container) container.addEventListener('scroll', updateNumberFromScroll);
+});
 // =========================== DOM READY INITIALISIERUNG ENDE ===========================
 
 
@@ -2239,6 +2245,8 @@ function selectProject(id){
     segmentAssignments = currentProject.segmentAssignments || {};
     ignoredSegments = new Set(currentProject.segmentIgnored || []);
     segmentSelection = [];
+    // Letzte bearbeitete Zeile für dieses Projekt laden
+    currentRowNumber = parseInt(localStorage.getItem('hla_lastNumber_' + currentProject.id) || '1');
 
     // Migration: completed-Flag nachziehen
     let migrated=false;
@@ -2897,6 +2905,58 @@ function addFiles() {
             if (selectedRow) {
                 selectedRow.classList.add('selected-row');
                 selectedRow.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            }
+        }
+
+        // ======= Zeilennavigation über Nummern =======
+        function getRowByNumber(num) {
+            const rows = document.querySelectorAll('#fileTableBody tr');
+            for (const row of rows) {
+                const cell = row.querySelector('.row-number');
+                if (cell && parseInt(cell.textContent) === num) return row;
+            }
+            return null;
+        }
+
+        function scrollToNumber(num) {
+            if (!files.length) return;
+            num = Math.max(1, Math.min(num, files.length));
+            const row = getRowByNumber(num);
+            if (row) {
+                row.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                currentRowNumber = num;
+                if (currentProject) {
+                    localStorage.setItem('hla_lastNumber_' + currentProject.id, num);
+                }
+            }
+        }
+
+        function goToNextNumber() {
+            scrollToNumber(currentRowNumber + 1);
+        }
+
+        function goToPreviousNumber() {
+            scrollToNumber(currentRowNumber - 1);
+        }
+
+        function updateNumberFromScroll() {
+            const container = document.querySelector('.table-container');
+            if (!container) return;
+            const containerTop = container.getBoundingClientRect().top;
+            const rows = container.querySelectorAll('#fileTableBody tr');
+            for (const row of rows) {
+                const rect = row.getBoundingClientRect();
+                if (rect.bottom >= containerTop) {
+                    const cell = row.querySelector('.row-number');
+                    if (cell) {
+                        const num = parseInt(cell.textContent, 10);
+                        currentRowNumber = num;
+                        if (currentProject) {
+                            localStorage.setItem('hla_lastNumber_' + currentProject.id, num);
+                        }
+                    }
+                    break;
+                }
             }
         }
 
@@ -3776,11 +3836,13 @@ return `
     // Tooltip- und Klicklogik auslagern
     // Bindet Tooltip und Klick auf die Score-Zellen und stellt die CSS-Klassen sicher
     attachScoreHandlers(tbody, files);
-    
+
     addDragAndDropHandlers();
     addPathCellContextMenus();
     updateCounts();
     updateDubButtons();
+    // Nach dem Rendern zur gemerkten Zeile springen
+    scrollToNumber(currentRowNumber);
 
     // Nach dem Rendern Textfelder und Übersetzungsanzeige anpassen
     setTimeout(() => {


### PR DESCRIPTION
## Zusammenfassung
- Buttons ▲/▼ neben den Projekt-Playback-Knöpfen springen zur nächsten oder vorherigen Nummer
- Letzte Zeilennummer wird projektbezogen gespeichert und beim Start wiederhergestellt
- Nummer wird beim Scrollen aktualisiert und im LocalStorage gesichert

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f10b748808327ac35e669cb18a4bc