### PR TITLE
Migration-UI und LocalStorage-Fehlerabfang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 🛠️ Patch in 1.40.196
+* Button „Migration starten“ exportiert LocalStorage-Daten in eine JSON-Datei und zeigt den Fortschritt an.
+* Speicheroperationen fangen das Überschreiten des LocalStorage-Limits ab und weisen auf die Migration hin.
+## 🛠️ Patch in 1.40.195
+* Projektdaten lassen sich per File System Access API als JSON speichern und wieder laden.
+* `migrateLocalStorageToFile` exportiert bestehende LocalStorage-Daten in das neue Dateiformat.
 ## 🛠️ Patch in 1.40.194
 * Neuer globaler Knopf durchsucht alle Dateien ohne deutschen Text und übernimmt eindeutige Untertitel automatisch.
 ## 🛠️ Patch in 1.40.193

--- a/README.md
+++ b/README.md
@@ -894,6 +894,10 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * ▶ **Neu:** Segment-Import ohne Ordnerauswahl – in der Desktop-Version landen zugeschnittene Segmente jetzt direkt per `saveDeFile` am richtigen Ort.
 * ▶ **Fix:** Importierte Segmente setzen alle Bearbeitungs-Symbole zurück.
 * ▶ **Neu:** Zuordnungen im Segment-Dialog bleiben nach einem Neustart erhalten.
+ 
+**📦 Zu große Projekte**
+* ▶ **Hinweis:** Überschreitet das Projekt das LocalStorage-Limit, erscheint beim Speichern eine Warnung.
+* ▶ **Lösung:** Über den Knopf „Migration starten“ lassen sich alle Einträge in eine JSON-Datei exportieren und der LocalStorage wird geleert.
 
 #### Häufige Crash-Stellen
 
@@ -1011,5 +1015,9 @@ verwendet werden, um optionale Downloads zu überspringen.
 * **`syncProjectData(projects, filePathDatabase, textDatabase)`** – gleicht Projekte mit der Datenbank ab, korrigiert Dateiendungen und überträgt Texte.
 * **`repairFileExtensions(projects, filePathDatabase, textDatabase)`** – aktualisiert veraltete Dateiendungen in Projekten und verschiebt vorhandene Texte.
   Die Funktionen stehen im Browser direkt unter `window` zur Verfügung und können ohne Import genutzt werden.
-* **`safeCopy(text)`** – kopiert Text in die Zwischenablage und greift bei Fehlern auf Electron zurück.
-* **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.
+  * **`safeCopy(text)`** – kopiert Text in die Zwischenablage und greift bei Fehlern auf Electron zurück.
+  * **`saveProjectToFile(data)`** – speichert das übergebene Objekt per File System Access API als JSON auf der Festplatte.
+  * **`loadProjectFromFile()`** – öffnet eine zuvor gesicherte JSON-Datei und liefert deren Inhalt als Objekt.
+  * **`migrateLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei und leert anschließend den Speicher.
+  * **`startMigration()`** – ruft die Migration per Button auf und zeigt den Fortschritt im Element `#migration-status` an.
+  * **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -25,6 +25,10 @@
         <span id="errorBannerMessage"></span>
         <button id="errorBannerRetry">Erneut versuchen</button>
     </div>
+    <!-- Knopf zur Migration der LocalStorage-Daten in das neue Dateiformat -->
+    <button id="migration-button" onclick="startMigration()">Migration starten</button>
+    <!-- Ausgabebereich für Fortschrittsmeldungen der Migration -->
+    <div id="migration-status"></div>
     <div class="container">
         <!-- Sidebar -->
         <aside class="sidebar">
@@ -941,9 +945,11 @@
     <!-- Verlinkung zur aktuellen Version -->
     <a id="versionLink" href="https://github.com/Lumorn/hla_translation_tool" target="_blank">v1.40.127</a>
 
-    <script src="src/colorUtils.js"></script>
-    <script src="src/main.js"></script>
-    <script type="module" src="renderer.js"></script>
+     <script src="src/colorUtils.js"></script>
+     <script src="src/fileStorage.js"></script>
+     <script src="src/migrationUI.js"></script>
+     <script src="src/main.js"></script>
+     <script type="module" src="renderer.js"></script>
 </body>
 </html>
 

