### PR TITLE
Markiere neue Zeilen automatisch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.166
+* Neue Dateien werden nach dem Einfügen automatisch markiert.
 ## 🛠️ Patch in 1.40.165
 * `verify_environment.py` prüft jetzt auch Paketversionen für Python und Node, repariert Abweichungen automatisch und wartet am Ende auf eine Eingabe.
 ## 🛠️ Patch in 1.40.164

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ### ⌨️ Keyboard & Maus
 
 * **Keyboard‑Navigation:** Pfeiltasten, Tab, Leertaste für Audio, Enter für Texteingabe
+* **Automatische Markierung:** Neue Zeilen werden nach dem Hinzufügen sofort ausgewählt
 * **Context‑Menu** (Rechtsklick): Audio, Kopieren, Einfügen, Ordner öffnen, Löschen
 * **Schnell hinzufügen:** Rechtsklick auf Level → Schnellprojekt, Rechtsklick auf Kapitel → Schnell‑Level
 * **Drag & Drop:** Projekte und Dateien sortieren

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -124,6 +124,7 @@ let autoIgnoreMs          = 400;   // Schwelle für Pausen in ms
 let draggedElement         = null;
 let currentlyPlaying       = null;
 let selectedRow            = null; // für Tastatur-Navigation
+let pendingSelectId        = null; // Merkt die ID der zuletzt hinzugefügten Datei
 let contextMenuFile        = null; // Rechtsklick-Menü-Datei
 let versionMenuFile        = null; // Menü für Versionsauswahl
 let projectContextId       = null; // Rechtsklick-Menü-Projekt
@@ -2492,8 +2493,9 @@ function addFiles() {
                 hallEffect: false,
                 version: 1
             };
-            
+
             files.push(newFile);
+            pendingSelectId = newFile.id; // neue Datei vormerken
             updateAutoTranslation(newFile, true);
             added++;
         }
@@ -3905,6 +3907,15 @@ return `
     updateDubButtons();
     // Nach dem Rendern zur gemerkten Zeile springen
     scrollToNumber(currentRowNumber);
+
+    // Falls eine neue Datei hinzugekommen ist, diese Zeile auswählen
+    if (pendingSelectId !== null) {
+        const neueZeile = tbody.querySelector(`tr[data-id="${pendingSelectId}"]`);
+        if (neueZeile) {
+            selectRow(neueZeile);
+        }
+        pendingSelectId = null;
+    }
 
     // Nach dem Rendern Textfelder und Übersetzungsanzeige anpassen
     setTimeout(() => {
@@ -8073,8 +8084,9 @@ function addFileFromFolderBrowser(filename, folder, fullPath) {
         hallEffect: false,
         version: 1
     };
-    
+
     files.push(newFile);
+    pendingSelectId = newFile.id; // neue Datei markieren
     updateAutoTranslation(newFile, true);
     updateAutoTranslation(newFile, true);
     
@@ -13400,9 +13412,10 @@ function addFileToProject(filename, folder, originalResult) {
         hallEffect: false,
         version: 1
     };
-    
+
     files.push(newFile);
-    
+    pendingSelectId = newFile.id; // hinzugefügte Datei merken
+
     // Update display order for new file
     displayOrder.push({ file: newFile, originalIndex: files.length - 1 });
     


### PR DESCRIPTION
## Zusammenfassung
- Merke die ID zuletzt hinzugefügter Dateien und wähle die Zeile nach dem Rendern automatisch aus
- Aktualisiere README und CHANGELOG für die automatische Markierung

## Tests
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a77b574ab88327b09164a6dcb96bc9