### PR TITLE
Add file-based storage via File System Access API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.195
+* Projektdaten lassen sich per File System Access API als JSON speichern und wieder laden.
+* `migrateLocalStorageToFile` exportiert bestehende LocalStorage-Daten in das neue Dateiformat.
 ## 🛠️ Patch in 1.40.194
 * Neuer globaler Knopf durchsucht alle Dateien ohne deutschen Text und übernimmt eindeutige Untertitel automatisch.
 ## 🛠️ Patch in 1.40.193

--- a/README.md
+++ b/README.md
@@ -1011,5 +1011,8 @@ verwendet werden, um optionale Downloads zu überspringen.
 * **`syncProjectData(projects, filePathDatabase, textDatabase)`** – gleicht Projekte mit der Datenbank ab, korrigiert Dateiendungen und überträgt Texte.
 * **`repairFileExtensions(projects, filePathDatabase, textDatabase)`** – aktualisiert veraltete Dateiendungen in Projekten und verschiebt vorhandene Texte.
   Die Funktionen stehen im Browser direkt unter `window` zur Verfügung und können ohne Import genutzt werden.
-* **`safeCopy(text)`** – kopiert Text in die Zwischenablage und greift bei Fehlern auf Electron zurück.
-* **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.
+  * **`safeCopy(text)`** – kopiert Text in die Zwischenablage und greift bei Fehlern auf Electron zurück.
+  * **`saveProjectToFile(data)`** – speichert das übergebene Objekt per File System Access API als JSON auf der Festplatte.
+  * **`loadProjectFromFile()`** – öffnet eine zuvor gesicherte JSON-Datei und liefert deren Inhalt als Objekt.
+  * **`migrateLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei und leert anschließend den Speicher.
+  * **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -941,9 +941,10 @@
     <!-- Verlinkung zur aktuellen Version -->
     <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.40.127</a>
 
-    <script src="src/colorUtils.js"></script>
-    <script src="src/main.js"></script>
-    <script type="module" src="renderer.js"></script>
+     <script src="src/colorUtils.js"></script>
+     <script src="src/fileStorage.js"></script>
+     <script src="src/main.js"></script>
+     <script type="module" src="renderer.js"></script>
 </body>
 </html>
 

--- a/web/src/fileStorage.js
+++ b/web/src/fileStorage.js
@@ -1,0 +1,41 @@
+// Verwaltet das Speichern und Laden großer Datenmengen über die File System Access API
+// Diese Funktionen ermöglichen es, Projektdaten außerhalb des LocalStorage abzulegen
+
+// Speichert das übergebene Objekt als JSON-Datei
+window.saveProjectToFile = async function(data) {
+    // Nutzer nach einem Speicherort fragen
+    const handle = await window.showSaveFilePicker({
+        types: [{
+            description: 'JSON-Datei',
+            accept: { 'application/json': ['.json'] }
+        }]
+    });
+    const writable = await handle.createWritable();
+    await writable.write(JSON.stringify(data, null, 2));
+    await writable.close();
+    return handle;
+};
+
+// Öffnet eine zuvor gespeicherte Datei und gibt deren Inhalt als Objekt zurück
+window.loadProjectFromFile = async function() {
+    const [handle] = await window.showOpenFilePicker({
+        types: [{
+            description: 'JSON-Datei',
+            accept: { 'application/json': ['.json'] }
+        }]
+    });
+    const file = await handle.getFile();
+    const text = await file.text();
+    return JSON.parse(text);
+};
+
+// Überträgt alle Einträge aus dem LocalStorage in eine Datei und leert den Speicher
+window.migrateLocalStorageToFile = async function() {
+    const data = {};
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        data[key] = localStorage.getItem(key);
+    }
+    await window.saveProjectToFile(data);
+    localStorage.clear();
+};


### PR DESCRIPTION
## Summary
- add File System Access API helper to store project data in JSON files
- export existing LocalStorage content with `migrateLocalStorageToFile`
- document new persistence helpers in README and changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b153447cb88327af1c21d31d60d43e