### PR TITLE
Fange verweigerten Dateizugriff bei Migration ab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.199
+* Migration zeigt bei verweigertem Dateizugriff eine verständliche Fehlermeldung an.
 ## 🛠️ Patch in 1.40.198
 * Migration fängt fehlende File-System-API ab und zeigt eine verständliche Fehlermeldung an.
 ## 🛠️ Patch in 1.40.197

--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,6 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`safeCopy(text)`** – kopiert Text in die Zwischenablage und greift bei Fehlern auf Electron zurück.
   * **`saveProjectToFile(data)`** – speichert das übergebene Objekt per File System Access API als JSON auf der Festplatte.
   * **`loadProjectFromFile()`** – öffnet eine zuvor gesicherte JSON-Datei und liefert deren Inhalt als Objekt.
-  * **`migrateLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei im gewählten Ordner, leert anschließend den Speicher und gibt den Speicherort zurück; prüft die Verfügbarkeit der File-System-API und liefert bei fehlendem Support eine verständliche Fehlermeldung.
+  * **`migrateLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei im gewählten Ordner, leert anschließend den Speicher und gibt den Speicherort zurück; prüft die Verfügbarkeit der File-System-API und liefert bei fehlendem Support oder verweigertem Zugriff eine verständliche Fehlermeldung.
   * **`startMigration()`** – startet den Export, zeigt alte und neue Eintragsanzahl sowie den Zielordner in der Oberfläche an.
   * **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.

--- a/tests/migrationUI.test.js
+++ b/tests/migrationUI.test.js
@@ -59,3 +59,22 @@ test('startMigration meldet fehlende File-System-API verständlich', async () =>
     expect(status).toContain('Fehler bei der Migration');
     expect(status).toContain('Dateisystem-API');
 });
+
+test('startMigration meldet verweigerten Dateizugriff verständlich', async () => {
+    // Verzeichnis-Handle liefert beim Öffnen der Datei einen Fehler
+    window.showDirectoryPicker = async () => ({
+        name: 'Export',
+        getFileHandle: async () => { throw new Error('not allowed'); }
+    });
+
+    const fileStorage = fs.readFileSync(path.join(__dirname, '../web/src/fileStorage.js'), 'utf8');
+    eval(fileStorage);
+    const migrationUI = fs.readFileSync(path.join(__dirname, '../web/src/migrationUI.js'), 'utf8');
+    eval(migrationUI);
+
+    await window.startMigration();
+
+    const status = document.getElementById('migration-status').textContent;
+    expect(status).toContain('Fehler bei der Migration');
+    expect(status).toContain('Dateisystem-Zugriff');
+});

--- a/web/src/fileStorage.js
+++ b/web/src/fileStorage.js
@@ -42,16 +42,17 @@ window.migrateLocalStorageToFile = async function() {
     if (!window.isSecureContext || typeof window.showDirectoryPicker !== 'function') {
         throw new Error('Dateisystem-API wird in diesem Kontext nicht unterstützt');
     }
-    // Ordner wählen, in dem die Datei landen soll
-    let dirHandle;
+    // Ordner wählen und Schreibzugriff anfordern
+    let dirHandle, fileHandle, writable;
     try {
         dirHandle = await window.showDirectoryPicker();
+        fileHandle = await dirHandle.getFileHandle('hla_daten.json', { create: true });
+        writable = await fileHandle.createWritable();
     } catch (err) {
-        // Verständliche Fehlermeldung, falls der Zugriff verweigert wird
+        // Verständliche Fehlermeldung, falls der Zugriff verweigert oder blockiert wird
         throw new Error('Dateisystem-Zugriff verweigert oder vom Browser blockiert');
     }
-    const fileHandle = await dirHandle.getFileHandle('hla_daten.json', { create: true });
-    const writable = await fileHandle.createWritable();
+    // Daten schreiben und Datei schließen
     await writable.write(JSON.stringify(data, null, 2));
     await writable.close();
     // LocalStorage aufräumen


### PR DESCRIPTION
## Zusammenfassung
- Fang Fehler beim Zugriff auf Dateisystem während der Migration ab und gib verständliche Meldung aus.
- Dokumentation um Hinweis auf freundliche Fehlermeldung bei verweigertem Zugriff erweitert.
- Test ergänzt, der blockierten Dateizugriff simuliert.

## Testanweisungen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b15f6d44a88327a8d5461c90c13de4