### PR TITLE
Tempo-Faktor beim Hochladen neuer DE-Audiodateien zurücksetzen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.185
+* Beim Hochladen einer DE-Audiodatei wird der Tempo-Faktor nun zuverlässig auf 1,0 gesetzt.
 ## 🛠️ Patch in 1.40.184
 * `translate_text.py` installiert fehlendes `argostranslate` automatisch und weist bei DLL-Problemen auf das VC++‑Laufzeitpaket hin.
 ## 🛠️ Patch in 1.40.183

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Bugfix:** Beim erneuten Öffnen und Speichern wird nur noch die Differenz zum gespeicherten Tempo angewendet. Unveränderte Werte schneiden jetzt nichts mehr ab.
 * **Bugfix:** Wird eine Audiodatei stärker gekürzt als ihre Länge, führt dies nicht mehr zu einer DOMException.
 * **Zurücksetzen nach Upload oder Dubbing:** Sowohl beim Hochladen als auch beim erneuten Erzeugen einer deutschen Audiodatei werden Lautstärkeangleichung, Funkgerät‑, Hall‑ und Störgeräusch‑Effekt automatisch deaktiviert.
-* **Tempo-Regler zurückgesetzt:** Nach einem Upload steht der Geschwindigkeitsregler wieder auf 1,00.
+* **Tempo-Regler zurückgesetzt:** Nach einem Upload steht der Geschwindigkeitsregler wieder zuverlässig auf 1,00.
 * **Tempo-Regler auch beim ZIP-Import auf 1,00:** Beim Import mehrerer Dateien per ZIP wird der Geschwindigkeitsregler jeder Zeile auf den Standardwert gesetzt.
 * **Backup bleibt beim Speichern erhalten:** Nur ein neuer Upload ersetzt die Sicherung in `DE-Backup`. "🔄 Zurücksetzen" stellt dadurch stets die zuletzt geladene Originaldatei wieder her.
 * **ZIP-Import aktualisiert das Backup:** Auch importierte ZIP-Dateien gelten nun als Original und lassen sich über "🔄 Zurücksetzen" wiederherstellen.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -10737,6 +10737,18 @@ async function handleDeUpload(input) {
         file.radioEffect = false;
         file.hallEffect = false;
         file.emiEffect = false;
+        file.tempoFactor = 1.0; // Tempo-Faktor auf Standard zurücksetzen
+        if (currentEditFile === file) {
+            tempoFactor = 1.0;
+            loadedTempoFactor = 1.0;
+            const tempoRange = document.getElementById('tempoRange');
+            const tempoDisp = document.getElementById('tempoDisplay');
+            if (tempoRange && tempoDisp) {
+                tempoRange.value = '1.00';
+                tempoDisp.textContent = '1.00';
+                tempoDisp.classList.remove('tempo-auto');
+            }
+        }
         // Fertig-Status ergibt sich nun automatisch
     }
 


### PR DESCRIPTION
## Zusammenfassung
- Setzt den Tempo-Faktor beim Upload neuer DE-Audiodateien auf 1,00 und aktualisiert ggf. den Regler im geöffneten Editor
- Dokumentiert das Verhalten im README und ergänzt einen Changelog-Eintrag

## Testen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aabb33a2ac83279a935fcdbfcade1b