### PR TITLE
Validierung der Vorschlagsfelder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.192
+* Vorschlagsfelder prüfen nun die zugehörige Datei, entfernen ungültige Einträge aus der Tabelle und zeigen eine Fehlermeldung an.
 ## 🛠️ Patch in 1.40.191
 * Kann ein Projekt nicht geladen werden, erscheint ein Fenster mit genauer Ursache und Reparaturhinweis.
 ## 🛠️ Patch in 1.40.190

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Score in Prozent:** Die Bewertung wird in der Tabelle mit Prozentzeichen dargestellt
 * **Aktive Score-Events:** Nach jedem Rendern bindet `attachScoreHandlers` Tooltip und Klick
 * **Bugfix:** Verwaiste Vorschlagsfelder lösen beim Laden kein Fehlerereignis mehr aus
+* **Validierte Vorschlagsfelder:** Fehlt die zugehörige Datei, wird der Eintrag entfernt und eine Meldung weist darauf hin
 * **Kommentar-Anzeige auf ganzer Fläche:** Der Tooltip reagiert jetzt auf das gesamte Score-Feld
 * **Direkter Daten-Refresh:** Nach jeder Bewertung wird die Tabelle mit den aktualisierten Dateien neu gerendert
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -4077,8 +4077,10 @@ return `
             const id = Number(div.dataset.fileId);
             const file = files.find(f => f.id === id);
             if (!file) {
-                // Fehlende Zuordnung abfangen, um Laufzeitfehler zu vermeiden
-                console.warn(`Keine Datei für Vorschlag mit ID ${id} gefunden.`);
+                // Dateizuordnung fehlt → Element entfernen und Nutzer informieren
+                const row = div.closest('tr');
+                if (row) row.remove();
+                alert(`❌ Keine Datei für Vorschlag mit ID ${id} gefunden. Der Eintrag wurde entfernt.`);
                 return;
             }
             div.textContent = file.suggestion || '';


### PR DESCRIPTION
## Zusammenfassung
- Vorschlagsfelder validieren nun die zugehörige Datei, entfernen verwaiste Zeilen und informieren den Nutzer
- Dokumentation zu dieser Validierung in README und CHANGELOG ergänzt

## Tests
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0c89729608327a92c069414761f6c