--- a/web/src/fileStorage.js
+++ b/web/src/fileStorage.js
@@ -1,0 +1,41 @@
+// Verwaltet das Speichern und Laden großer Datenmengen über die File System Access API
+// Diese Funktionen ermöglichen es, Projektdaten außerhalb des LocalStorage abzulegen
+
+// Speichert das übergebene Objekt als JSON-Datei
+window.saveProjectToFile = async function(data) {
+    // Nutzer nach einem Speicherort fragen
+    const handle = await window.showSaveFilePicker({
+        types: [{
+            description: 'JSON-Datei',
+            accept: { 'application/json': ['.json'] }
+        }]
+    });
+    const writable = await handle.createWritable();
+    await writable.write(JSON.stringify(data, null, 2));
+    await writable.close();
+    return handle;
+};
+
+// Öffnet eine zuvor gespeicherte Datei und gibt deren Inhalt als Objekt zurück
+window.loadProjectFromFile = async function() {
+    const [handle] = await window.showOpenFilePicker({
+        types: [{
+            description: 'JSON-Datei',
+            accept: { 'application/json': ['.json'] }
+        }]
+    });
+    const file = await handle.getFile();
+    const text = await file.text();
+    return JSON.parse(text);
+};
+
+// Überträgt alle Einträge aus dem LocalStorage in eine Datei und leert den Speicher
+window.migrateLocalStorageToFile = async function() {
+    const data = {};
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        data[key] = localStorage.getItem(key);
+    }
+    await window.saveProjectToFile(data);
+    localStorage.clear();
+};

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1869,21 +1869,36 @@ function loadProjects() {
 // =========================== LOAD PROJECTS END ===========================
 
 
+        // Sicheres Speichern in den LocalStorage mit Fehlerabfang
+        function safeSetItem(key, value) {
+            try {
+                localStorage.setItem(key, value);
+                return true;
+            } catch (e) {
+                if (e.name === 'QuotaExceededError') {
+                    alert('Speicherlimit erreicht. Bitte nutzen Sie "Migration starten" und speichern Sie Daten in eine Datei.');
+                }
+                console.error('Speichern in LocalStorage fehlgeschlagen', e);
+                return false;
+            }
+        }
+
         function saveProjects() {
-            localStorage.setItem('hla_projects', JSON.stringify(projects));
-            updateGlobalProjectProgress();
+            if (safeSetItem('hla_projects', JSON.stringify(projects))) {
+                updateGlobalProjectProgress();
+            }
         }
 
         function saveTextDatabase() {
-            localStorage.setItem('hla_textDatabase', JSON.stringify(textDatabase));
+            safeSetItem('hla_textDatabase', JSON.stringify(textDatabase));
         }
 
         function saveFilePathDatabase() {
-            localStorage.setItem('hla_filePathDatabase', JSON.stringify(filePathDatabase));
+            safeSetItem('hla_filePathDatabase', JSON.stringify(filePathDatabase));
         }
 
         function saveFolderCustomizations() {
-            localStorage.setItem('hla_folderCustomizations', JSON.stringify(folderCustomizations));
+            safeSetItem('hla_folderCustomizations', JSON.stringify(folderCustomizations));
         }
 
         // =========================== HANDLE-DATENBANK START =====================

--- a/web/src/migrationUI.js
+++ b/web/src/migrationUI.js
@@ -1,0 +1,19 @@
+// Zeigt den Migrationsfortschritt aus dem LocalStorage in eine Datei an
+// und nutzt dabei die Funktionen aus fileStorage.js
+
+window.startMigration = async function() {
+    // Status-Element im DOM ermitteln
+    const statusEl = document.getElementById('migration-status');
+    const total = localStorage.length;
+    // Anzahl der Einträge vor Beginn anzeigen
+    statusEl.textContent = `Übertrage ${total} Einträge...`;
+    try {
+        await window.migrateLocalStorageToFile();
+        // Erfolgsmeldung ausgeben und verbleibende Einträge prüfen
+        statusEl.textContent = `Migration abgeschlossen – ${total} Einträge exportiert. LocalStorage enthält jetzt ${localStorage.length} Einträge.`;
+    } catch (err) {
+        // Fehler anzeigen, falls etwas schief geht
+        console.error('Migration fehlgeschlagen', err);
+        statusEl.textContent = 'Migration fehlgeschlagen. Details in der Konsole.';
+    }
+};


### PR DESCRIPTION
## Zusammenfassung
- Migration-UI für den Umzug von LocalStorage-Daten in eine Datei mit Fortschrittsanzeige
- Speichern fängt QuotaExceededError ab und weist auf Migration hin
- Dokumentation in README und CHANGELOG ergänzt

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b153447cb88327af1c21d31d60d43e