### PR TITLE
Speicher-Adapter mit LocalStorage-Backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.203
+* Neuer Speicher-Adapter mit LocalStorage-Backend.
 ## 🛠️ Patch in 1.40.202
 * OPFS-Datei kann über einen neuen UI-Knopf geladen und in den LocalStorage importiert werden.
 ## 🛠️ Patch in 1.40.201

--- a/README.md
+++ b/README.md
@@ -1019,3 +1019,4 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`importLocalStorageFromOpfs()`** – liest die Datei `hla_daten.json` aus dem OPFS, ersetzt den aktuellen LocalStorage und gibt die Anzahl der geladenen Einträge zurück.
   * **`loadMigration()`** – UI-Helfer, der den Import startet und Statusmeldungen anzeigt.
   * **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.
+  * **`createStorage(type)`** – liefert je nach Typ ein Speicher-Backend, derzeit wird `localStorage` unterstützt.

--- a/web/src/storage/localStorageBackend.js
+++ b/web/src/storage/localStorageBackend.js
@@ -1,0 +1,25 @@
+// Wrapper für window.localStorage
+// Implementiert die Speicher-Schnittstelle mit den Methoden getItem, setItem, removeItem, clear und keys
+
+export const localStorageBackend = {
+    // Liefert den gespeicherten Wert zu einem Schlüssel
+    getItem(key) {
+        return window.localStorage.getItem(key);
+    },
+    // Speichert einen Wert unter einem Schlüssel
+    setItem(key, value) {
+        window.localStorage.setItem(key, value);
+    },
+    // Entfernt einen Eintrag
+    removeItem(key) {
+        window.localStorage.removeItem(key);
+    },
+    // Leert den gesamten Speicher
+    clear() {
+        window.localStorage.clear();
+    },
+    // Gibt alle vorhandenen Schlüssel als Array zurück
+    keys() {
+        return Object.keys(window.localStorage);
+    }
+};

--- a/web/src/storage/storageAdapter.js
+++ b/web/src/storage/storageAdapter.js
@@ -1,0 +1,20 @@
+// Definiert eine allgemeine Schnittstelle für Speicher-Backends
+// Die folgenden Funktionen müssen von jedem Backend implementiert werden:
+// getItem, setItem, removeItem, clear und keys
+
+import { localStorageBackend } from './localStorageBackend.js';
+
+/**
+ * Gibt je nach Typ das passende Speicher-Backend zurück
+ * @param {string} type - Bezeichner des gewünschten Backends
+ * @returns {{getItem: Function, setItem: Function, removeItem: Function, clear: Function, keys: Function}}
+ */
+export function createStorage(type) {
+    switch (type) {
+        case 'local':
+        case 'localStorage':
+            return localStorageBackend;
+        default:
+            throw new Error(`Unbekannter Speicher-Typ: ${type}`);
+    }
+}


### PR DESCRIPTION
## Zusammenfassung
- Neues Storage-Modul mit `createStorage` zur Auswahl des gewünschten Backends
- LocalStorage-Backend implementiert die Speicher-Schnittstelle
- Dokumentation in README und CHANGELOG ergänzt

## Testdurchführung
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b17162728c83278df4a2b79cdbb5b6