### PR TITLE
Nummernnavigation zentriert Zeilen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,8 @@
 * Beim Scrollen bleibt die aktuelle Zeile am Tabellenkopf fixiert und wird dezent hervorgehoben.
 ## 🛠 Patch in 1.40.149
 * Debug-Konsole ist nun standardmäßig ausgeblendet und erscheint nur bei Entwickleraktionen.
+## 🛠 Patch in 1.40.150
+* ▲/▼-Knöpfe zentrieren die gewählte Zeile nun in der Tabellenmitte.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Fortschrittsanzeige** beim automatischen Übersetzen aller fehlenden Texte
 * **Lade-Indikator für Übersetzungen:** Jede Anfrage zeigt nun einen Spinner und das Ergebnis kommt über das IPC-Event `translate-finished`
 * **Projekt-Playback:** ▶/⏸/⏹ spielt verfügbare DE-Dateien nacheinander ab
-* **Numerische Navigation:** ▲/▼ neben den Playback-Knöpfen springen zur nächsten oder vorherigen Nummer und merken die Position
+* **Numerische Navigation:** ▲/▼ neben den Playback-Knöpfen springen zur nächsten oder vorherigen Nummer, zentrieren die Zeile in der Tabelle und merken die Position
 * **Aktuelle Zeile angeheftet:** Beim Scrollen bleibt die oberste Zeile direkt unter der Überschrift stehen und ist dezent markiert
 * **Feste Reihenfolge:** Beim Projekt-Playback wird die Dateiliste strikt von oben nach unten abgespielt, unabhängig vom Dateityp
 * **Stabileres Audio-Playback:** Unterbrochene Wiedergabe erzeugt keine Fehlermeldungen mehr
@@ -665,7 +665,7 @@ Auch Kapitel und Level bieten dieses Rechtsklick-Menü.
 | -------------------------- | ----------------------------------------------- |
 | **Audio abspielen**       | ▶ Button oder Leertaste (bei ausgewaehlter Zeile) |
 | **Projekt-Playback**      | ▶/⏸/⏹ spielt vorhandene DE-Dateien der Reihe nach |
-| **Zur nächsten Nummer**   | ▲/▼ neben ▶/⏹ springen eine Zeile weiter oder zurück |
+| **Zur nächsten Nummer**   | ▲/▼ neben ▶/⏹ springen eine Zeile weiter oder zurück und zentrieren diese |
 | **Audio im Textfeld**     | `Ctrl + Leertaste` |
 | **Text kopieren**         | 📋 Button neben Textfeld |
 | **Zwischen Feldern**      | `Tab` / `Shift + Tab` |

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2930,12 +2930,21 @@ function addFiles() {
             }
         }
 
+        // Springt zu einer bestimmten Nummer und zentriert die Zeile im sichtbaren Bereich
         function scrollToNumber(num) {
             if (!files.length) return;
             num = Math.max(1, Math.min(num, files.length));
             const row = getRowByNumber(num);
             if (row) {
-                row.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                const container = document.querySelector('.table-container');
+                if (container) {
+                    // Berechne Scrollposition so, dass die Zeile in der Mitte steht
+                    const offset = row.offsetTop - container.offsetTop;
+                    const target = offset - (container.clientHeight / 2 - row.clientHeight / 2);
+                    container.scrollTo({ top: target, behavior: 'smooth' });
+                } else {
+                    row.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
                 setActiveRow(row);
                 currentRowNumber = num;
                 if (currentProject) {
@@ -2952,14 +2961,16 @@ function addFiles() {
             scrollToNumber(currentRowNumber - 1);
         }
 
+        // Aktualisiert die aktuelle Nummer anhand der scrollbaren Tabellenmitte
         function updateNumberFromScroll() {
             const container = document.querySelector('.table-container');
             if (!container) return;
             const containerTop = container.getBoundingClientRect().top;
+            const containerCenter = containerTop + container.clientHeight / 2;
             const rows = container.querySelectorAll('#fileTableBody tr');
             for (const row of rows) {
                 const rect = row.getBoundingClientRect();
-                if (rect.bottom >= containerTop) {
+                if (rect.top <= containerCenter && rect.bottom >= containerCenter) {
                     const cell = row.querySelector('.row-number');
                     if (cell) {
                         const num = parseInt(cell.textContent, 10);


### PR DESCRIPTION
## Zusammenfassung
- Zeilensprung über ▲/▼ zentriert die markierte Zeile nun automatisch in der Tabelle.
- Anpassung verfolgt dynamisch die Bildschirmhöhe für optimale Sichtbarkeit.
- Dokumentation und Changelog entsprechend aktualisiert.

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f206cda7083278165a069a15d710f