### PR TITLE
Speicher-Feature-Flags und Manifest-Validierung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.221
+* Speicher-Backends liefern jetzt Feature-Flags über `storage.capabilities`, um fehlendes OPFS zu erkennen.
+* `validateProjectManifest` prüft `project.json` gegen ein Zod-Schema.
 ## 🛠️ Patch in 1.40.220
 * Single-Writer-Lock pro Projekt mit BroadcastChannel und Heartbeat im localStorage.
 * `storage.runTransaction` bündelt Mehrfach-Schreibvorgänge und verwirft alle bei Fehlern.

--- a/README.md
+++ b/README.md
@@ -1058,8 +1058,10 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`loadMigration()`** – UI-Helfer, der den Import startet und Statusmeldungen anzeigt.
   * **`cleanupProject.js`** – gleicht Datei-IDs mit einer Liste aus der Oberfläche ab und entfernt unbekannte Einträge. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.
   * **`createStorage(type)`** – liefert je nach Typ ein Speicher-Backend; neben `localStorage` steht nun `indexedDB` zur Verfügung, das Daten je Objekt in eigenen Stores ablegt, große Dateien im OPFS oder als Blob auslagert und ohne Benutzerschlüssel auskommt.
+  * **`storage.capabilities`** – liefert Feature-Flags wie `blobs` (`opfs`, `file` oder `none`) und `atomicWrite`, sodass die Oberfläche fehlende OPFS-Unterstützung erkennen und ausweichen kann.
   * **`storage.runTransaction(async tx => { ... })`** – führt mehrere Schreibvorgänge gebündelt aus und bricht bei Fehlern komplett ab.
   * **`acquireProjectLock(id)`** – verhandelt einen exklusiven Schreibzugriff pro Projekt und schaltet weitere Fenster in den Nur-Lesen-Modus.
   * **`journalWiederherstellen(basis)`** – prüft ein vorhandenes `journal.json` und schließt abgebrochene Schreibvorgänge atomar ab.
   * **`garbageCollect(manifeste, basis, dryRun)`** – entfernt nicht referenzierte Dateien aus `.hla_store/objects` und meldet wahlweise nur den potentiellen Speichergewinn.
+  * **`validateProjectManifest(data)`** – prüft `project.json` gegen ein Zod-Schema und stellt sicher, dass `schemaVersion` und Name vorhanden sind.
   * **Beim Start** wird jetzt `navigator.storage.persist()` ausgeführt; zusammen mit `navigator.storage.estimate()` zeigt die Oberfläche an, wie viel lokaler Speicher verfügbar bleibt.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "playwright": "^1.42.1",
         "progress": "^2.0.3",
         "unzipper": "^0.12.3",
-        "ytdl-core": "^4.11.5"
+        "ytdl-core": "^4.11.5",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "fake-indexeddb": "^6.2.0",
@@ -5500,6 +5501,15 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "playwright": "^1.42.1",
     "progress": "^2.0.3",
     "unzipper": "^0.12.3",
-    "ytdl-core": "^4.11.5"
+    "ytdl-core": "^4.11.5",
+    "zod": "^3.25.76"
   }
 }

--- a/tests/projectSchema.test.js
+++ b/tests/projectSchema.test.js
@@ -1,0 +1,10 @@
+const { validateProjectManifest } = require('../utils/projectSchema.js');
+
+test('valide Manifestdaten werden akzeptiert', () => {
+    const data = { schemaVersion: 1, name: 'Testprojekt' };
+    expect(validateProjectManifest(data)).toEqual(data);
+});
+
+test('ungültige Daten lösen einen Fehler aus', () => {
+    expect(() => validateProjectManifest({ name: 'Ohne Version' })).toThrow();
+});

