### PR TITLE
Neu hinzugefügte Dateien werden sofort ausgewählt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.166
+* Neu hinzugefügte Dateien werden nach dem Einfügen automatisch ausgewählt.
 ## 🛠️ Patch in 1.40.165
 * `verify_environment.py` prüft jetzt auch Paketversionen für Python und Node, repariert Abweichungen automatisch und wartet am Ende auf eine Eingabe.
 ## 🛠️ Patch in 1.40.164

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Lade-Indikator für Übersetzungen:** Jede Anfrage zeigt nun einen Spinner und das Ergebnis kommt über das IPC-Event `translate-finished`
 * **Projekt-Playback:** ▶/⏸/⏹ spielt verfügbare DE-Dateien nacheinander ab
 * **Numerische Navigation:** ▲/▼ neben den Playback-Knöpfen springen zur nächsten oder vorherigen Nummer und stellen sicher, dass Nummer, Dateiname und Ordner direkt unter dem Tabellenkopf komplett sichtbar bleiben. Beim Scrollen mit dem Mausrad wird automatisch die Zeile in Bildschirmmitte markiert, ohne die Ausrichtung zu verändern. Schnelle Klicks nach unten funktionieren jetzt ebenfalls ohne Zurückspringen
+* **Automatische Auswahl neuer Dateien:** Nach dem Hinzufügen springt die Markierung direkt auf die frisch eingefügte Zeile
 * **Aktuelle Zeile angeheftet:** Beim Scrollen bleibt die oberste Zeile direkt unter der Überschrift stehen und ist dezent markiert
 * **Feste Reihenfolge:** Beim Projekt-Playback wird die Dateiliste strikt von oben nach unten abgespielt, unabhängig vom Dateityp
 * **Stabileres Audio-Playback:** Unterbrochene Wiedergabe erzeugt keine Fehlermeldungen mehr

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -124,6 +124,7 @@ let autoIgnoreMs          = 400;   // Schwelle für Pausen in ms
 let draggedElement         = null;
 let currentlyPlaying       = null;
 let selectedRow            = null; // für Tastatur-Navigation
+let lastAddedFileId        = null; // ID der zuletzt hinzugefügten Datei
 let contextMenuFile        = null; // Rechtsklick-Menü-Datei
 let versionMenuFile        = null; // Menü für Versionsauswahl
 let projectContextId       = null; // Rechtsklick-Menü-Projekt
@@ -2492,8 +2493,9 @@ function addFiles() {
                 hallEffect: false,
                 version: 1
             };
-            
+
             files.push(newFile);
+            lastAddedFileId = newFile.id; // Neu: zuletzt hinzugefügte Datei merken
             updateAutoTranslation(newFile, true);
             added++;
         }
@@ -4882,6 +4884,20 @@ function findAudioInFilePathCache(filename, folder) {
         }
 
         await renderFileTableWithOrder(sortedFiles);
+
+        // Neu: zuletzt hinzugefügte Datei automatisch auswählen
+        if (lastAddedFileId !== null) {
+            const row = document.querySelector(`#fileTableBody tr[data-id='${lastAddedFileId}']`);
+            if (row) {
+                selectRow(row);
+                setActiveRow(row);
+                const numCell = row.querySelector('.row-number');
+                if (numCell) {
+                    currentRowNumber = parseInt(numCell.textContent, 10);
+                }
+            }
+            lastAddedFileId = null;
+        }
     }
 
 function addDragAndDropHandlers() {
@@ -8075,6 +8091,7 @@ function addFileFromFolderBrowser(filename, folder, fullPath) {
     };
     
     files.push(newFile);
+    lastAddedFileId = newFile.id; // Neu: zuletzt hinzugefügte Datei merken
     updateAutoTranslation(newFile, true);
     updateAutoTranslation(newFile, true);
     
@@ -13400,9 +13417,10 @@ function addFileToProject(filename, folder, originalResult) {
         hallEffect: false,
         version: 1
     };
-    
+
     files.push(newFile);
-    
+    lastAddedFileId = newFile.id; // Neu: zuletzt hinzugefügte Datei merken
+
     // Update display order for new file
     displayOrder.push({ file: newFile, originalIndex: files.length - 1 });
     


### PR DESCRIPTION
## Zusammenfassung
- merke ID der zuletzt eingefügten Datei, um sie nach dem Rendern anzuspringen
- markiere und scrolle automatisch zur neu hinzugefügten Zeile
- dokumentiere die automatische Dateiauswahl in README und CHANGELOG

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a77621bc848327925263b4915c8bad