### PR TITLE
Schnellstart mit Cheats für HLA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.156
+* Schnellstart-Knöpfe mit Cheat-Presets (Godmode, unendliche Munition, Kombination oder nur Entwicklerkonsole) hinzugefügt.
 ## ✨ Neue Features in 1.40.0
 * GitHub-Workflow `node-test.yml` führt automatisch `npm ci` und `npm test` für Node 18–22 bei jedem Push und Pull Request aus.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Live‑Statistiken:** EN‑%, DE‑%, Completion‑%, Globale Textzahlen (EN/DE/BEIDE/∑)
 * **Vollständig offline** – keine Server, keine externen Abhängigkeiten
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
+* **Schnellstart mit Cheats:** Über ein Dropdown lassen sich Godmode, unendliche Munition, beides oder nur die Entwicklerkonsole direkt aktivieren.
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Eigenes Wörterbuch:** Der 📚-Knopf speichert nun sowohl englisch‑deutsche Übersetzungen als auch Lautschrift.
 * **Audio-Datei zuordnen:** Lange Aufnahmen lassen sich automatisch in Segmente teilen, per Klick auswählen, farblich passenden Textzeilen zuweisen und direkt ins Projekt importieren. Über den 🚫‑Knopf markierte Bereiche werden dauerhaft übersprungen und in der Liste grau hinterlegt. Fehlhafte Eingaben löschen die Zuordnung automatisch, laufende Wiedergaben stoppen beim Neu‑Upload. Die gewählte Datei und alle Zuordnungen werden im Projekt gespeichert und sind Teil des Backups. In der Desktop‑Version landet die Originaldatei zusätzlich im Ordner `Sounds/Segments` und trägt die ID des Projekts. Beim Klicken werden ausgewählte Segmente sofort abgespielt. Die Segmentierungslogik ist fest im Hauptskript verankert. Der Datei‑Input besitzt zusätzlich ein `onchange`-Attribut und der Listener wird beim Öffnen des Dialogs neu gesetzt, sodass der Upload immer reagiert. Der Dialog setzt die HTML‑Elemente `segmentFileInput` und `segmentWaveform` voraus.
@@ -643,7 +644,7 @@ In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über da
 | **Schnell-Level**         | Rechtsklick auf Kapitel → Schnell-Level |
 | **Level anpassen**        | Rechtsklick auf Level-Titel → Bearbeiten/Löschen |
 | **Level‑Name kopieren**   | ⧉‑Button in Meta‑Leiste                           |
-| **Half-Life: Alyx starten** | Zentrale Start-Leiste mit Modus‑ und Sprachauswahl sowie optionalem +map‑Parameter |
+| **Half-Life: Alyx starten** | Zentrale Start-Leiste mit Modus‑ und Sprachauswahl, optionalem +map‑Parameter und Cheat-Dropdown |
 
 Beim Rechtsklick auf eine Projekt‑Kachel erscheint ein kleines Menü zum Bearbeiten (⚙️) oder Löschen (🗑️) des Projekts.
 Auch Kapitel und Level bieten dieses Rechtsklick-Menü.