--- a/utils/projectSchema.js
+++ b/utils/projectSchema.js
@@ -1,0 +1,20 @@
+const { z } = require('zod');
+
+// Schema für das Projekt-Manifest (project.json)
+const projectManifestSchema = z.object({
+    schemaVersion: z.number().int(), // Versionsnummer des Schemas
+    name: z.string(),                // Anzeigename des Projekts
+    created: z.string().optional()   // optionales Erstellungsdatum
+});
+
+/**
+ * Validiert ein Projekt-Manifest gegen das definierte Schema.
+ * Löst bei ungültigen Daten eine Ausnahme aus.
+ * @param {unknown} data - zu prüfendes Objekt
+ * @returns {object} - validierte Daten
+ */
+function validateProjectManifest(data) {
+    return projectManifestSchema.parse(data);
+}
+
+module.exports = { projectManifestSchema, validateProjectManifest };

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -48,7 +48,14 @@ function updateStorageIndicator(mode) {
     const indicator = document.getElementById('storageModeIndicator');
     const button = document.getElementById('switchStorageButton');
     if (!indicator || !button) return;
-    indicator.textContent = mode === 'indexedDB' ? 'Neues System' : 'LocalStorage';
+    // Basistext je nach Modus
+    let text = mode === 'indexedDB' ? 'Neues System' : 'LocalStorage';
+    // Zusatzhinweis, falls keine OPFS-Unterstützung vorhanden ist
+    const caps = window.storage && window.storage.capabilities;
+    if (caps && caps.blobs !== 'opfs') {
+        text += ' (ohne OPFS)';
+    }
+    indicator.textContent = text;
     button.textContent = mode === 'indexedDB' ? 'Wechsel zu LocalStorage' : 'Wechsel zu neuem System';
 }
 

--- a/web/src/storage/indexedDbBackend.js
+++ b/web/src/storage/indexedDbBackend.js
@@ -152,12 +152,18 @@ async function keysInternal() {
 
 // Factory-Funktion zum Erstellen des Backends
 export function createIndexedDbBackend() {
+    const hasOpfs = typeof navigator !== 'undefined' && navigator.storage && navigator.storage.getDirectory;
+    const capabilities = {
+        blobs: hasOpfs ? 'opfs' : 'file', // bevorzugt OPFS, sonst Datei-Fallback
+        atomicWrite: true                 // IndexedDB-Transaktionen sind atomar
+    };
     return {
         getItem: key => getItemInternal(key),
         setItem: (key, value) => setItemInternal(key, value),
         removeItem: key => removeItemInternal(key),
         clear: () => clearInternal(),
-        keys: () => keysInternal()
+        keys: () => keysInternal(),
+        capabilities
     };
 }
 

--- a/web/src/storage/localStorageBackend.js
+++ b/web/src/storage/localStorageBackend.js
@@ -21,5 +21,10 @@ export const localStorageBackend = {
     // Gibt alle vorhandenen Schlüssel als Array zurück
     keys() {
         return Object.keys(window.localStorage);
+    },
+    // Unterstützte Features dieses Backends
+    capabilities: {
+        blobs: 'none',          // keine Speicherung großer Binärdaten
+        atomicWrite: false      // keine atomaren Mehrfach-Schreibvorgänge
     }
 };

--- a/web/src/storage/storageAdapter.js
+++ b/web/src/storage/storageAdapter.js
@@ -23,15 +23,18 @@ export function createStorage(type) {
         default:
             throw new Error(`Unbekannter Speicher-Typ: ${type}`);
     }
-
-    return {
+    const result = {
         ...backend,
+        // Standard-Fähigkeiten festlegen, falls das Backend keine angibt
+        capabilities: backend.capabilities || { blobs: 'none', atomicWrite: false }
+    };
+    if (!backend.runTransaction) {
         /**
          * Führt mehrere Schreiboperationen als Einheit aus.
          * Bei Fehlern werden keine Änderungen übernommen.
          * @param {Function} fn - Callback, das einen Transaktions-Kontext erhält
          */
-        async runTransaction(fn) {
+        result.runTransaction = async function (fn) {
             // Operationen zwischenspeichern
             const ops = [];
             const tx = {
@@ -52,8 +55,9 @@ export function createStorage(type) {
                 // Bei Fehlern nichts schreiben
                 throw err;
             }
-        }
-    };
+        };
+    }
+    return result;
 }
 
 /**


### PR DESCRIPTION
## Zusammenfassung
- Storage-Backends melden jetzt ihre Fähigkeiten über `capabilities`, inklusive OPFS-Unterstützung.
- `updateStorageIndicator` zeigt fehlende OPFS-Unterstützung an.
- Neues `projectSchema` validiert `project.json` mittels Zod.

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1d00dbe90832787fb459ae7108201