### PR TITLE
Migration speichert Daten in Ordner und zeigt Vergleich an

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.197
+* Migration zeigt alte und neue Eintragsanzahl und speichert die Daten in einen gewählten Ordner.
 ## 🛠️ Patch in 1.40.196
 * UI-Knopf „Migration starten“ exportiert alle LocalStorage-Einträge in eine Datei und zeigt Statusmeldungen an.
 ## 🛠️ Patch in 1.40.195

--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,6 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`safeCopy(text)`** – kopiert Text in die Zwischenablage und greift bei Fehlern auf Electron zurück.
   * **`saveProjectToFile(data)`** – speichert das übergebene Objekt per File System Access API als JSON auf der Festplatte.
   * **`loadProjectFromFile()`** – öffnet eine zuvor gesicherte JSON-Datei und liefert deren Inhalt als Objekt.
-  * **`migrateLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei und leert anschließend den Speicher.
-  * **`startMigration()`** – startet die LocalStorage-Migration und zeigt Statusmeldungen in der Oberfläche an.
+  * **`migrateLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei im gewählten Ordner, leert anschließend den Speicher und gibt den Speicherort zurück.
+  * **`startMigration()`** – startet den Export, zeigt alte und neue Eintragsanzahl sowie den Zielordner in der Oberfläche an.
   * **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.

--- a/tests/migrationUI.test.js
+++ b/tests/migrationUI.test.js
@@ -8,11 +8,15 @@ beforeEach(() => {
     document.body.innerHTML = '<div id="migration-status"></div>';
     // LocalStorage leeren
     localStorage.clear();
-    // File-System-API stubben
-    window.showSaveFilePicker = async () => ({
-        createWritable: async () => ({
-            write: async (text) => { gespeicherterText = text; },
-            close: async () => {}
+    // File-System-API stubben: Verzeichnis- und Dateihandles
+    window.showDirectoryPicker = async () => ({
+        name: 'Export',
+        getFileHandle: async (name, opts) => ({
+            name,
+            createWritable: async () => ({
+                write: async (text) => { gespeicherterText = text; },
+                close: async () => {}
+            })
         })
     });
 });
@@ -32,6 +36,8 @@ test('startMigration exportiert alle Einträge und leert den Speicher', async ()
     expect(gespeichert.projektA).toBe('datenA');
     expect(gespeichert.projektB).toBe('datenB');
     expect(localStorage.length).toBe(0);
-    expect(document.getElementById('migration-status').textContent)
-        .toContain('Migration abgeschlossen');
+    const status = document.getElementById('migration-status').textContent;
+    expect(status).toContain('Migration abgeschlossen');
+    expect(status).toContain('Export');
+    expect(status).toContain('2 → 2');
 });

--- a/web/src/fileStorage.js
+++ b/web/src/fileStorage.js
@@ -30,12 +30,21 @@ window.loadProjectFromFile = async function() {
 };
 
 // Überträgt alle Einträge aus dem LocalStorage in eine Datei und leert den Speicher
+// Die Daten werden in einem vom Nutzer gewählten Ordner als "hla_daten.json" gespeichert
+// und die Funktion liefert Informationen über den Speicherort zurück
 window.migrateLocalStorageToFile = async function() {
     const data = {};
     for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
         data[key] = localStorage.getItem(key);
     }
-    await window.saveProjectToFile(data);
+    // Ordner wählen, in dem die Datei landen soll
+    const dirHandle = await window.showDirectoryPicker();
+    const fileHandle = await dirHandle.getFileHandle('hla_daten.json', { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(JSON.stringify(data, null, 2));
+    await writable.close();
+    // LocalStorage aufräumen
     localStorage.clear();
+    return { newCount: Object.keys(data).length, fileName: fileHandle.name, dirName: dirHandle.name };
 };

--- a/web/src/migrationUI.js
+++ b/web/src/migrationUI.js
@@ -1,13 +1,13 @@
 // Steuert die Migration von LocalStorage-Daten in eine Datei und zeigt Statusmeldungen an
 window.startMigration = async function() {
     const statusEl = document.getElementById('migration-status');
-    const count = localStorage.length;
-    // Anzahl der vorhandenen Einträge anzeigen
-    statusEl.textContent = `Starte Migration mit ${count} Einträgen...`;
+    const oldCount = localStorage.length;
+    // Vorherige Anzahl anzeigen
+    statusEl.textContent = `Alte Daten: ${oldCount} Einträge – Export läuft...`;
     try {
-        await window.migrateLocalStorageToFile();
-        // Erfolgsmeldung nach Abschluss
-        statusEl.textContent = `Migration abgeschlossen: ${count} Einträge exportiert.`;
+        const result = await window.migrateLocalStorageToFile();
+        // Erfolgsmeldung mit Vergleich alt/neu und Zielordner
+        statusEl.textContent = `Migration abgeschlossen: ${oldCount} → ${result.newCount} Einträge in "${result.dirName}" (${result.fileName}).`;
     } catch (err) {
         // Fehlerhinweis bei Problemen
         statusEl.textContent = `Fehler bei der Migration: ${err.message}`;


### PR DESCRIPTION
## Zusammenfassung
- LocalStorage-Daten wandern jetzt per File System Access API in eine Datei `hla_daten.json` innerhalb eines gewählten Ordners.
- Die Migrationsoberfläche zeigt Anzahl alter und neuer Einträge sowie Zielordner und Dateiname an.
- README und Changelog dokumentieren die erweiterte Migration.

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b15c8a414883278be18f1796660000