### PR TITLE
Längenvergleich für bearbeitete Audios ergänzen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,8 @@
 * ▲/▼-Knöpfe richten die gewählte Zeile jetzt an der Bildschirmmitte aus. Beim Scrollen mit dem Mausrad wird automatisch die Zeile in der Mitte des Monitors markiert, ohne den Scrollpunkt zu verändern.
 ## 🛠 Patch in 1.40.153
 * Ein-Nummer-Zurück/Vor zeigt Nummer, Dateiname und Ordner stets vollständig unter dem Tabellenkopf an.
+## 🛠 Patch in 1.40.154
+* Längen-Vergleich zeigt nun zusätzlich, ob die bearbeitete deutsche Datei länger, kürzer oder gleich lang wie das englische Original ist.
 ## ✨ Neue Features in 1.38.0
 * Neues Skript `check_environment.js` prueft Node-Version, installiert Abhaengigkeiten und startet einen Electron-Testlauf.
 

--- a/README.md
+++ b/README.md
@@ -819,7 +819,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 
 * **🧠 Smart Folder Detection:** Erkennt Half‑Life Charaktere automatisch
 * **📏 Auto‑Height Textboxen:** EN/DE Felder bleiben höhengleich
-* **📐 Längen-Vergleich:** Farbige Symbole zeigen, ob die deutsche Audiodatei kürzer (grün) oder länger (rot) als das englische Original ist
+* **📐 Längen-Vergleich:** Zwei farbige Symbole zeigen, ob die ursprüngliche und die bearbeitete deutsche Audiodatei kürzer (grün), länger (rot) oder gleich lang wie das englische Original sind
 * **🎨 Theme‑System:** Automatische Icon‑ und Farb‑Zuweisungen
 * **💡 Context‑Awareness:** Funktionen passen sich dem aktuellen Kontext an
 * **🔄 Dateinamen-Prüfung:** Klick auf den Dateinamen öffnet einen Dialog mit passenden Endungen

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -3703,24 +3703,43 @@ async function renderFileTableWithOrder(sortedFiles) {
         const dePath = getDeFilePath(file);
         const hasDeAudio = !!dePath;
         const hasHistory = await checkHistoryAvailable(file);
-        // Symbol und Farbe für den Längenvergleich vorbereiten
-        let lengthIndicator = '';
-        let lengthClass = '';
+        // Symbole und Farben für Längenvergleich vorbereiten
+        let lengthIndicatorOrig = '';
+        let lengthClassOrig = '';
+        let lengthIndicatorEdit = '';
+        let lengthClassEdit = '';
         if (hasDeAudio) {
+            // Pfade zu EN, DE (bearbeitet) und DE-Backup
             const enUrl = audioFileCache[relPath] || `sounds/EN/${relPath}`;
             const deUrl = deAudioCache[dePath] || `sounds/DE/${dePath}`;
+            const deBackupUrl = `sounds/DE-Backup/${dePath}`;
             const enDur = await getAudioDuration(enUrl);
-            const deDur = await getAudioDuration(deUrl);
-            if (enDur != null && deDur != null) {
-                if (deDur < enDur) {
-                    lengthIndicator = '⬇️';
-                    lengthClass = 'good'; // kürzer = positiv
-                } else if (deDur > enDur) {
-                    lengthIndicator = '‼️';
-                    lengthClass = 'bad'; // länger = potentiell negativ
+            const editDur = await getAudioDuration(deUrl);
+            const origDur = await getAudioDuration(deBackupUrl);
+            // Vergleich für ursprüngliche DE-Datei
+            if (enDur != null && origDur != null) {
+                if (origDur < enDur) {
+                    lengthIndicatorOrig = '⬇️';
+                    lengthClassOrig = 'good'; // kürzer = positiv
+                } else if (origDur > enDur) {
+                    lengthIndicatorOrig = '‼️';
+                    lengthClassOrig = 'bad'; // länger = negativ
                 } else {
-                    lengthIndicator = '↔️';
-                    lengthClass = 'neutral';
+                    lengthIndicatorOrig = '↔️';
+                    lengthClassOrig = 'neutral';
+                }
+            }
+            // Vergleich für bearbeitete DE-Datei
+            if (enDur != null && editDur != null) {
+                if (editDur < enDur) {
+                    lengthIndicatorEdit = '⬇️';
+                    lengthClassEdit = 'good'; // kürzer = positiv
+                } else if (editDur > enDur) {
+                    lengthIndicatorEdit = '‼️';
+                    lengthClassEdit = 'bad'; // länger = negativ
+                } else {
+                    lengthIndicatorEdit = '↔️';
+                    lengthClassEdit = 'neutral';
                 }
             }
         }
@@ -3835,7 +3854,10 @@ return `
             </div>
             <span class="path-detail">EN: sounds/EN/${relPath}<br>DE: ${dePath ? `sounds/DE/${dePath}` : 'fehlend'}</span>
         </td>
-        <td><span class="length-diff ${lengthClass}">${lengthIndicator}</span></td>
+        <td>
+            <span class="length-diff ${lengthClassOrig}" title="Original">${lengthIndicatorOrig}</span>
+            <span class="length-diff ${lengthClassEdit}" title="Bearbeitet">${lengthIndicatorEdit}</span>
+        </td>
         <td>
             <!-- Vertikal gruppierte Aktionsknöpfe -->
             <div class="action-toolbar">

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -909,6 +909,9 @@ th:nth-child(8) {
 .length-diff.neutral {
     color: #ffc107;
 }
+.length-diff + .length-diff {
+    margin-left: 4px; /* kleiner Abstand zwischen den Symbolen */
+}
 
         /* Raster-Anordnung der Bearbeitungs-Symbole (maximal zwei pro Zeile) */
         .edit-column {


### PR DESCRIPTION
## Zusammenfassung
- Zeigt nun zwei Symbole im Dateiraster: eines für die ursprüngliche, eines für die bearbeitete deutsche Audiodatei.
- CSS um kleinen Abstand zwischen den Vergleichssymbolen ergänzt.
- Dokumentation und Changelog zum neuen Längen-Vergleich aktualisiert.

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68911d86cdb88327bdce1ab86ae91895