### PR TITLE
Fix fast downward navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,8 @@
 * Debug-Konsole ist nun standardmäßig ausgeblendet und erscheint nur bei Entwickleraktionen.
 ## 🛠 Patch in 1.40.150
 * ▲/▼-Knöpfe zentrieren die gewählte Zeile nun in der Tabellenmitte.
+## 🛠 Patch in 1.40.151
+* Schnelle Klicks auf den ▼-Knopf springen nun zuverlässig zur nächsten Nummer, ohne wieder hochzuspringen.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Fortschrittsanzeige** beim automatischen Übersetzen aller fehlenden Texte
 * **Lade-Indikator für Übersetzungen:** Jede Anfrage zeigt nun einen Spinner und das Ergebnis kommt über das IPC-Event `translate-finished`
 * **Projekt-Playback:** ▶/⏸/⏹ spielt verfügbare DE-Dateien nacheinander ab
-* **Numerische Navigation:** ▲/▼ neben den Playback-Knöpfen springen zur nächsten oder vorherigen Nummer, zentrieren die Zeile in der Tabelle und merken die Position
+* **Numerische Navigation:** ▲/▼ neben den Playback-Knöpfen springen zur nächsten oder vorherigen Nummer, zentrieren die Zeile in der Tabelle und merken die Position. Schnelle Klicks nach unten funktionieren jetzt ebenfalls ohne Zurückspringen
 * **Aktuelle Zeile angeheftet:** Beim Scrollen bleibt die oberste Zeile direkt unter der Überschrift stehen und ist dezent markiert
 * **Feste Reihenfolge:** Beim Projekt-Playback wird die Dateiliste strikt von oben nach unten abgespielt, unabhängig vom Dateityp
 * **Stabileres Audio-Playback:** Unterbrochene Wiedergabe erzeugt keine Fehlermeldungen mehr
@@ -665,7 +665,7 @@ Auch Kapitel und Level bieten dieses Rechtsklick-Menü.
 | -------------------------- | ----------------------------------------------- |
 | **Audio abspielen**       | ▶ Button oder Leertaste (bei ausgewaehlter Zeile) |
 | **Projekt-Playback**      | ▶/⏸/⏹ spielt vorhandene DE-Dateien der Reihe nach |
-| **Zur nächsten Nummer**   | ▲/▼ neben ▶/⏹ springen eine Zeile weiter oder zurück und zentrieren diese |
+| **Zur nächsten Nummer**   | ▲/▼ neben ▶/⏹ springen eine Zeile weiter oder zurück, zentrieren die Zeile und reagieren nun auch bei schnellen Klicks zuverlässig |
 | **Audio im Textfeld**     | `Ctrl + Leertaste` |
 | **Text kopieren**         | 📋 Button neben Textfeld |
 | **Zwischen Feldern**      | `Tab` / `Shift + Tab` |

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -138,6 +138,8 @@ let expandedChapter       = null; // aktuell geöffnetes Kapitel
 let chapterColors         = {}; // Farbe pro Kapitel
 let currentRowNumber      = 1;  // Merkt die aktuelle Zeilennummer im Projekt
 let currentRowElement     = null; // HTML-Element der aktuell markierten Zeile
+let isAutoScrolling       = false; // Wahr, solange ein automatischer Scroll läuft
+let autoScrollTimeout     = null;  // Timer zum Zurücksetzen von isAutoScrolling
 
 // Status für Projekt-Wiedergabe
 let projectPlayState       = 'stopped'; // 'playing', 'paused'
@@ -2934,6 +2936,8 @@ function addFiles() {
         function scrollToNumber(num) {
             if (!files.length) return;
             num = Math.max(1, Math.min(num, files.length));
+            isAutoScrolling = true;
+            if (autoScrollTimeout) clearTimeout(autoScrollTimeout);
             const row = getRowByNumber(num);
             if (row) {
                 const container = document.querySelector('.table-container');
@@ -2951,6 +2955,7 @@ function addFiles() {
                     localStorage.setItem('hla_lastNumber_' + currentProject.id, num);
                 }
             }
+            autoScrollTimeout = setTimeout(() => { isAutoScrolling = false; }, 300);
         }
 
         function goToNextNumber() {
@@ -2963,6 +2968,7 @@ function addFiles() {
 
         // Aktualisiert die aktuelle Nummer anhand der scrollbaren Tabellenmitte
         function updateNumberFromScroll() {
+            if (isAutoScrolling) return; // Ignoriere Scroll-Events während automatischem Scrollen
             const container = document.querySelector('.table-container');
             if (!container) return;
             const containerTop = container.getBoundingClientRect().top;


### PR DESCRIPTION
## Summary
- verhindern, dass automatische Scroll-Events die Zeilennummer zurücksetzen
- Dokumentation für schnelle Nummernwechsel ergänzt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f2350a04083279d7b19615d068061