### PR TITLE
feat: migrate data between storage backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.206
+* Speicher-Adapter enthält `migrateStorage`, um Daten zwischen Backends zu kopieren.
+* UI-Knopf „Daten migrieren“ überträgt alle Einträge in das neue System.
 ## 🛠️ Patch in 1.40.205
 * Beim Start Auswahl zwischen LocalStorage und neuem System; alle Zugriffe laufen über einen Speicher-Adapter.
 ## 🛠️ Patch in 1.40.204

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.149-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.206-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -53,6 +53,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Schnellstart mit Cheats:** Im Dropdown lassen sich Godmode, unendliche Munition und die Entwicklerkonsole einzeln auswählen. Das Spiel startet nach Klick auf **Starten** mit allen markierten Optionen.
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Wählbarer Speichermodus:** Beim ersten Start kann zwischen klassischem LocalStorage und dem neuen verschlüsselten System gewählt werden; alle Zugriffe erfolgen über einen Speicher-Adapter.
+* **Daten migrieren:** Ein zusätzlicher Knopf kopiert alle LocalStorage-Einträge in das neue Speicher-System.
 * **Eigenes Wörterbuch:** Der 📚-Knopf speichert nun sowohl englisch‑deutsche Übersetzungen als auch Lautschrift.
 * **Audio-Datei zuordnen:** Lange Aufnahmen lassen sich automatisch in Segmente teilen, per Klick auswählen, farblich passenden Textzeilen zuweisen und direkt ins Projekt importieren. Über den 🚫‑Knopf markierte Bereiche werden dauerhaft übersprungen und in der Liste grau hinterlegt. Fehlhafte Eingaben löschen die Zuordnung automatisch, laufende Wiedergaben stoppen beim Neu‑Upload. Die gewählte Datei und alle Zuordnungen werden im Projekt gespeichert und sind Teil des Backups. In der Desktop‑Version landet die Originaldatei zusätzlich im Ordner `Sounds/Segments` und trägt die ID des Projekts. Beim Klicken werden ausgewählte Segmente sofort abgespielt. Die Segmentierungslogik ist fest im Hauptskript verankert. Der Datei‑Input besitzt zusätzlich ein `onchange`-Attribut und der Listener wird beim Öffnen des Dialogs neu gesetzt, sodass der Upload immer reagiert. Der Dialog setzt die HTML‑Elemente `segmentFileInput` und `segmentWaveform` voraus.
 * **Segment-Zuordnungen behalten:** Beim Neustart lädt der Segment-Dialog automatisch die gespeicherte Audiodatei und zeigt alle zuvor getroffenen Zuordnungen.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -67,6 +67,7 @@
                     <button class="btn btn-secondary" onclick="openDubbingLog()">📝 Protokoll</button>
                     <button class="btn btn-secondary" onclick="startMigration()">Migration starten</button>
                     <button class="btn btn-secondary" onclick="loadMigration()">Migration laden</button>
+                    <button class="btn btn-secondary" onclick="migrateData()">Daten migrieren</button>
                     <div id="migration-status"></div>
                 </div>
             </div>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -6,12 +6,14 @@ window.storage = storage;
 if (typeof module === 'undefined' || !module.exports) {
     (async () => {
         // Speicher-Adapter dynamisch laden
-        const { createStorage } = await import('./storage/storageAdapter.js');
+        const { createStorage, migrateStorage } = await import('./storage/storageAdapter.js');
         let storageMode = window.localStorage.getItem('hla_storageMode');
         // Gewählten Speicher herstellen
         storage = createStorage(storageMode || 'localStorage');
         // Global verfügbar machen
         window.storage = storage;
+        window.createStorage = createStorage;
+        window.migrateStorage = migrateStorage;
         // Beim ersten Start Auswahl anbieten
         if (!storageMode) {
             window.addEventListener('DOMContentLoaded', () => {

--- a/web/src/migrationUI.js
+++ b/web/src/migrationUI.js
@@ -28,3 +28,17 @@ window.loadMigration = async function() {
         statusEl.textContent = `Fehler beim Import: ${err.message}`;
     }
 };
+
+// Kopiert alle Einträge vom LocalStorage in das neue Backend
+window.migrateData = async function() {
+    const statusEl = document.getElementById('migration-status');
+    statusEl.textContent = 'Migration läuft...';
+    try {
+        const oldBackend = window.createStorage('localStorage');
+        const newBackend = window.createStorage('indexedDB');
+        const count = await window.migrateStorage(oldBackend, newBackend);
+        statusEl.textContent = `Migration abgeschlossen: ${count} Einträge übertragen.`;
+    } catch (err) {
+        statusEl.textContent = `Fehler bei Migration: ${err.message}`;
+    }
+};

--- a/web/src/storage/storageAdapter.js
+++ b/web/src/storage/storageAdapter.js
@@ -22,3 +22,18 @@ export function createStorage(type, options = {}) {
             throw new Error(`Unbekannter Speicher-Typ: ${type}`);
     }
 }
+
+/**
+ * Kopiert alle Einträge aus einem alten Backend in ein neues
+ * @param {{getItem: Function, setItem: Function, keys: Function}} oldBackend - Quelle der Daten
+ * @param {{setItem: Function}} newBackend - Ziel-Backend für die Daten
+ * @returns {Promise<number>} Anzahl der übertragenen Schlüssel
+ */
+export async function migrateStorage(oldBackend, newBackend) {
+    const keys = await oldBackend.keys();
+    for (const key of keys) {
+        const value = await oldBackend.getItem(key);
+        await newBackend.setItem(key, value);
+    }
+    return keys.length;
+}


### PR DESCRIPTION
## Summary
- add migrateStorage helper to copy keys across backends
- expose migration UI button to trigger storage copy
- document storage migration workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b176a2a80c832784a2616e820e0d42