### PR TITLE
Erweitertes Debug-Logging für detaillierte Fehleranalyse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.217
+* Debug-Modus protokolliert jetzt unbehandelte Promise-Ablehnungen und zeigt Datei-, Zeilen- sowie Stack-Informationen an.
 ## 🛠️ Patch in 1.40.216
 * Reitermenü bietet jetzt einen Knopf, der den Ordner des neuen Speichersystems öffnet.
 ## 🛠️ Patch in 1.40.215

--- a/README.md
+++ b/README.md
@@ -946,6 +946,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **📸 VideoFrame-Details:** Zusätzlich werden der Pfad zum Frame-Ordner und die Versionen der Video-Abhängigkeiten angezeigt.
 * **📝 Ausführliche API-Logs:** Alle Anfragen und Antworten werden im Dubbing-Log protokolliert
 * **🛠 Debug-Logging aktivieren:** Setze `localStorage.setItem('hla_debug_mode','true')` im Browser, um zusätzliche Konsolen-Ausgaben zu erhalten
+* **🐞 Ausführliche Fehlerprotokolle:** Im Debug-Modus erscheinen unbehandelte Promise-Ablehnungen sowie Datei-, Zeilen- und Stack-Informationen
 
 ### Performance‑Tipps
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -845,16 +845,33 @@ function debugLog(...args) {
 }
 window.debugLog = debugLog;
 
-// =========================== ERROR-HANDLING START ===========================
-// Leitet JavaScript-Fehler in die Debug-Konsole um
+// =========================== FEHLERBEHANDLUNG START ===========================
+// Leitet JavaScript-Fehler detailliert in die Debug-Konsole um
 window.addEventListener('error', (event) => {
-    debugLog('FEHLER:', event.message);
+    const { message, filename, lineno, colno, error } = event;
+    debugLog('FEHLER:', message, `${filename}:${lineno}:${colno}`);
+    if (error && error.stack) {
+        debugLog('STAPEL:', error.stack);
+    }
+});
+// Fängt unbehandelte Promise-Ablehnungen ab
+window.addEventListener('unhandledrejection', (event) => {
+    const grund = event.reason;
+    debugLog('UNBEHANDELTE PROMISE:', grund);
+    if (grund && grund.stack) {
+        debugLog('STAPEL:', grund.stack);
+    }
 });
 // Ergänzt console.error, damit Fehler im Debug-Bereich auftauchen
 const origConsoleError = console.error;
 console.error = function(...args) {
     origConsoleError.apply(console, args);
     debugLog('FEHLER:', ...args);
+    for (const arg of args) {
+        if (arg && arg.stack) {
+            debugLog('STAPEL:', arg.stack);
+        }
+    }
 };
 // =========================== ZWISCHENABLAGE HELFER ==========================
 // Versucht zuerst das Browser-Clipboard und nutzt bei Fehlern Electron


### PR DESCRIPTION
## Zusammenfassung
- Loggt JavaScript-Fehler mit Datei-, Zeilen- und Stack-Informationen
- Fängt unbehandelte Promise-Ablehnungen ab und schreibt sie in die Debug-Konsole
- Dokumentation um neue Fehlermeldungsfunktionen ergänzt

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1b7f022e083279f8373aa683608a8