### PR TITLE
Zeilennavigation zentriert auf Bildschirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,8 @@
 * ▲/▼-Knöpfe zentrieren die gewählte Zeile nun in der Tabellenmitte.
 ## 🛠 Patch in 1.40.151
 * Schnelle Klicks auf den ▼-Knopf springen nun zuverlässig zur nächsten Nummer, ohne wieder hochzuspringen.
+## 🛠 Patch in 1.40.152
+* ▲/▼-Knöpfe richten die gewählte Zeile jetzt an der Bildschirmmitte aus. Beim Scrollen mit dem Mausrad wird automatisch die Zeile in der Mitte des Monitors markiert, ohne den Scrollpunkt zu verändern.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Fortschrittsanzeige** beim automatischen Übersetzen aller fehlenden Texte
 * **Lade-Indikator für Übersetzungen:** Jede Anfrage zeigt nun einen Spinner und das Ergebnis kommt über das IPC-Event `translate-finished`
 * **Projekt-Playback:** ▶/⏸/⏹ spielt verfügbare DE-Dateien nacheinander ab
-* **Numerische Navigation:** ▲/▼ neben den Playback-Knöpfen springen zur nächsten oder vorherigen Nummer, zentrieren die Zeile in der Tabelle und merken die Position. Schnelle Klicks nach unten funktionieren jetzt ebenfalls ohne Zurückspringen
+* **Numerische Navigation:** ▲/▼ neben den Playback-Knöpfen springen zur nächsten oder vorherigen Nummer, zentrieren die Zeile stets in der Mitte des Bildschirms und merken die Position. Beim Scrollen mit dem Mausrad wird automatisch die Zeile in Bildschirmmitte markiert, ohne die Ausrichtung zu verändern. Schnelle Klicks nach unten funktionieren jetzt ebenfalls ohne Zurückspringen
 * **Aktuelle Zeile angeheftet:** Beim Scrollen bleibt die oberste Zeile direkt unter der Überschrift stehen und ist dezent markiert
 * **Feste Reihenfolge:** Beim Projekt-Playback wird die Dateiliste strikt von oben nach unten abgespielt, unabhängig vom Dateityp
 * **Stabileres Audio-Playback:** Unterbrochene Wiedergabe erzeugt keine Fehlermeldungen mehr
@@ -315,6 +315,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Schnell hinzufügen:** Rechtsklick auf Level → Schnellprojekt, Rechtsklick auf Kapitel → Schnell‑Level
 * **Drag & Drop:** Projekte und Dateien sortieren
 * **Klick auf Zeilennummer:** Position über Dialog anpassen
+* **Mausrad:** Markiert beim Scrollen automatisch die Zeile in der Bildschirmmitte, ohne sie neu auszurichten
 * **Doppelklick:** Projekt umbenennen
 
 ---
@@ -665,7 +666,7 @@ Auch Kapitel und Level bieten dieses Rechtsklick-Menü.
 | -------------------------- | ----------------------------------------------- |
 | **Audio abspielen**       | ▶ Button oder Leertaste (bei ausgewaehlter Zeile) |
 | **Projekt-Playback**      | ▶/⏸/⏹ spielt vorhandene DE-Dateien der Reihe nach |
-| **Zur nächsten Nummer**   | ▲/▼ neben ▶/⏹ springen eine Zeile weiter oder zurück, zentrieren die Zeile und reagieren nun auch bei schnellen Klicks zuverlässig |
+| **Zur nächsten Nummer**   | ▲/▼ neben ▶/⏹ springen eine Zeile weiter oder zurück und zentrieren die gewählte Zeile auf dem Bildschirm; das Mausrad markiert nur die Zeile in der Bildschirmmitte, ohne die Position zu verändern. Schnelle Klicks funktionieren weiterhin zuverlässig |
 | **Audio im Textfeld**     | `Ctrl + Leertaste` |
 | **Text kopieren**         | 📋 Button neben Textfeld |
 | **Zwischen Feldern**      | `Tab` / `Shift + Tab` |

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2932,7 +2932,7 @@ function addFiles() {
             }
         }
 
-        // Springt zu einer bestimmten Nummer und zentriert die Zeile im sichtbaren Bereich
+        // Springt zu einer bestimmten Nummer und zentriert die Zeile auf dem Bildschirm
         function scrollToNumber(num) {
             if (!files.length) return;
             num = Math.max(1, Math.min(num, files.length));
@@ -2942,9 +2942,14 @@ function addFiles() {
             if (row) {
                 const container = document.querySelector('.table-container');
                 if (container) {
-                    // Berechne Scrollposition so, dass die Zeile in der Mitte steht
-                    const offset = row.offsetTop - container.offsetTop;
-                    const target = offset - (container.clientHeight / 2 - row.clientHeight / 2);
+                    // Ziel so berechnen, dass die Zeile mittig im sichtbaren Bereich des Monitors erscheint
+                    const containerRect = container.getBoundingClientRect();
+                    const rowRect = row.getBoundingClientRect();
+                    const viewportCenter = window.innerHeight / 2;
+                    const currentScroll = container.scrollTop;
+                    // Abstand der Zeilenmitte relativ zum Container plus aktueller Scroll
+                    const rowCenterOffset = rowRect.top - containerRect.top + rowRect.height / 2;
+                    const target = currentScroll + rowCenterOffset - viewportCenter;
                     container.scrollTo({ top: target, behavior: 'smooth' });
                 } else {
                     row.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -2966,17 +2971,16 @@ function addFiles() {
             scrollToNumber(currentRowNumber - 1);
         }
 
-        // Aktualisiert die aktuelle Nummer anhand der scrollbaren Tabellenmitte
+        // Aktualisiert die aktuelle Nummer anhand der Bildschirmmitte beim manuellen Scrollen
         function updateNumberFromScroll() {
             if (isAutoScrolling) return; // Ignoriere Scroll-Events während automatischem Scrollen
             const container = document.querySelector('.table-container');
             if (!container) return;
-            const containerTop = container.getBoundingClientRect().top;
-            const containerCenter = containerTop + container.clientHeight / 2;
+            const viewportCenter = window.innerHeight / 2;
             const rows = container.querySelectorAll('#fileTableBody tr');
             for (const row of rows) {
                 const rect = row.getBoundingClientRect();
-                if (rect.top <= containerCenter && rect.bottom >= containerCenter) {
+                if (rect.top <= viewportCenter && rect.bottom >= viewportCenter) {
                     const cell = row.querySelector('.row-number');
                     if (cell) {
                         const num = parseInt(cell.textContent, 10);


### PR DESCRIPTION
## Zusammenfassung
- Zeilen springen bei ▲/▼ immer in die Bildschirmmitte
- Scrollrad markiert automatisch die gerade mittige Zeile, ohne den Bildlauf zu ändern
- Dokumentation und Changelog aktualisiert

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f276d34d48327bb708f493c2fd680