### PR TITLE
Fallback auf internen Browser-Speicher bei fehlendem Dateizugriff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.200
+* Migration speichert bei verweigertem Dateizugriff automatisch im internen Browser-Speicher (OPFS).
 ## 🛠️ Patch in 1.40.199
 * Migration zeigt bei verweigertem Dateizugriff eine verständliche Fehlermeldung an.
 ## 🛠️ Patch in 1.40.198

--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,6 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`safeCopy(text)`** – kopiert Text in die Zwischenablage und greift bei Fehlern auf Electron zurück.
   * **`saveProjectToFile(data)`** – speichert das übergebene Objekt per File System Access API als JSON auf der Festplatte.
   * **`loadProjectFromFile()`** – öffnet eine zuvor gesicherte JSON-Datei und liefert deren Inhalt als Objekt.
-  * **`migrateLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei im gewählten Ordner, leert anschließend den Speicher und gibt den Speicherort zurück; prüft die Verfügbarkeit der File-System-API und liefert bei fehlendem Support oder verweigertem Zugriff eine verständliche Fehlermeldung.
+  * **`migrateLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei im gewählten Ordner, leert anschließend den Speicher und gibt den Speicherort zurück; prüft die Verfügbarkeit der File-System-API, nutzt bei verweigertem Zugriff den internen Browser-Speicher (OPFS) als Fallback und liefert nur bei fehlendem Support eine verständliche Fehlermeldung.
   * **`startMigration()`** – startet den Export, zeigt alte und neue Eintragsanzahl sowie den Zielordner in der Oberfläche an.
   * **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.


### PR DESCRIPTION
## Zusammenfassung
- nutze OPFS als Fallback, wenn der Zugriff über `showDirectoryPicker` blockiert wird
- beschreibe den neuen Fallback in README und CHANGELOG
- erweitere Migrationstests um den OPFS-Fallback

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b16080838c8327a074c6313f226340