### PR TITLE
Fehlende Sprachpakete besser melden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.159
+* Offline-Übersetzung meldet fehlende Sprachpakete nun verständlich und beendet sich mit Status 1.
 ## 🛠️ Patch in 1.40.158
 * `settingsStore` nutzt jetzt einen zufälligen IV pro Speicherung und leitet den Schlüssel aus `HLA_ENC_KEY` ab.
 ## 🛠️ Patch in 1.40.157

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ Bei einem Upload-Fehler mit Status 400 wird zusätzlich ein Ausschnitt der erzeu
 
 ### Python-Übersetzungsskript
 
-`translate_text.py` übersetzt kurze Texte offline mit Argos Translate. Die benötigten Pakete werden durch `start_tool.py` automatisch installiert. Fehlende Sprachpakete lädt das Skript beim ersten Aufruf automatisch herunter. Über `--no-download` lässt sich dieser Schritt verhindern. Für eine komplett Offline-Nutzung müssen die Pakete vorher mit `argos-translate-cli` installiert werden. Seit Version 1.40.13 wird korrekt erkannt, ob ein Paket bereits vorhanden ist. Anschließend kann der gewünschte Text per `echo "Hello" | python translate_text.py` übersetzt werden.
+`translate_text.py` übersetzt kurze Texte offline mit Argos Translate. Die benötigten Pakete werden durch `start_tool.py` automatisch installiert. Fehlende Sprachpakete lädt das Skript beim ersten Aufruf automatisch herunter. Über `--no-download` lässt sich dieser Schritt verhindern. Findet es kein passendes Paket im Index, gibt das Skript nun eine verständliche Fehlermeldung aus und beendet sich mit Status 1. Für eine komplett Offline-Nutzung müssen die Pakete vorher mit `argos-translate-cli` installiert werden. Seit Version 1.40.13 wird korrekt erkannt, ob ein Paket bereits vorhanden ist. Anschließend kann der gewünschte Text per `echo "Hello" | python translate_text.py` übersetzt werden.
 In der Desktop-App wird das Skript asynchron gestartet und das Ergebnis über das Event `translate-finished` zurückgegeben.
 
 ### Version aktualisieren

--- a/translate_text.py
+++ b/translate_text.py
@@ -38,9 +38,18 @@ def ensure_package(from_code: str, to_code: str, allow_download: bool = True) ->
     # Paket nur herunterladen, wenn es nicht vorhanden ist
     package.update_package_index()
     available = package.get_available_packages()
+    # passendes Paket suchen; liefert None, wenn nichts gefunden wird
     pkg = next(
-        p for p in available if p.from_code == from_code and p.to_code == to_code
+        (
+            p for p in available if p.from_code == from_code and p.to_code == to_code
+        ),
+        None,
     )
+    if pkg is None:
+        sys.stderr.write(
+            f"Kein Sprachpaket für {from_code}->{to_code} gefunden.\n"
+        )
+        sys.exit(1)
     package.install_from_path(pkg.download())
 
 


### PR DESCRIPTION
## Zusammenfassung
- Prüft beim Paket-Download auf fehlende Sprachpakete und bricht mit Status 1 ab.
- Dokumentation um Hinweis auf verständliche Fehlermeldung erweitert.
- Changelog mit verbessertem Fehlermanagement ergänzt.

## Testdurchführung
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a629665670832799e6fa7841c8ff85