### PR TITLE
Projekt-Lock und Transaktionsunterstützung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.220
+* Single-Writer-Lock pro Projekt mit BroadcastChannel und Heartbeat im localStorage.
+* `storage.runTransaction` bündelt Mehrfach-Schreibvorgänge und verwirft alle bei Fehlern.
 ## 🛠️ Patch in 1.40.219
 * Schreibvorgänge nutzen nun ein Journal und atomare Umbenennungen, um korrupte Dateien zu vermeiden.
 * `garbageCollect` räumt nicht referenzierte Blobs aus `.hla_store/objects` auf und unterstützt einen Dry-Run.

--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,8 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`loadMigration()`** – UI-Helfer, der den Import startet und Statusmeldungen anzeigt.
   * **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.
   * **`createStorage(type)`** – liefert je nach Typ ein Speicher-Backend; neben `localStorage` steht nun `indexedDB` zur Verfügung, das Daten je Objekt in eigenen Stores ablegt, große Dateien im OPFS oder als Blob auslagert und ohne Benutzerschlüssel auskommt.
+  * **`storage.runTransaction(async tx => { ... })`** – führt mehrere Schreibvorgänge gebündelt aus und bricht bei Fehlern komplett ab.
+  * **`acquireProjectLock(id)`** – verhandelt einen exklusiven Schreibzugriff pro Projekt und schaltet weitere Fenster in den Nur-Lesen-Modus.
   * **`journalWiederherstellen(basis)`** – prüft ein vorhandenes `journal.json` und schließt abgebrochene Schreibvorgänge atomar ab.
   * **`garbageCollect(manifeste, basis, dryRun)`** – entfernt nicht referenzierte Dateien aus `.hla_store/objects` und meldet wahlweise nur den potentiellen Speichergewinn.
   * **Beim Start** wird jetzt `navigator.storage.persist()` ausgeführt; zusammen mit `navigator.storage.estimate()` zeigt die Oberfläche an, wie viel lokaler Speicher verfügbar bleibt.

--- a/web/src/storage/projectLock.js
+++ b/web/src/storage/projectLock.js
@@ -1,0 +1,77 @@
+// Verwaltet einen exklusiven Schreib-Lock pro Projekt
+// Verwendet BroadcastChannel und ein Heartbeat im localStorage als Fallback
+
+const HEARTBEAT_INTERVAL = 2000; // ms
+const HEARTBEAT_TIMEOUT = 5000;  // ms
+
+/**
+ * Versucht einen Schreib-Lock für ein Projekt zu erhalten.
+ * Gibt ein Objekt mit `readOnly` und `release()` zurück.
+ * @param {number|string} projectId
+ */
+export async function acquireProjectLock(projectId) {
+    const channel = new BroadcastChannel(`project:${projectId}`);
+    const flagKey = `project-lock:${projectId}`;
+    let isOwner = false;
+    let heartbeatHandle;
+
+    function startHeartbeat() {
+        localStorage.setItem(flagKey, Date.now().toString());
+        heartbeatHandle = setInterval(() => {
+            localStorage.setItem(flagKey, Date.now().toString());
+        }, HEARTBEAT_INTERVAL);
+        channel.onmessage = ev => {
+            if (ev.data === 'lock-request') {
+                channel.postMessage('lock-taken');
+            }
+        };
+    }
+
+    // Prüfen, ob ein vorhandener Lock abgelaufen ist
+    const last = parseInt(localStorage.getItem(flagKey) || '0', 10);
+    if (!last || Date.now() - last > HEARTBEAT_TIMEOUT) {
+        // Kein aktiver Lock vorhanden
+        isOwner = true;
+        startHeartbeat();
+    } else {
+        channel.postMessage('lock-request');
+    }
+
+    function release() {
+        if (isOwner) {
+            clearInterval(heartbeatHandle);
+            localStorage.removeItem(flagKey);
+            channel.postMessage('lock-released');
+        }
+        channel.close();
+    }
+
+    return new Promise(resolve => {
+        if (isOwner) {
+            resolve({ readOnly: false, release });
+            return;
+        }
+        let settled = false;
+        const timeout = setTimeout(() => {
+            if (!settled) {
+                settled = true;
+                resolve({ readOnly: true, release });
+            }
+        }, 300);
+
+        channel.onmessage = ev => {
+            if (settled) return;
+            if (ev.data === 'lock-taken') {
+                clearTimeout(timeout);
+                settled = true;
+                resolve({ readOnly: true, release });
+            } else if (ev.data === 'lock-released') {
+                clearTimeout(timeout);
+                isOwner = true;
+                startHeartbeat();
+                settled = true;
+                resolve({ readOnly: false, release });
+            }
+        };
+    });
+}

--- a/web/src/storage/storageAdapter.js
+++ b/web/src/storage/storageAdapter.js
@@ -1,6 +1,6 @@
 // Definiert eine allgemeine Schnittstelle für Speicher-Backends
 // Die folgenden Funktionen müssen von jedem Backend implementiert werden:
-// getItem, setItem, removeItem, clear und keys
+// getItem, setItem, removeItem, clear, keys und optional runTransaction
 
 import { localStorageBackend } from './localStorageBackend.js';
 import { createIndexedDbBackend } from './indexedDbBackend.js';
@@ -11,15 +11,49 @@ import { createIndexedDbBackend } from './indexedDbBackend.js';
  * @returns {{getItem: Function, setItem: Function, removeItem: Function, clear: Function, keys: Function}}
  */
 export function createStorage(type) {
+    let backend;
     switch (type) {
         case 'local':
         case 'localStorage':
-            return localStorageBackend;
+            backend = localStorageBackend;
+            break;
         case 'indexedDB':
-            return createIndexedDbBackend();
+            backend = createIndexedDbBackend();
+            break;
         default:
             throw new Error(`Unbekannter Speicher-Typ: ${type}`);
     }
+
+    return {
+        ...backend,
+        /**
+         * Führt mehrere Schreiboperationen als Einheit aus.
+         * Bei Fehlern werden keine Änderungen übernommen.
+         * @param {Function} fn - Callback, das einen Transaktions-Kontext erhält
+         */
+        async runTransaction(fn) {
+            // Operationen zwischenspeichern
+            const ops = [];
+            const tx = {
+                getItem: key => backend.getItem(key),
+                setItem: (key, value) => ops.push({ type: 'set', key, value }),
+                removeItem: key => ops.push({ type: 'remove', key })
+            };
+            try {
+                await fn(tx);
+                for (const op of ops) {
+                    if (op.type === 'set') {
+                        await backend.setItem(op.key, op.value);
+                    } else {
+                        await backend.removeItem(op.key);
+                    }
+                }
+            } catch (err) {
+                // Bei Fehlern nichts schreiben
+                throw err;
+            }
+        }
+    };
 }
 
 /**


### PR DESCRIPTION
## Zusammenfassung
- Füge BroadcastChannel-basierten Schreib-Lock mit Heartbeat-Fallback hinzu
- Erweiterung des Speicheradapters um `runTransaction` für gebündelte Schreibvorgänge
- Dokumentation in README und CHANGELOG aktualisiert

## Testanweisungen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1ce09b0c483279bd648e38d2e478e