### PR TITLE
Sichere LocalStorage-Migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.201
+* `exportLocalStorageToFile` sichert LocalStorage-Einträge ohne sie zu löschen; der alte Name `migrateLocalStorageToFile` bleibt als Alias erhalten.
 ## 🛠️ Patch in 1.40.200
 * Migration speichert bei verweigertem Dateizugriff automatisch im internen Browser-Speicher (OPFS).
 ## 🛠️ Patch in 1.40.199

--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,6 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`safeCopy(text)`** – kopiert Text in die Zwischenablage und greift bei Fehlern auf Electron zurück.
   * **`saveProjectToFile(data)`** – speichert das übergebene Objekt per File System Access API als JSON auf der Festplatte.
   * **`loadProjectFromFile()`** – öffnet eine zuvor gesicherte JSON-Datei und liefert deren Inhalt als Objekt.
-  * **`migrateLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei im gewählten Ordner, leert anschließend den Speicher und gibt den Speicherort zurück; prüft die Verfügbarkeit der File-System-API, nutzt bei verweigertem Zugriff den internen Browser-Speicher (OPFS) als Fallback und liefert nur bei fehlendem Support eine verständliche Fehlermeldung.
+  * **`exportLocalStorageToFile()`** – exportiert alle LocalStorage-Einträge in eine Datei im gewählten Ordner und gibt den Speicherort zurück, ohne die Originaldaten zu löschen; prüft die Verfügbarkeit der File-System-API, nutzt bei verweigertem Zugriff den internen Browser-Speicher (OPFS) als Fallback und liefert nur bei fehlendem Support eine verständliche Fehlermeldung. Der frühere Funktionsname `migrateLocalStorageToFile` bleibt als Alias erhalten.
   * **`startMigration()`** – startet den Export, zeigt alte und neue Eintragsanzahl sowie den Zielordner in der Oberfläche an.
   * **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.

--- a/tests/migrationUI.test.js
+++ b/tests/migrationUI.test.js
@@ -25,7 +25,7 @@ beforeEach(() => {
     });
 });
 
-test('startMigration exportiert alle Einträge und leert den Speicher', async () => {
+test('startMigration exportiert alle Einträge und belässt den Speicher', async () => {
     localStorage.setItem('projektA', 'datenA');
     localStorage.setItem('projektB', 'datenB');
 
@@ -39,10 +39,9 @@ test('startMigration exportiert alle Einträge und leert den Speicher', async ()
     const gespeichert = JSON.parse(gespeicherterText);
     expect(gespeichert.projektA).toBe('datenA');
     expect(gespeichert.projektB).toBe('datenB');
-    expect(localStorage.length).toBe(0);
+    expect(localStorage.length).toBe(2);
     const status = document.getElementById('migration-status').textContent;
-    expect(status).toContain('Migration abgeschlossen');
-    expect(status).toContain('Export');
+    expect(status).toContain('Export abgeschlossen');
     expect(status).toContain('2 → 2');
 });
 
@@ -59,7 +58,7 @@ test('startMigration meldet fehlende File-System-API verständlich', async () =>
     await window.startMigration();
 
     const status = document.getElementById('migration-status').textContent;
-    expect(status).toContain('Fehler bei der Migration');
+    expect(status).toContain('Fehler beim Export');
     expect(status).toContain('Dateisystem-API');
 });
 
@@ -96,8 +95,8 @@ test('startMigration nutzt OPFS-Fallback bei verweigertem Dateizugriff', async (
 
     const gespeichert = JSON.parse(gespeicherterText);
     expect(gespeichert.projektA).toBe('datenA');
-    expect(localStorage.length).toBe(0);
+    expect(localStorage.length).toBe(1);
     const status = document.getElementById('migration-status').textContent;
-    expect(status).toContain('Migration abgeschlossen');
+    expect(status).toContain('Export abgeschlossen');
     expect(status).toContain('OPFS');
 });

--- a/web/src/fileStorage.js
+++ b/web/src/fileStorage.js
@@ -29,10 +29,10 @@ window.loadProjectFromFile = async function() {
     return JSON.parse(text);
 };
 
-// Überträgt alle Einträge aus dem LocalStorage in eine Datei und leert den Speicher
+// Überträgt alle Einträge aus dem LocalStorage in eine Datei, belässt die Originaldaten jedoch im Speicher
 // Die Daten werden in einem vom Nutzer gewählten Ordner als "hla_daten.json" gespeichert
 // und die Funktion liefert Informationen über den Speicherort zurück
-window.migrateLocalStorageToFile = async function() {
+window.exportLocalStorageToFile = async function() {
     const data = {};
     for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
@@ -66,9 +66,10 @@ window.migrateLocalStorageToFile = async function() {
     // Daten schreiben und Datei schließen
     await writable.write(JSON.stringify(data, null, 2));
     await writable.close();
-    // LocalStorage aufräumen
-    localStorage.clear();
     // Name des Verzeichnisses, bei OPFS ggf. leer -> Platzhalter setzen
     const dirName = dirHandle.name || 'OPFS';
     return { newCount: Object.keys(data).length, fileName: fileHandle.name, dirName };
 };
+
+// Rückwärtskompatibilität: alter Funktionsname bleibt als Alias erhalten
+window.migrateLocalStorageToFile = window.exportLocalStorageToFile;

--- a/web/src/migrationUI.js
+++ b/web/src/migrationUI.js
@@ -1,15 +1,15 @@
-// Steuert die Migration von LocalStorage-Daten in eine Datei und zeigt Statusmeldungen an
+// Steuert den Export von LocalStorage-Daten in eine Datei und zeigt Statusmeldungen an
 window.startMigration = async function() {
     const statusEl = document.getElementById('migration-status');
     const oldCount = localStorage.length;
     // Vorherige Anzahl anzeigen
     statusEl.textContent = `Alte Daten: ${oldCount} Einträge – Export läuft...`;
     try {
-        const result = await window.migrateLocalStorageToFile();
+        const result = await window.exportLocalStorageToFile();
         // Erfolgsmeldung mit Vergleich alt/neu und Zielordner
-        statusEl.textContent = `Migration abgeschlossen: ${oldCount} → ${result.newCount} Einträge in "${result.dirName}" (${result.fileName}).`;
+        statusEl.textContent = `Export abgeschlossen: ${oldCount} → ${result.newCount} Einträge in "${result.dirName}" (${result.fileName}).`;
     } catch (err) {
         // Fehlerhinweis bei Problemen
-        statusEl.textContent = `Fehler bei der Migration: ${err.message}`;
+        statusEl.textContent = `Fehler beim Export: ${err.message}`;
     }
 };


### PR DESCRIPTION
## Zusammenfassung
- ersetzt die destructive Migration durch `exportLocalStorageToFile`, die LocalStorage-Einträge ohne Löschung sichert
- passt UI und Tests auf den neuen Export an
- aktualisiert Dokumentation und Changelog mit dem neuen Funktionsnamen

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b16391268483278563860870c0d70b