--- a/electron/main.js
+++ b/electron/main.js
@@ -868,12 +868,12 @@ app.whenReady().then(() => {
 
   // =========================== START-HLA START ==============================
   // Startet Half-Life: Alyx oder den Workshop-Modus über ein Python-Skript
-  ipcMain.handle('start-hla', async (event, { mode, lang, map }) => {
+  ipcMain.handle('start-hla', async (event, { mode, lang, map, preset }) => {
     return await new Promise(resolve => {
       try {
         const proc = spawn(
           'python',
-          [path.join(__dirname, '..', 'launch_hla.py'), mode, lang || '', map || ''],
+          [path.join(__dirname, '..', 'launch_hla.py'), mode, lang || '', map || '', preset || 'normal'],
           { env: { ...process.env, PYTHONIOENCODING: 'utf-8' } }
         );
         proc.on('close', code => resolve(code === 0));

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -74,8 +74,8 @@ if (typeof require !== 'function') {
     join: (...segments) => path.join(...segments),
     translateText: (id, text) => ipcRenderer.send('translate-text', { id, text }),
     onTranslateFinished: cb => ipcRenderer.on('translate-finished', (e, data) => cb(data)),
-    // Half-Life: Alyx starten (Modus und Sprache wählbar, optional Map)
-    startHla: (mode, lang, map) => ipcRenderer.invoke('start-hla', { mode, lang, map }),
+    // Half-Life: Alyx starten (Modus, Sprache, Map und Cheat-Preset)
+    startHla: (mode, lang, map, preset) => ipcRenderer.invoke('start-hla', { mode, lang, map, preset }),
     openExternal: (url) => ipcRenderer.invoke('open-external', url),
     openPath: (p) => ipcRenderer.invoke('open-path', p),
     loadOpenaiSettings: () => ipcRenderer.invoke('load-openai-settings'),

--- a/launch_hla.py
+++ b/launch_hla.py
@@ -19,12 +19,13 @@ def _get_steam_path() -> str | None:
         return None
 
 
-def start_hla(mode: str = "normal", lang: str = "english", level: str | None = None) -> bool:
+def start_hla(mode: str = "normal", lang: str = "english", level: str | None = None, preset: str = "normal") -> bool:
     """Startet Half-Life: Alyx oder den Workshop-Modus.
 
     Bei ``mode == 'workshop'`` wird ``hlvrcfg.exe`` direkt aufgerufen.
     Ansonsten erfolgt der Start über ``steam.exe``. Optional kann ein
-    Level per ``+map`` übergeben werden.
+    Level per ``+map`` übergeben werden. Mit ``preset`` lassen sich
+    voreingestellte Cheats aktivieren.
     Gibt ``True`` bei Erfolg zurück.
     """
 
@@ -49,6 +50,16 @@ def start_hla(mode: str = "normal", lang: str = "english", level: str | None = N
 
         if lang:
             cmd.extend(["-language", lang])
+
+        cheat_args = {
+            "god": ["-vconsole", "-console", "+sv_cheats", "1", "+god"],
+            "ammo": ["-vconsole", "-console", "+sv_cheats", "1", "+sv_infinite_ammo", "1"],
+            "both": ["-vconsole", "-console", "+sv_cheats", "1", "+god", "+sv_infinite_ammo", "1"],
+            "console": ["-vconsole", "-console"],
+        }
+        if preset in cheat_args:
+            cmd.extend(cheat_args[preset])
+
         if level:
             cmd.extend(["+map", level])
         subprocess.Popen(cmd)
@@ -61,6 +72,16 @@ def start_hla(mode: str = "normal", lang: str = "english", level: str | None = N
         args.append("-hlvr_workshop")
     if lang:
         args.extend(["-language", lang])
+
+    cheat_args = {
+        "god": ["-vconsole", "-console", "+sv_cheats", "1", "+god"],
+        "ammo": ["-vconsole", "-console", "+sv_cheats", "1", "+sv_infinite_ammo", "1"],
+        "both": ["-vconsole", "-console", "+sv_cheats", "1", "+god", "+sv_infinite_ammo", "1"],
+        "console": ["-vconsole", "-console"],
+    }
+    if preset in cheat_args:
+        args.extend(cheat_args[preset])
+
     if level:
         args.extend(["+map", level])
 
@@ -78,10 +99,11 @@ def start_hla(mode: str = "normal", lang: str = "english", level: str | None = N
 
 
 if __name__ == "__main__":
-    # Optionaler Aufruf über Kommandozeile: ``python launch_hla.py workshop german``
+    # Optionaler Aufruf über Kommandozeile: ``python launch_hla.py workshop german a1 intro god``
     import sys
     mode = sys.argv[1] if len(sys.argv) > 1 else "normal"
     lang = sys.argv[2] if len(sys.argv) > 2 else "english"
     level = sys.argv[3] if len(sys.argv) > 3 and sys.argv[3] else None
-    ok = start_hla(mode, lang, level)
+    preset = sys.argv[4] if len(sys.argv) > 4 else "normal"
+    ok = start_hla(mode, lang, level, preset)
     sys.exit(0 if ok else 1)

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -85,7 +85,16 @@
                         <input type="checkbox" id="mapCheckbox"> +map
                     </label>
                     <input type="text" id="mapSelect" placeholder="Level" style="width:140px">
-                    <button id="startButton" class="btn btn-secondary" onclick="startHla()">Starten</button>
+                    <div class="start-dropdown">
+                        <button id="startButton" class="btn btn-secondary" onclick="startHla('normal')" title="">Starten</button>
+                        <button id="startDropdown" class="btn btn-secondary" onclick="toggleStartMenu()">▼</button>
+                        <div id="startMenu" class="dropdown-menu">
+                            <button id="startCheatGod" class="dropdown-item" onclick="startHla('god')" title="">Start (Cheats: God)</button>
+                            <button id="startCheatAmmo" class="dropdown-item" onclick="startHla('ammo')" title="">Start (Cheats: Infinite Ammo)</button>
+                            <button id="startCheatBoth" class="dropdown-item" onclick="startHla('both')" title="">Start (Cheats: God + Ammo)</button>
+                            <button id="startConsole" class="dropdown-item" onclick="startHla('console')" title="">Start (Entwicklerkonsole)</button>
+                        </div>
+                    </div>
                 </div>
             </div>
 			

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -9806,7 +9806,7 @@ async function scanAudioDuplicates() {
         window.toggleDevTools = toggleDevTools;
 
         // Startet Half-Life: Alyx über die Desktop-Version
-        async function startHla() {
+        async function startHla(preset = 'normal') {
             const modeSel = document.getElementById('modusSelect');
             const langSel = document.getElementById('spracheSelect');
             const mapCb   = document.getElementById('mapCheckbox');
@@ -9817,13 +9817,63 @@ async function scanAudioDuplicates() {
             const map  = mapCb && mapCb.checked && mapSel ? mapSel.value.trim() : '';
 
             if (window.electronAPI && window.electronAPI.startHla) {
-                const ok = await window.electronAPI.startHla(mode, lang, map);
+                const ok = await window.electronAPI.startHla(mode, lang, map, preset);
                 if (!ok) showToast('Start fehlgeschlagen', 'error');
             } else {
                 alert('Nur in der Desktop-Version verfügbar');
             }
+
+            // Dropdown nach dem Start wieder schließen
+            document.querySelector('.start-dropdown')?.classList.remove('show');
         }
         window.startHla = startHla;
+
+        // Zeigt/versteckt das Dropdown-Menü für den Schnellstart
+        function toggleStartMenu() {
+            document.querySelector('.start-dropdown')?.classList.toggle('show');
+        }
+        window.toggleStartMenu = toggleStartMenu;
+
+        // Aktualisiert die Tooltips der Startknöpfe mit aktueller Map
+        function updateStartTooltips() {
+            const mapSel = document.getElementById('mapSelect');
+            const level = mapSel ? mapSel.value.trim() : '';
+            const mapTxt = level ? ` (Map: ${level})` : '';
+            const cheatTip = `Startet HLA mit -vconsole/-console und setzt +sv_cheats 1. Cheats können Erfolge deaktivieren.${mapTxt}`;
+            const consoleTip = `Startet HLA mit -vconsole/-console ohne Cheats${mapTxt}`;
+            const normalTip = `Startet HLA${mapTxt}`;
+
+            const startBtn = document.getElementById('startButton');
+            const godBtn = document.getElementById('startCheatGod');
+            const ammoBtn = document.getElementById('startCheatAmmo');
+            const bothBtn = document.getElementById('startCheatBoth');
+            const consoleBtn = document.getElementById('startConsole');
+            if (startBtn) startBtn.title = normalTip;
+            if (godBtn) godBtn.title = cheatTip;
+            if (ammoBtn) ammoBtn.title = cheatTip;
+            if (bothBtn) bothBtn.title = cheatTip;
+            if (consoleBtn) consoleBtn.title = consoleTip;
+        }
+        window.updateStartTooltips = updateStartTooltips;
+
+        if (typeof document !== 'undefined' && typeof document.getElementById === 'function') {
+            document.getElementById('mapSelect')?.addEventListener('input', updateStartTooltips);
+            document.getElementById('mapCheckbox')?.addEventListener('change', updateStartTooltips);
+            updateStartTooltips();
+
+            // Tastenkürzel für Cheat-Starts
+            document.addEventListener('keydown', e => {
+                if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return;
+                const key = e.key.toLowerCase();
+                if (e.shiftKey && key === 'g') {
+                    startHla('both');
+                } else if (key === 'g') {
+                    startHla('god');
+                } else if (key === 'i') {
+                    startHla('ammo');
+                }
+            });
+        }
 
         // Speichert die URL des Videos dauerhaft
         function saveVideoUrl() {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -443,6 +443,41 @@ th:nth-child(8) {
             align-items: center;
         }
 
+        /* Dropdown für Schnellstart mit Cheats */
+        .start-dropdown {
+            position: relative;
+            display: flex;
+        }
+
+        .start-dropdown .dropdown-menu {
+            display: none;
+            position: absolute;
+            top: 100%;
+            left: 0;
+            background: #2c2c2c;
+            border: 1px solid #555;
+            flex-direction: column;
+            min-width: 180px;
+            z-index: 10;
+        }
+
+        .start-dropdown.show .dropdown-menu {
+            display: flex;
+        }
+
+        .start-dropdown .dropdown-menu .dropdown-item {
+            padding: 5px 10px;
+            text-align: left;
+            background: none;
+            border: none;
+            color: inherit;
+            width: 100%;
+        }
+
+        .start-dropdown .dropdown-menu .dropdown-item:hover {
+            background: #444;
+        }
+
         /* GPT-Knopf neben der Suche */
         #gptScoreButton {
             margin-left: 10px;


### PR DESCRIPTION
## Zusammenfassung
- Startleiste um Dropdown mit Cheat-Presets erweitert
- Launch-Skripte unterstützen Godmode, unendliche Munition und Entwicklerkonsole
- Dokumentation und Changelog aktualisiert

## Tests
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a19568c0048327a8e85f7259d4541e