### PR TITLE
📊 Notizstatistik pro Level in der Projektleiste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.189
+* 📊‑Symbol neben jedem Level zeigt die Notizen dieses Levels samt Gesamtanzahl im Projekt.
 ## 🛠️ Patch in 1.40.188
 * Gleichlautende Notizen werden farbig hervorgehoben und zeigen die Anzahl identischer Einträge.
 ## 🛠️ Patch in 1.40.187

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Automatische MP3-Konvertierung** beim Start (Originale in `Backups/mp3`)
 * **Automatische Prüfung geänderter Endungen** passt Datenbank und Projekte an
 * **Live‑Statistiken:** EN‑%, DE‑%, Completion‑%, Globale Textzahlen (EN/DE/BEIDE/∑)
+* **Notiz-Übersicht pro Level:** 📊‑Symbol zeigt alle Notizen eines Levels und deren Häufigkeit im gesamten Projekt
 * **Vollständig offline** – keine Server, keine externen Abhängigkeiten
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
 * **Schnellstart mit Cheats:** Im Dropdown lassen sich Godmode, unendliche Munition und die Entwicklerkonsole einzeln auswählen. Das Spiel startet nach Klick auf **Starten** mit allen markierten Optionen.

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -3279,7 +3279,7 @@ th:nth-child(8) {
 .level-container.collapsed .projects { display: none; }
 .level {
     display: grid;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto auto 1fr auto auto;
     gap: 6px;
     align-items: center;
     cursor: pointer;
@@ -3302,6 +3302,14 @@ th:nth-child(8) {
     font-size: 0.8em;                      /* Level-ID kleiner und grau */
     color: #aaa;
     font-family: "Courier New", monospace;
+}
+.level-header .level-stats-icon {
+    cursor: pointer;                       /* Klickbares Statistik-Symbol */
+    color: #888;                           /* dezente Ausgangsfarbe */
+    transition: color 0.2s;
+}
+.level-header .level-stats-icon:hover {
+    color: #fff;                           /* hellere Farbe beim Überfahren */
 }
 .level-header .level-arrow {
     color: #888;


### PR DESCRIPTION
## Zusammenfassung
- Statistik-Symbol neben jedem Level zeigt eine Übersicht der Notizen dieses Levels samt Häufigkeit
- Layout der Level-Leiste angepasst und Icon optisch hervorgehoben
- README und CHANGELOG um neue Funktion ergänzt

## Tests
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ad2344d48327b041868d2893fb50