### PR TITLE
Bugfix: Fehler beim Laden durch verwaiste Vorschlagsfelder verhindern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.190
+* Beim Laden eines Projekts führen Vorschlagsfelder ohne zugehörige Datei nicht mehr zu einem Fehler
 ## 🛠️ Patch in 1.40.189
 * 📊‑Symbol neben jedem Level zeigt die Notizen dieses Levels samt Gesamtanzahl im Projekt.
 ## 🛠️ Patch in 1.40.188

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Feineres Bewertungsschema:** Ab 95 % wird der Score grün, zwischen 85 % und 94 % gelb
 * **Score in Prozent:** Die Bewertung wird in der Tabelle mit Prozentzeichen dargestellt
 * **Aktive Score-Events:** Nach jedem Rendern bindet `attachScoreHandlers` Tooltip und Klick
+* **Bugfix:** Verwaiste Vorschlagsfelder lösen beim Laden kein Fehlerereignis mehr aus
 * **Kommentar-Anzeige auf ganzer Fläche:** Der Tooltip reagiert jetzt auf das gesamte Score-Feld
 * **Direkter Daten-Refresh:** Nach jeder Bewertung wird die Tabelle mit den aktualisierten Dateien neu gerendert
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -4052,8 +4052,14 @@ return `
         document.querySelectorAll('.suggestion-box').forEach(div => {
             const id = Number(div.dataset.fileId);
             const file = files.find(f => f.id === id);
+            if (!file) {
+                // Fehlende Zuordnung abfangen, um Laufzeitfehler zu vermeiden
+                console.warn(`Keine Datei für Vorschlag mit ID ${id} gefunden.`);
+                return;
+            }
             div.textContent = file.suggestion || '';
             div.onclick = () => {
+                // Klick übernimmt den GPT-Vorschlag in den DE-Text
                 file.deText = file.suggestion;
                 window.isDirty = true;
                 const container = div.nextElementSibling;


### PR DESCRIPTION
## Zusammenfassung
- Fehlerbehandlung für `.suggestion-box` eingefügt, um fehlende Dateien abzufangen
- Dokumentation um Hinweis auf behobenen Projekt-Ladefehler erweitert
- Changelog für Version 1.40.190 ergänzt

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0bee397148327b5ccb7f82dcb9613