### PR TITLE
Neue Dateien werden nach dem Hinzufügen automatisch ausgewählt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.166
+* Neu hinzugefügte Dateien werden nach dem Einfügen automatisch ausgewählt.
 ## 🛠️ Patch in 1.40.165
 * `verify_environment.py` prüft jetzt auch Paketversionen für Python und Node, repariert Abweichungen automatisch und wartet am Ende auf eine Eingabe.
 ## 🛠️ Patch in 1.40.164

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Projekt-Playback:** ▶/⏸/⏹ spielt verfügbare DE-Dateien nacheinander ab
 * **Numerische Navigation:** ▲/▼ neben den Playback-Knöpfen springen zur nächsten oder vorherigen Nummer und stellen sicher, dass Nummer, Dateiname und Ordner direkt unter dem Tabellenkopf komplett sichtbar bleiben. Beim Scrollen mit dem Mausrad wird automatisch die Zeile in Bildschirmmitte markiert, ohne die Ausrichtung zu verändern. Schnelle Klicks nach unten funktionieren jetzt ebenfalls ohne Zurückspringen
 * **Aktuelle Zeile angeheftet:** Beim Scrollen bleibt die oberste Zeile direkt unter der Überschrift stehen und ist dezent markiert
+* **Automatische Zeilenauswahl:** Neu hinzugefügte Dateien werden direkt markiert und in den sichtbaren Bereich gescrollt
 * **Feste Reihenfolge:** Beim Projekt-Playback wird die Dateiliste strikt von oben nach unten abgespielt, unabhängig vom Dateityp
 * **Stabileres Audio-Playback:** Unterbrochene Wiedergabe erzeugt keine Fehlermeldungen mehr
 * **Fehlerhinweis bei der Bearbeitungs-Vorschau:** Schlägt das Abspielen fehl, erscheint jetzt eine Meldung

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -13405,9 +13405,15 @@ function addFileToProject(filename, folder, originalResult) {
     
     // Update display order for new file
     displayOrder.push({ file: newFile, originalIndex: files.length - 1 });
-    
+
     isDirty = true;
-    renderFileTable();
+    renderFileTable().then(() => {
+        // Neu hinzugefügte Datei automatisch auswählen
+        const row = document.querySelector(`tr[data-id="${newFile.id}"]`);
+        if (row) {
+            selectRow(row);
+        }
+    });
     renderProjects(); // Live Update
     updateProgressStats();
     


### PR DESCRIPTION
## Zusammenfassung
- Markiert neu hinzugefügte Dateien sofort und scrollt sie in den sichtbaren Bereich.
- Dokumentation in README und CHANGELOG aktualisiert.

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a779f8b91483279c7923a393a683b9