### PR TITLE
Entferne Verschlüsselung aus IndexedDB-Backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.209
+* IndexedDB-Backend speichert Daten jetzt unverschlüsselt ohne Benutzerschlüssel.
+* `createIndexedDbBackend` benötigt keinen Parameter mehr.
 ## 🛠️ Patch in 1.40.208
 * Anzeige des aktuellen Speichermodus mit direktem Wechsel und Migration.
 ## 🛠️ Patch in 1.40.207

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
 * **Schnellstart mit Cheats:** Im Dropdown lassen sich Godmode, unendliche Munition und die Entwicklerkonsole einzeln auswählen. Das Spiel startet nach Klick auf **Starten** mit allen markierten Optionen.
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
-* **Wählbarer Speichermodus:** Beim ersten Start kann zwischen klassischem LocalStorage und dem neuen verschlüsselten System gewählt werden; alle Zugriffe erfolgen über einen Speicher-Adapter.
+* **Wählbarer Speichermodus:** Beim ersten Start kann zwischen klassischem LocalStorage und einem IndexedDB-System gewählt werden; alle Zugriffe erfolgen über einen Speicher-Adapter.
 * **Daten migrieren:** Ein zusätzlicher Knopf kopiert alle LocalStorage-Einträge in das neue Speicher-System.
 * **Speichermodus-Anzeige:** In der Werkzeugleiste zeigt ein Indikator das aktive System und ermöglicht den direkten Wechsel.
 * **Eigenes Wörterbuch:** Der 📚-Knopf speichert nun sowohl englisch‑deutsche Übersetzungen als auch Lautschrift.
@@ -816,7 +816,7 @@ Mit dem Backup-Dialog lassen sich alle Projekt-Daten als JSON speichern. Neu ist
 
 ## 🗃️ Speichersysteme
 
-Beim ersten Start erscheint ein Dialog zur Wahl des Speichersystems. Zur Auswahl stehen der klassische `localStorage` und ein neues, verschlüsseltes `IndexedDB`-Backend. Alle Zugriffe erfolgen über einen gemeinsamen Adapter, der die gewählte Variante kapselt.
+Beim ersten Start erscheint ein Dialog zur Wahl des Speichersystems. Zur Auswahl stehen der klassische `localStorage` und ein neues `IndexedDB`-Backend. Alle Zugriffe erfolgen über einen gemeinsamen Adapter, der die gewählte Variante kapselt.
 
 ### Auswahl
 
@@ -1040,4 +1040,4 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`importLocalStorageFromOpfs()`** – liest die Datei `hla_daten.json` aus dem OPFS, ersetzt den aktuellen LocalStorage und gibt die Anzahl der geladenen Einträge zurück.
   * **`loadMigration()`** – UI-Helfer, der den Import startet und Statusmeldungen anzeigt.
   * **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.
-  * **`createStorage(type, options)`** – liefert je nach Typ ein Speicher-Backend; neben `localStorage` steht nun `indexedDB` zur Verfügung, das Daten je Objekt in eigenen Stores ablegt, vor dem Speichern per AES‑GCM verschlüsselt und große Dateien im OPFS oder als Blob auslagert.
+  * **`createStorage(type)`** – liefert je nach Typ ein Speicher-Backend; neben `localStorage` steht nun `indexedDB` zur Verfügung, das Daten je Objekt in eigenen Stores ablegt und große Dateien im OPFS oder als Blob auslagert.

--- a/tests/indexedDbBackend.test.js
+++ b/tests/indexedDbBackend.test.js
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-// Testet das verschlüsselte IndexedDB-Backend
+// Testet das IndexedDB-Backend
 
 global.structuredClone = obj => JSON.parse(JSON.stringify(obj));
 const { indexedDB, IDBKeyRange } = require('fake-indexeddb');
