### PR TITLE
Optionale Zeit- und Strichfunktion beim Emotionen-Kopieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.186
+* "Emotionen kopieren" bietet Checkboxen, um Zeit und/oder `---` anzufügen.
 ## 🛠️ Patch in 1.40.185
 * Beim Hochladen einer DE-Audiodatei wird der Tempo-Faktor nun zuverlässig auf 1,0 gesetzt.
 ## 🛠️ Patch in 1.40.184

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Automatischer Voice-Abgleich:** Beim Öffnen der Kopierhilfe lädt das Tool die verfügbaren ElevenLabs-Stimmen und zeigt Namen und IDs korrekt an.
 * **Zusätzliche Zwischenablage-Prüfung:** Die Kopierhilfe stellt sicher, dass im ersten Schritt der Name und im zweiten der Emotionstext in der Zwischenablage liegt.
 * **Zweite Kopierhilfe:** Ein neuer Dialog blättert durch alle Einträge und zeigt Ordnernamen, deutschen Text und Emotionstext an. Ein Seitenzähler informiert über die aktuelle Position.
-* **Alle Emotionstexte kopieren:** Der Button sammelt alle Emotionstexte, entfernt Zeilenumbrüche, trennt die Blöcke mit einer Leerzeile und stellt die Laufzeit der EN‑Datei im Format `[8,57sec]` voran.
+* **Alle Emotionstexte kopieren:** Der Button sammelt alle Emotionstexte, entfernt Zeilenumbrüche und trennt die Blöcke mit einer Leerzeile. Optional stellt er die Laufzeit der EN‑Datei im Format `[8,57sec]` voran und/oder hängt `---` ans Ende.
 * **Stabile Base64-Kodierung:** Große Audiodateien werden beim Hochladen in handlichen Blöcken verarbeitet, sodass kein "Maximum call stack size exceeded" mehr auftritt.
 * **Warteschlange für GPT-Anfragen:** Mehrere Emotionstexte werden nacheinander an OpenAI geschickt, um HTTP‑429‑Fehler zu vermeiden.
 * **ZIP-Import mit Vorschau:** Die gewählte ZIP-Datei wird in einen temporären Ordner entpackt. Scheitert "unzipper", greift automatisch 7‑Zip als Fallback. Anschließend werden die Audios nach führender Nummer sortiert angezeigt und bei Übereinstimmung direkt zugeordnet.

