### PR TITLE
Validierung für chooseExisting und JSDoc-Kommentar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.161
+* `chooseExisting` prüft jetzt leere Namenslisten und wirft bei Bedarf einen Fehler.
+* Kommentar von `copyDubbedFile` nutzt korrekte JSDoc-Syntax.
 ## 🛠️ Patch in 1.40.160
 * Python-Skripte setzen jetzt auf `subprocess.run` mit `check=True` ohne `shell=True`.
 * `needs_npm_ci` und `write_npm_hash` verwenden `with`-Blöcke und schließen Dateien automatisch.

--- a/README.md
+++ b/README.md
@@ -977,6 +977,7 @@ verwendet werden, um optionale Downloads zu überspringen.
 * **`list-sound-backups()`** – listet vorhandene ZIP-Sicherungen auf.
 * **`delete-sound-backup(name)`** – entfernt ein ZIP-Backup.
 * **`saveDeHistoryBuffer(relPath, data)`** – legt einen Buffer als neue History-Version ab.
+* **`chooseExisting(base, names)`** – liefert den ersten existierenden Ordnernamen und wirft einen Fehler bei leerer Liste.
 * **`copyDubbedFile(originalPath, tempDubPath)`** – verschiebt eine heruntergeladene Dub-Datei in den deutschen Ordnerbaum.
 * **`extractRelevantFolder(parts)`** – gibt den relevanten Abschnitt eines Dateipfades ab "vo" oder ohne führendes "sounds" zurück (siehe `web/src/pathUtils.js`).
 * **`calculateProjectStats(project)`** – ermittelt pro Projekt den Übersetzungs‑ und Audio‑Fortschritt. Diese Funktion wird auch in den Tests ausführlich geprüft.

--- a/pathUtils.js
+++ b/pathUtils.js
@@ -3,20 +3,25 @@ const fsp = require('fs/promises');
 const path = require('path');
 
 // Liefert den ersten vorhandenen Ordnernamen aus der Liste
+// und prüft, ob überhaupt Namen übergeben wurden
 function chooseExisting(base, names) {
+  if (names.length === 0)
+    throw new Error('Namen-Liste darf nicht leer sein');
   for (const name of names) {
     if (fs.existsSync(path.join(base, name))) return name;
   }
   return names[0];
 }
 
-// Kopiert bzw. verschiebt eine heruntergeladene Dub-Datei an den
-// entsprechenden Ort unterhalb von ...\web\Sounds\DE\...
-// Dabei wird exakt das Segment "EN" im Pfad durch "DE" ersetzt.
-//\n @param {string} originalPath Voller Pfad der englischen Originaldatei
-// @param {string} tempDubPath  Temporärer Pfad der heruntergeladenen Dub-Datei
-// @param {boolean} move        true => Datei verschieben, false => nur kopieren
-// @returns {Promise<string>}   Zielpfad der deutschen Datei
+/**
+ * Kopiert bzw. verschiebt eine heruntergeladene Dub-Datei an den
+ * entsprechenden Ort unterhalb von ...\web\Sounds\DE\...
+ * Dabei wird exakt das Segment "EN" im Pfad durch "DE" ersetzt.
+ * @param {string} originalPath Voller Pfad der englischen Originaldatei
+ * @param {string} tempDubPath  Temporärer Pfad der heruntergeladenen Dub-Datei
+ * @param {boolean} move        true => Datei verschieben, false => nur kopieren
+ * @returns {Promise<string>}   Zielpfad der deutschen Datei
+ */
 async function copyDubbedFile(originalPath, tempDubPath, move = true) {
   const sep = path.sep;
   const parts = originalPath.split(sep);

--- a/tests/pathDetection.test.js
+++ b/tests/pathDetection.test.js
@@ -17,4 +17,9 @@ describe('Pfaderkennung', () => {
     const name = chooseExisting(tmp, ['Sounds', 'sounds']);
     expect(name).toBe('sounds');
   });
+
+  test('wirft Fehler bei leerer Liste', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'case-'));
+    expect(() => chooseExisting(tmp, [])).toThrow('Namen-Liste darf nicht leer sein');
+  });
 });


### PR DESCRIPTION
## Zusammenfassung
- verhindert Aufrufe von `chooseExisting` mit leerer Namensliste
- bereinigter JSDoc-Kommentar für `copyDubbedFile`
- Dokumentation und Changelog aktualisiert

## Testplan
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6304f97348327a1c1f9d6ee6ab44a