@@ -29,14 +29,14 @@ beforeEach(() => {
 });
 
 test('setItem und getItem liefern gespeicherten Wert', async () => {
-    const backend = createIndexedDbBackend(new Uint8Array(16).buffer);
+    const backend = createIndexedDbBackend();
     await backend.setItem('misc:foo', 'bar');
     const wert = await backend.getItem('misc:foo');
     expect(wert).toBe('bar');
 });
 
 test('keys listet alle Schlüssel', async () => {
-    const backend = createIndexedDbBackend(new Uint8Array(16).buffer);
+    const backend = createIndexedDbBackend();
     await backend.setItem('projects:p1', 'a');
     await backend.setItem('textDB:t1', 'b');
     const schluessel = await backend.keys();
@@ -44,7 +44,7 @@ test('keys listet alle Schlüssel', async () => {
 });
 
 test('removeItem und clear löschen Einträge', async () => {
-    const backend = createIndexedDbBackend(new Uint8Array(16).buffer);
+    const backend = createIndexedDbBackend();
     await backend.setItem('misc:a', '1');
     await backend.removeItem('misc:a');
     expect(await backend.getItem('misc:a')).toBeNull();

--- a/web/src/storage/indexedDbBackend.js
+++ b/web/src/storage/indexedDbBackend.js
@@ -1,23 +1,10 @@
-// IndexedDB-Backend mit verschlüsselter Speicherung
+// IndexedDB-Backend für lokale Speicherung
 // Jeder Datentyp nutzt einen eigenen Object Store (projects, textDB, pathDB, misc)
 // Größere Dateien werden über OPFS oder Blob-URLs ausgelagert, nur Verweise landen in der Datenbank
 
 const DB_NAME = 'hla-db';
 const DB_VERSION = 1;
 const STORE_NAMES = ['projects', 'textDB', 'pathDB', 'misc'];
-
-let cryptoKey;
-
-// Benutzer-Schlüssel setzen und als CryptoKey importieren
-export async function setUserKey(rawKey) {
-    cryptoKey = await window.crypto.subtle.importKey(
-        'raw',
-        rawKey,
-        { name: 'AES-GCM' },
-        false,
-        ['encrypt', 'decrypt']
-    );
-}
 
 // Datenbank öffnen und bei Bedarf Object Stores anlegen
 function openDb() {
@@ -45,36 +32,8 @@ function parseKey(key) {
     return { store: 'misc', key };
 }
 
-// ArrayBuffer in Base64 umwandeln
-function arrayBufferToBase64(buffer) {
-    return btoa(String.fromCharCode(...new Uint8Array(buffer)));
-}
-
-// Base64 in ArrayBuffer zurückwandeln
-function base64ToArrayBuffer(base64) {
-    const binary = atob(base64);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) {
-        bytes[i] = binary.charCodeAt(i);
-    }
-    return bytes.buffer;
-}
-
-// Daten mit AES-GCM verschlüsseln
-async function encrypt(text) {
-    const iv = window.crypto.getRandomValues(new Uint8Array(12));
-    const data = new TextEncoder().encode(text);
-    const encrypted = await window.crypto.subtle.encrypt({ name: 'AES-GCM', iv }, cryptoKey, data);
-    return { iv: arrayBufferToBase64(iv), data: arrayBufferToBase64(encrypted) };
-}
-
-// Daten entschlüsseln
-async function decrypt(payload) {
-    const iv = base64ToArrayBuffer(payload.iv);
-    const data = base64ToArrayBuffer(payload.data);
-    const decrypted = await window.crypto.subtle.decrypt({ name: 'AES-GCM', iv: iv }, cryptoKey, data);
-    return new TextDecoder().decode(decrypted);
-}
+// Hinweis: Früher wurden Einträge verschlüsselt. Die Verschlüsselung wurde entfernt,
+// daher bleiben Hilfsfunktionen für Base64 und AES-GCM ungenutzt und entfallen.
 
 // Größere Dateien auslagern
 async function storeLargeData(value) {
@@ -116,9 +75,9 @@ async function setItemInternal(key, value) {
     if (value instanceof Blob || value instanceof ArrayBuffer) {
         data = await storeLargeData(value);
     }
-    const encrypted = await encrypt(JSON.stringify(data));
     const tx = db.transaction(store, 'readwrite');
-    tx.objectStore(store).put(encrypted, realKey);
+    // JSON-String direkt im Store ablegen
+    tx.objectStore(store).put(JSON.stringify(data), realKey);
     return new Promise((resolve, reject) => {
         tx.oncomplete = () => resolve();
         tx.onerror = () => reject(tx.error);
@@ -137,8 +96,8 @@ async function getItemInternal(key) {
         request.onerror = () => reject(request.error);
     });
     if (!result) return null;
-    const decrypted = await decrypt(result);
-    const data = JSON.parse(decrypted);
+    // Gespeicherten String direkt zu Daten umwandeln
+    const data = JSON.parse(result);
     if (data && (data.type === 'opfs' || data.type === 'blob')) {
         return await loadLargeData(data);
     }
@@ -192,18 +151,13 @@ async function keysInternal() {
 }
 
 // Factory-Funktion zum Erstellen des Backends
-export function createIndexedDbBackend(userKey) {
-    if (!userKey) {
-        throw new Error('Benutzerschlüssel wird benötigt');
-    }
-    setUserKey(userKey);
+export function createIndexedDbBackend() {
     return {
         getItem: key => getItemInternal(key),
         setItem: (key, value) => setItemInternal(key, value),
         removeItem: key => removeItemInternal(key),
         clear: () => clearInternal(),
-        keys: () => keysInternal(),
-        setUserKey
+        keys: () => keysInternal()
     };
 }
 

--- a/web/src/storage/storageAdapter.js
+++ b/web/src/storage/storageAdapter.js
@@ -8,16 +8,15 @@ import { createIndexedDbBackend } from './indexedDbBackend.js';
 /**
  * Gibt je nach Typ das passende Speicher-Backend zurück
  * @param {string} type - Bezeichner des gewünschten Backends
- * @param {{userKey?: ArrayBuffer}} [options] - Zusätzliche Optionen wie der Benutzerschlüssel
  * @returns {{getItem: Function, setItem: Function, removeItem: Function, clear: Function, keys: Function}}
  */
-export function createStorage(type, options = {}) {
+export function createStorage(type) {
     switch (type) {
         case 'local':
         case 'localStorage':
             return localStorageBackend;
         case 'indexedDB':
-            return createIndexedDbBackend(options.userKey);
+            return createIndexedDbBackend();
         default:
             throw new Error(`Unbekannter Speicher-Typ: ${type}`);
     }


### PR DESCRIPTION
## Zusammenfassung
- Entfernt den Benutzerschlüssel und alle AES-GCM-Hilfsfunktionen aus dem IndexedDB-Backend
- Speichert und liest JSON-Daten nun direkt ohne Verschlüsselung
- Passt Storage-Adapter, Tests sowie Dokumentation an

## Testanweisungen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b184022b488327b4c080346b478e35