### PR TITLE
Dauerhafter Browser-Fallback über IndexedDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.200
+* Migration sichert Daten bei verweigertem Dateizugriff dauerhaft in einer Browser-Datenbank (IndexedDB), ohne den LocalStorage zu löschen.
 ## 🛠️ Patch in 1.40.199
 * Migration zeigt bei verweigertem Dateizugriff eine verständliche Fehlermeldung an.
 ## 🛠️ Patch in 1.40.198

--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,6 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`safeCopy(text)`** – kopiert Text in die Zwischenablage und greift bei Fehlern auf Electron zurück.
   * **`saveProjectToFile(data)`** – speichert das übergebene Objekt per File System Access API als JSON auf der Festplatte.
   * **`loadProjectFromFile()`** – öffnet eine zuvor gesicherte JSON-Datei und liefert deren Inhalt als Objekt.
-  * **`migrateLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei im gewählten Ordner, leert anschließend den Speicher und gibt den Speicherort zurück; prüft die Verfügbarkeit der File-System-API und liefert bei fehlendem Support oder verweigertem Zugriff eine verständliche Fehlermeldung.
+  * **`migrateLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei im gewählten Ordner, leert anschließend den Speicher und gibt den Speicherort zurück; prüft die Verfügbarkeit der File-System-API, sichert bei verweigertem Zugriff die Daten dauerhaft in einer Browser-Datenbank (IndexedDB) und liefert nur bei fehlendem Support eine verständliche Fehlermeldung.
   * **`startMigration()`** – startet den Export, zeigt alte und neue Eintragsanzahl sowie den Zielordner in der Oberfläche an.
   * **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "ytdl-core": "^4.11.5"
       },
       "devDependencies": {
+        "fake-indexeddb": "^6.2.0",
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^30.0.0",
         "jsdom": "^26.1.0",
@@ -2444,6 +2445,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.0.tgz",
+      "integrity": "sha512-0DiWlcOgogaZktJ0ussOET5wNFZctM3oiJRvL5BcaZkukeg5s0nvvFbQrguOZtctrrH/kwqF3Gu9tQWTmsfpfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-fifo": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "hla_translation_tool",
   "version": "1.40.149",
   "devDependencies": {
+    "fake-indexeddb": "^6.2.0",
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^30.0.0",
     "jsdom": "^26.1.0",


### PR DESCRIPTION
## Zusammenfassung
- sichere fehlgeschlagene Migrationen persistent in IndexedDB und lasse LocalStorage unangetastet
- dokumentiere den neuen IndexedDB-Fallback in README und CHANGELOG
- teste den Fallback über eine Fake-IndexedDB-Umgebung

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b16080838c8327a074c6313f226340