--- a/tests/copyAllEmotions.test.js
+++ b/tests/copyAllEmotions.test.js
@@ -14,20 +14,50 @@ function loadMain() {
     ({ copyAllEmotionsToClipboard, __setFiles, __setGetAudioDuration } = require('../web/src/main.js'));
     // nach dem Laden die Toast-Funktion überschreiben und DOM vorbereiten
     global.showToast = jest.fn();
-    document.body.innerHTML = '<div id="toastContainer"></div>';
+    document.body.innerHTML = '<div id="toastContainer"></div>' +
+        '<input type="checkbox" id="copyIncludeTime">' +
+        '<input type="checkbox" id="copyAddDashes">';
 }
 
 describe('copyAllEmotionsToClipboard', () => {
     beforeEach(loadMain);
 
-    test('bereitet Emotionstexte auf und kopiert sie', async () => {
+    test('bereitet Emotionstexte auf und kopiert sie mit Zeit', async () => {
         const arr = [
             { emotionalText: '[dankbar]\nDanke\n', filename: 'a.wav', folder: 'f1' },
             { emotionalText: 'Hallo Welt!\nWie gehts?\n', filename: 'b.wav', folder: 'f1' }
         ];
         __setFiles(arr);
         __setGetAudioDuration(() => 8.57);
+        document.getElementById('copyIncludeTime').checked = true;
         await copyAllEmotionsToClipboard();
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith('[8,57sec] [dankbar] Danke\n\n[8,57sec] Hallo Welt! Wie gehts?');
+    });
+
+    test('fügt nur Striche an', async () => {
+        const arr = [
+            { emotionalText: '[dankbar]\nDanke\n', filename: 'a.wav', folder: 'f1' },
+            { emotionalText: 'Hallo Welt!\nWie gehts?\n', filename: 'b.wav', folder: 'f1' }
+        ];
+        __setFiles(arr);
+        const durFn = jest.fn();
+        __setGetAudioDuration(durFn);
+        document.getElementById('copyAddDashes').checked = true;
+        await copyAllEmotionsToClipboard();
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('[dankbar] Danke ---\n\nHallo Welt! Wie gehts? ---');
+        expect(durFn).not.toHaveBeenCalled();
+    });
+
+    test('fügt Zeit und Striche hinzu', async () => {
+        const arr = [
+            { emotionalText: '[dankbar]\nDanke\n', filename: 'a.wav', folder: 'f1' },
+            { emotionalText: 'Hallo Welt!\nWie gehts?\n', filename: 'b.wav', folder: 'f1' }
+        ];
+        __setFiles(arr);
+        __setGetAudioDuration(() => 8.57);
+        document.getElementById('copyIncludeTime').checked = true;
+        document.getElementById('copyAddDashes').checked = true;
+        await copyAllEmotionsToClipboard();
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('[8,57sec] [dankbar] Danke ---\n\n[8,57sec] Hallo Welt! Wie gehts? ---');
     });
 });

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -125,6 +125,8 @@
                     <button id="copyAssistantButton" class="btn btn-secondary">Kopierhilfe</button>
                     <button id="copyAssistant2Button" class="btn btn-secondary">Kopierhilfe 2</button>
                     <button id="copyAllEmosButton" class="btn btn-secondary">Emotionen kopieren</button>
+                    <label class="copy-option"><input type="checkbox" id="copyIncludeTime" checked> Zeit voranstellen</label>
+                    <label class="copy-option"><input type="checkbox" id="copyAddDashes"> --- anhängen</label>
                 </div>
                 <div class="sort-controls">
                     <span style="color: #999;">Sortierung:</span>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1098,18 +1098,29 @@ function normalizeEmotionalText(text) {
 }
 
 // Kopiert alle Emotionstexte nacheinander in die Zwischenablage
-// Fuegt vor jedem Emotionstext die Laufzeit der EN-Audiodatei an
+// Optional: Zeit vorne anfügen und drei Striche am Ende setzen
 async function copyAllEmotionsToClipboard() {
     const blocks = [];
+    // Optionen aus den Checkboxen lesen
+    const addTime = document.getElementById('copyIncludeTime')?.checked;
+    const addDashes = document.getElementById('copyAddDashes')?.checked;
     for (const f of files) {
-        let dur = null;
-        if (f && f.filename && f.folder) {
-            const enSrc = `sounds/EN/${getFullPath(f)}`;
-            dur = await getAudioDurationFn(enSrc);
+        let entry = normalizeEmotionalText(f.emotionalText || '');
+        if (addTime) {
+            // Zeit berechnen und voranstellen
+            let dur = null;
+            if (f && f.filename && f.folder) {
+                const enSrc = `sounds/EN/${getFullPath(f)}`;
+                dur = await getAudioDurationFn(enSrc);
+            }
+            const durStr = dur != null ? dur.toFixed(2).replace('.', ',') + 'sec' : '?sec';
+            entry = `[${durStr}] ${entry}`;
         }
-        const durStr = dur != null ? dur.toFixed(2).replace('.', ',') + 'sec' : '?sec';
-        const text = normalizeEmotionalText(f.emotionalText || '');
-        blocks.push(`[${durStr}] ${text}`);
+        if (addDashes) {
+            // Gewünschte Trennstriche hinten anfügen
+            entry += ' ---';
+        }
+        blocks.push(entry);
     }
     const texts = blocks.join('\n\n');
     await safeCopy(texts);

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -220,6 +220,12 @@ th:nth-child(8) {
             gap: 10px;
             flex-wrap: wrap;
         }
+        /* Optionen im Suchbereich */
+        .copy-option {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
 		
 		
 


### PR DESCRIPTION
## Zusammenfassung
- Checkboxen fügen optional Zeit und/oder `---` beim Kopieren der Emotionstexte hinzu
- Styling und Tests angepasst
- Dokumentation und Changelog aktualisiert

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abf02d302083278436d7cdb8e8b023