### PR TITLE
feat: ensure npm via corepack in reset script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.164
+* `reset_repo.py` richtet fehlendes `npm` über `corepack` automatisch ein.
 ## 🛠️ Patch in 1.40.163
 * `start_tool.py` erkennt fehlendes `npm` und zeigt einen Hinweis auf `corepack enable` statt mit `FileNotFoundError` zu abbrechen.
 ## 🛠️ Patch in 1.40.162

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 * **Überarbeitete Hilfsskripte:** Python-Tools nutzen jetzt `subprocess.run` mit `check=True` ohne `shell=True` und schließen Dateien konsequent über `with`-Blöcke.
 * **Robuster npm-Test:** Fehlt `npm` (z. B. bei Node 22), bricht das Startskript nicht mehr ab, sondern weist auf `corepack enable` oder eine separate Installation hin.
+* **Automatische npm-Aktivierung:** `reset_repo.py` versucht bei fehlendem `npm`, es über `corepack` einzurichten, bevor das Tool startet.
 * **Mehrere Projekte** mit Icon, Farbe, Level‑Namen & Teil‑Nummer
 * **Level-Kapitel** zur besseren Gruppierung und ein-/ausklappbaren Bereichen
 * **Kapitel bearbeiten:** Name, Farbe und Löschung im Projekt möglich

--- a/reset_repo.py
+++ b/reset_repo.py
@@ -17,12 +17,35 @@ def run(cmd: list[str], cwd: str | None = None) -> None:
         raise subprocess.CalledProcessError(127, cmd) from e
 
 
+def ensure_npm() -> bool:
+    """Prüft, ob npm verfügbar ist und richtet es bei Bedarf über corepack ein."""
+    try:
+        run(["npm", "--version"])
+        return True
+    except subprocess.CalledProcessError:
+        print("npm fehlt. Versuche, corepack zu aktivieren...")
+        try:
+            run(["corepack", "enable"])
+            run(["corepack", "prepare", "npm@latest", "--activate"])
+            run(["npm", "--version"])
+            return True
+        except subprocess.CalledProcessError:
+            print(
+                "npm konnte nicht automatisch eingerichtet werden. Bitte Node mit npm installieren oder corepack manuell nutzen."
+            )
+            return False
+
+
 def main() -> None:
     # Verzeichnis dieses Skripts ermitteln
     repo_dir = os.path.dirname(os.path.abspath(__file__))
     os.chdir(repo_dir)
 
     electron_dir = os.path.join(repo_dir, "electron")
+
+    if not ensure_npm():
+        input("Fertig. Mit Enter schliessen...")
+        return
 
     try:
         run(["git", "reset", "--hard", "HEAD"])


### PR DESCRIPTION
## Summary
- enable npm via corepack in `reset_repo.py` if missing
- document automatic npm activation
- record change in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a63918daa0832795e8cd207a8587a7