### PR TITLE
Debug-Konsole standardmäßig versteckt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,8 @@
 * ▲/▼-Knöpfe neben ▶/⏹ springen zur nächsten oder vorherigen Nummer und merken die letzte Position.
 ## 🛠 Patch in 1.40.148
 * Beim Scrollen bleibt die aktuelle Zeile am Tabellenkopf fixiert und wird dezent hervorgehoben.
+## 🛠 Patch in 1.40.149
+* Debug-Konsole ist nun standardmäßig ausgeblendet und erscheint nur bei Entwickleraktionen.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.148-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.149-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -879,7 +879,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **🔍 Debug‑Spalte:** Zeigt aufgelöste Pfade und Status
 * **📊 Datenquellen‑Analyse:** Console‑Logs für Entwickler
 * **🎯 Access‑Status:** Echtzeit‑Anzeige der Dateiberechtigungen
-* **🔧 Debug-Konsole:** Über das Dropdown "Debug-Konsole" können Sie Logs einsehen. In der Desktop-Version öffnen sich die DevTools jetzt automatisch in einem separaten Fenster oder per `Ctrl+Shift+I`.
+* **🔧 Debug-Konsole:** Diese Konsole ist standardmäßig verborgen und erscheint nur bei Entwickleraktionen (z. B. Dev-Button). In der Desktop-Version öffnen sich die DevTools automatisch in einem separaten Fenster oder per `Ctrl+Shift+I`.
 * **💡 Neues Debug-Fenster:** Gruppiert System- und Pfadinformationen übersichtlich und bietet eine Kopierfunktion.
 * **📦 Modul-Status:** Neue Spalte im Debug-Fenster zeigt, ob alle Module korrekt geladen wurden und aus welcher Quelle sie stammen.
 * **🖥️ Erweiterte Systemdaten:** Das Debug-Fenster zeigt jetzt Betriebssystem, CPU-Modell und freien Arbeitsspeicher an.

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla-translation-desktop",
-  "version": "1.40.148",
+  "version": "1.40.149",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla-translation-desktop",
-      "version": "1.40.148",
+      "version": "1.40.149",
       "dependencies": {
         "archiver": "^6.0.2",
         "chokidar": "^4.0.3"

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla-translation-desktop",
-  "version": "1.40.148",
+  "version": "1.40.149",
   "main": "main.js",
   "scripts": {
     "start": "electron ."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.40.148",
+  "version": "1.40.149",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hla_translation_tool",
-      "version": "1.40.148",
+      "version": "1.40.149",
       "dependencies": {
         "7zip-bin": "^5.2.0",
         "archiver": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hla_translation_tool",
-  "version": "1.40.148",
+  "version": "1.40.149",
   "devDependencies": {
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -842,8 +842,8 @@
     <input type="file" id="zipImportInput" style="display:none" accept=".zip" onchange="handleZipImport(this)">
     <input type="file" id="backupUploadInput" style="display:none" accept=".json" onchange="handleBackupUpload(this)">
 
-    <!-- Umschaltbare Debug-Konsole -->
-    <details id="debugConsoleWrapper" style="margin:10px 0;">
+    <!-- Umschaltbare Debug-Konsole (standardmäßig versteckt) -->
+    <details id="debugConsoleWrapper" style="margin:10px 0; display:none;">
         <summary>🛠️ Debug-Konsole</summary>
         <button class="btn btn-secondary" onclick="showFolderDebug()">🐞 Ordner prüfen</button>
         <div id="folderDebug" style="margin:10px 0;"></div>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -6598,7 +6598,8 @@ function cleanupIncorrectFolderNames() {
 // Ordner. Fehlende Ordner lassen sich direkt löschen.
 function showFolderDebug() {
     const wrapper = document.getElementById('debugConsoleWrapper');
-    wrapper.open = true;
+    wrapper.style.display = 'block'; // Debug-Konsole einblenden
+    wrapper.open = true; // Bereich aufklappen
 
     const listDiv = document.getElementById('folderDebug');
     if (!listDiv) return;
@@ -9744,6 +9745,7 @@ async function scanAudioDuplicates() {
         function toggleDevTools() {
             const wrapper = document.getElementById('debugConsoleWrapper');
             if (wrapper) {
+                wrapper.style.display = 'block'; // Debug-Konsole sichtbar machen
                 wrapper.open = true; // Zeigt die eingebettete Konsole an
             }
             debugLog('Dev-Button aktiviert');


### PR DESCRIPTION
## Zusammenfassung
- Debug-Konsole ist jetzt im HTML standardmäßig ausgeblendet und wird nur bei Bedarf geöffnet.
- `showFolderDebug` und `toggleDevTools` blenden die Konsole ein, bevor sie geöffnet wird.
- README, CHANGELOG und Versionsnummer wurden aktualisiert.

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f1dc1503c8327beb2dc52e60d0b1c