### PR TITLE
Migration: verständliche Fehlermeldung ohne File-System-API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.198
+* Migration fängt fehlende File-System-API ab und zeigt eine verständliche Fehlermeldung an.
 ## 🛠️ Patch in 1.40.197
 * Migration zeigt alte und neue Eintragsanzahl und speichert die Daten in einen gewählten Ordner.
 ## 🛠️ Patch in 1.40.196

--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,6 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`safeCopy(text)`** – kopiert Text in die Zwischenablage und greift bei Fehlern auf Electron zurück.
   * **`saveProjectToFile(data)`** – speichert das übergebene Objekt per File System Access API als JSON auf der Festplatte.
   * **`loadProjectFromFile()`** – öffnet eine zuvor gesicherte JSON-Datei und liefert deren Inhalt als Objekt.
-  * **`migrateLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei im gewählten Ordner, leert anschließend den Speicher und gibt den Speicherort zurück.
+  * **`migrateLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei im gewählten Ordner, leert anschließend den Speicher und gibt den Speicherort zurück; prüft die Verfügbarkeit der File-System-API und liefert bei fehlendem Support eine verständliche Fehlermeldung.
   * **`startMigration()`** – startet den Export, zeigt alte und neue Eintragsanzahl sowie den Zielordner in der Oberfläche an.
   * **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.

--- a/tests/migrationUI.test.js
+++ b/tests/migrationUI.test.js
@@ -8,6 +8,8 @@ beforeEach(() => {
     document.body.innerHTML = '<div id="migration-status"></div>';
     // LocalStorage leeren
     localStorage.clear();
+    // Sicherstellen, dass der Kontext als sicher gilt
+    window.isSecureContext = true;
     // File-System-API stubben: Verzeichnis- und Dateihandles
     window.showDirectoryPicker = async () => ({
         name: 'Export',
@@ -40,4 +42,20 @@ test('startMigration exportiert alle Einträge und leert den Speicher', async ()
     expect(status).toContain('Migration abgeschlossen');
     expect(status).toContain('Export');
     expect(status).toContain('2 → 2');
+});
+
+test('startMigration meldet fehlende File-System-API verständlich', async () => {
+    // API entfernt, um Fehlerpfad zu testen
+    delete window.showDirectoryPicker;
+
+    const fileStorage = fs.readFileSync(path.join(__dirname, '../web/src/fileStorage.js'), 'utf8');
+    eval(fileStorage);
+    const migrationUI = fs.readFileSync(path.join(__dirname, '../web/src/migrationUI.js'), 'utf8');
+    eval(migrationUI);
+
+    await window.startMigration();
+
+    const status = document.getElementById('migration-status').textContent;
+    expect(status).toContain('Fehler bei der Migration');
+    expect(status).toContain('Dateisystem-API');
 });

--- a/web/src/fileStorage.js
+++ b/web/src/fileStorage.js
@@ -38,8 +38,18 @@ window.migrateLocalStorageToFile = async function() {
         const key = localStorage.key(i);
         data[key] = localStorage.getItem(key);
     }
+    // Prüfen, ob die File-System-API im aktuellen Kontext verfügbar ist
+    if (!window.isSecureContext || typeof window.showDirectoryPicker !== 'function') {
+        throw new Error('Dateisystem-API wird in diesem Kontext nicht unterstützt');
+    }
     // Ordner wählen, in dem die Datei landen soll
-    const dirHandle = await window.showDirectoryPicker();
+    let dirHandle;
+    try {
+        dirHandle = await window.showDirectoryPicker();
+    } catch (err) {
+        // Verständliche Fehlermeldung, falls der Zugriff verweigert wird
+        throw new Error('Dateisystem-Zugriff verweigert oder vom Browser blockiert');
+    }
     const fileHandle = await dirHandle.getFileHandle('hla_daten.json', { create: true });
     const writable = await fileHandle.createWritable();
     await writable.write(JSON.stringify(data, null, 2));


### PR DESCRIPTION
## Zusammenfassung
- Prüfung der File-System-API vor der Migration und verständliche Fehlermeldung bei blockiertem Zugriff
- Testfall für fehlende File-System-API ergänzt
- Dokumentation und Changelog aktualisiert

## Testanweisungen
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b15d9e24648327a9db74a03679ba8d