### PR TITLE
Knopf zum Öffnen des neuen Speicherordners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.216
+* Reitermenü bietet jetzt einen Knopf, der den Ordner des neuen Speichersystems öffnet.
 ## 🛠️ Patch in 1.40.215
 * Dateiliste zeigt jetzt pro Datei, ob der Eintrag im neuen Speichersystem liegt.
 ## 🛠️ Patch in 1.40.214

--- a/README.md
+++ b/README.md
@@ -830,6 +830,7 @@ Der Startdialog fragt einmalig nach dem bevorzugten Modus und merkt sich die Ent
 ### Anzeige und Wechsel
 
 In der Werkzeugleiste informiert ein Indikator über den aktuell genutzten Speicher. Ein danebenliegender Knopf wechselt auf Wunsch das System, ohne dabei Daten zu kopieren. Für eine Übernahme steht weiterhin **Daten migrieren** bereit. Beim Wechsel erscheinen kurze Hinweise, und die Statusleiste nennt beim Speichern das aktive System.
+Ein weiterer Knopf öffnet den Ordner, in dem das neue Speichersystem seine Daten ablegt.
 
 ### Kontrolle
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -70,6 +70,7 @@
                     <button class="btn btn-secondary" onclick="migrateData()">Daten migrieren</button>
                     <span id="storageModeIndicator"></span>
                     <button id="switchStorageButton" class="btn btn-secondary">...</button>
+                    <button id="openStorageFolderButton" class="btn btn-secondary" onclick="openStorageFolder()">📂 Speicherordner</button>
                     <div id="migration-status"></div>
                 </div>
             </div>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -92,10 +92,21 @@ async function visualizeFileStorage(key) {
     return { local: !!localValue, indexedDB: !!indexedValue };
 }
 
+// Öffnet den Ordner des neuen Speichersystems im Dateimanager
+async function openStorageFolder() {
+    if (!debugInfo.userDataPath || !window.electronAPI) {
+        showToast('Pfad zum neuen Speichersystem ist nicht verfügbar');
+        return;
+    }
+    const pfad = window.electronAPI.join(debugInfo.userDataPath, 'IndexedDB');
+    await window.electronAPI.openPath(pfad);
+}
+
 // Globale Bereitstellung und Initialisierung nach DOM-Ladevorgang
 window.updateStorageIndicator = updateStorageIndicator;
 window.switchStorage = switchStorage;
 window.visualizeFileStorage = visualizeFileStorage;
+window.openStorageFolder = openStorageFolder;
 window.addEventListener('DOMContentLoaded', () => {
     const mode = window.localStorage.getItem('hla_storageMode') || 'localStorage';
     updateStorageIndicator(mode);


### PR DESCRIPTION
## Zusammenfassung
- Neuer Button im Reitermenü öffnet direkt den Ordner des neuen Speichersystems.
- JavaScript-Funktion `openStorageFolder` öffnet den IndexedDB-Ordner über Electron.
- Dokumentation in README und CHANGELOG ergänzt.

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ac0e6ae4832798a878a05d933b19