### PR TITLE
Notizfeld pro Ordnerzeile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.187
+* Pro Datei kann jetzt eine individuelle Notiz unter dem Ordnernamen gespeichert werden.
 ## 🛠️ Patch in 1.40.186
 * "Emotionen kopieren" bietet Checkboxen, um Zeit und/oder `---` anzufügen.
 ## 🛠️ Patch in 1.40.185

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Kompaktere Dubbing-Spalte:** Der Statuspunkt und der Download-Pfeil stehen jetzt direkt neben dem Dubbing-Button in einer gemeinsamen Spalte.
 * **Einheitliche Tabellenspalten:** EN- und DE-Text erscheinen untereinander, alle Aktions-Buttons bilden eine vertikale Spalte.
 * **Optimierte Tabelle:** Ordnernamen sind korrekt ausgerichtet, schmale UT- und Pfad-Spalten lassen mehr Platz für die Texte und die Aktionssymbole sind gruppiert.
+* **Notizen pro Ordnerzeile:** Unter dem Ordnernamen lässt sich nun eine individuelle Notiz speichern.
 * **Erklärende Tooltips:** In der Aktionenspalte zeigt jedes Symbol beim Überfahren mit der Maus seinen Zweck an.
 * **Schmalere Versionsspalte:** "Version" und "Score" stehen im Kopf sowie in jeder Zeile untereinander, wodurch die Tabelle breiterem Text mehr Platz lässt.
 * **Modernisierte Aktionsleiste:** Alle Bedienknöpfe besitzen abgerundete Ecken und sind in klaren Zeilen gruppiert.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2525,6 +2525,7 @@ function addFiles() {
                 filename: filename,
                 folder: folder,
                 fullPath: fullPath,
+                folderNote: '',
                 enText: textDatabase[fileKey]?.en || '',
                 deText: textDatabase[fileKey]?.de || '',
                 emotionalText: textDatabase[fileKey]?.emo || '',
@@ -3898,6 +3899,8 @@ return `
                   onclick="showFileExchangeOptions(${file.id})">
                 ${folderIcon} ${lastFolder}
             </span>
+            <input type="text" class="folder-note" placeholder="Notiz" value="${escapeHtml(file.folderNote || '')}"
+                   oninput="setFolderNote(${file.id}, this.value)">
         </td>
         <td class="version-score-cell">
             ${hasDeAudio ? `<span class="version-badge" style="background:${getVersionColor(file.version ?? 1)}" onclick="openVersionMenu(event, ${file.id})">${file.version ?? 1}</span>` : ''}
@@ -5620,6 +5623,15 @@ function deleteFile(fileId) {
                 }
             }, 100);
         }
+        
+// Aktualisiert die Notiz eines Datei-Eintrags
+function setFolderNote(fileId, note) {
+    const file = files.find(f => f.id === fileId);
+    if (!file) return;
+    file.folderNote = note;
+    isDirty = true;
+    saveCurrentProject();
+}
 
 // =========================== CHECKFILENAME START ===========================
 // Prüft beim Klick auf den Dateinamen, ob die Datei existiert und bietet
@@ -8192,6 +8204,7 @@ function addFileFromFolderBrowser(filename, folder, fullPath) {
         filename: filename,
         folder: folder,
         // fullPath wird NICHT mehr gespeichert - wird dynamisch geladen
+        folderNote: '',
         enText: textDatabase[fileKey]?.en || '',
         deText: textDatabase[fileKey]?.de || '',
         emotionalText: textDatabase[fileKey]?.emo || '',
@@ -13791,6 +13804,7 @@ function addFileToProject(filename, folder, originalResult) {
         filename: filename,
         folder: folder,
         // fullPath wird NICHT mehr gespeichert - wird dynamisch geladen
+        folderNote: '',
         enText: textDatabase[fileKey]?.en || '',
         deText: textDatabase[fileKey]?.de || '',
         emotionalText: textDatabase[fileKey]?.emo || '',

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1233,6 +1233,13 @@ th:nth-child(8) {
     vertical-align: top;
 }
 
+/* Eingabefeld für Notizen unter dem Ordnernamen */
+.folder-note {
+    display: block;
+    width: 100%;
+    margin-top: 4px;
+}
+
 /* Version und Score untereinander */
 .version-score-cell {
     display: flex;


### PR DESCRIPTION
## Zusammenfassung
- Notizfeld unter dem Ordnernamen in der Dateitabelle, speichert individuelle Hinweise pro Datei
- CSS-Stil für das neue Notizfeld
- README und CHANGELOG angepasst

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a473fe9c8327876393d08f8e223d