### PR TITLE
Speicherwechsel leert nun globale Caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.223
+* Beim Wechsel des Speichersystems werden alle globalen Caches geleert, sodass keine Datenreste zwischen den Backends verbleiben.
 ## 🛠️ Patch in 1.40.222
 * Virtuelle Listen rendern nur sichtbare Zeilen und laden Daten bei Bedarf.
 * Optionaler invertierter Suchindex pro Projekt für schnelle lokale Treffer.

--- a/README.md
+++ b/README.md
@@ -830,7 +830,7 @@ Der Startdialog fragt einmalig nach dem bevorzugten Modus und merkt sich die Ent
 
 ### Anzeige und Wechsel
 
-In der Werkzeugleiste informiert ein Indikator über den aktuell genutzten Speicher. Ein danebenliegender Knopf wechselt auf Wunsch das System, ohne dabei Daten zu kopieren. Für eine Übernahme steht weiterhin **Daten migrieren** bereit. Beim Wechsel erscheinen kurze Hinweise, und die Statusleiste nennt beim Speichern das aktive System.
+In der Werkzeugleiste informiert ein Indikator über den aktuell genutzten Speicher. Ein danebenliegender Knopf wechselt auf Wunsch das System, ohne dabei Daten zu kopieren. Für eine Übernahme steht weiterhin **Daten migrieren** bereit. Beim Wechsel erscheinen kurze Hinweise, und die Statusleiste nennt beim Speichern das aktive System. Dabei werden alle internen Caches geleert, damit keine Daten aus dem zuvor aktiven Backend sichtbar bleiben.
 Ein weiterer Knopf öffnet den Ordner, in dem das neue Speichersystem seine Daten ablegt.
 
 ### Kontrolle

--- a/tests/switchStorage.test.js
+++ b/tests/switchStorage.test.js
@@ -32,6 +32,10 @@ test('switchStorage lädt gewählten Speicher ohne Migration neu', async () => {
 
     // Einfaches Nachladen simulieren
     window.projects = JSON.parse(alterSpeicher['hla_projects']);
+    window.files = ['alt'];
+    window.textDatabase = { foo: 'bar' };
+    window.audioFileCache = { a: 1 };
+    window.historyPresenceCache = { h: true };
     window.loadProjects = async () => {
         const saved = await window.storage.getItem('hla_projects');
         window.projects = saved ? JSON.parse(saved) : [];
@@ -57,6 +61,10 @@ test('switchStorage lädt gewählten Speicher ohne Migration neu', async () => {
     expect(localStorage.getItem('hla_storageMode')).toBe('indexedDB');
     expect(document.getElementById('storageModeIndicator').textContent).toContain('Datei-Modus');
     expect(window.projects).toEqual([]);
+    expect(window.files).toEqual([]);
+    expect(window.textDatabase).toEqual({});
+    expect(window.audioFileCache).toEqual({});
+    expect(window.historyPresenceCache).toEqual({});
 
     // Neues Projekt im neuen Speicher anlegen und zurückwechseln
     neuerSpeicher['hla_projects'] = JSON.stringify([{ id: 2, name: 'Neu' }]);

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -82,6 +82,7 @@ async function switchStorage(targetMode) {
     showToast(`Wechsle zu ${zielLabel} (ohne Kopieren der Daten)`);
     const newBackend = window.createStorage(newMode);
     // Beim Wechsel werden keine Daten übertragen
+    resetGlobalState();
     window.storage = newBackend;
     window.localStorage.setItem('hla_storageMode', newMode);
     updateStorageIndicator(newMode);
@@ -91,6 +92,44 @@ async function switchStorage(targetMode) {
     if (typeof loadProjects === 'function') {
         await loadProjects();
     }
+}
+
+// Setzt alle globalen Zustände zurück, um Reste des alten Backends zu vermeiden
+function resetGlobalState() {
+    if (typeof projects !== 'undefined') projects = [];
+    if (typeof levelColors !== 'undefined') levelColors = {};
+    if (typeof levelOrders !== 'undefined') levelOrders = {};
+    if (typeof levelIcons !== 'undefined') levelIcons = {};
+    if (typeof levelColorHistory !== 'undefined') levelColorHistory = [];
+    if (typeof currentProjectLock !== 'undefined' && currentProjectLock && typeof currentProjectLock.release === 'function') {
+        currentProjectLock.release();
+    }
+    if (typeof currentProject !== 'undefined') currentProject = null;
+    if (typeof currentProjectLock !== 'undefined') currentProjectLock = null;
+    if (typeof readOnlyMode !== 'undefined') readOnlyMode = false;
+    if (typeof files !== 'undefined') files = [];
+    if (typeof textDatabase !== 'undefined') textDatabase = {};
+    if (typeof filePathDatabase !== 'undefined') filePathDatabase = {};
+    if (typeof audioFileCache !== 'undefined') audioFileCache = {};
+    if (typeof deAudioCache !== 'undefined') deAudioCache = {};
+    if (typeof audioDurationCache !== 'undefined') audioDurationCache = {};
+    if (typeof historyPresenceCache !== 'undefined') historyPresenceCache = {};
+    if (typeof folderCustomizations !== 'undefined') folderCustomizations = {};
+    if (typeof isDirty !== 'undefined') isDirty = false;
+    if (typeof aktiveOrdnerDateien !== 'undefined') aktiveOrdnerDateien = [];
+    if (typeof segmentInfo !== 'undefined') segmentInfo = null;
+    if (typeof segmentAssignments !== 'undefined') segmentAssignments = {};
+    if (typeof segmentPlayer !== 'undefined' && segmentPlayer) {
+        try { segmentPlayer.pause && segmentPlayer.pause(); } catch (e) {}
+        segmentPlayer = null;
+    }
+    if (typeof segmentSelection !== 'undefined') segmentSelection = [];
+    if (typeof segmentPlayerUrl !== 'undefined' && segmentPlayerUrl) {
+        URL.revokeObjectURL(segmentPlayerUrl);
+        segmentPlayerUrl = null;
+    }
+    if (typeof ignoredSegments !== 'undefined' && ignoredSegments.clear) ignoredSegments.clear();
+    if (typeof projectIndex !== 'undefined') projectIndex = null;
 }
 
 // Prüft, in welchem Speichersystem ein Schlüssel liegt und zeigt den Status an


### PR DESCRIPTION
## Zusammenfassung
- Leert beim Wechsel des Speichersystems alle globalen Caches, um Datenreste zu vermeiden.
- Dokumentiert den Cache-Reset in README und CHANGELOG.
- Testet, dass Dateien- und Textcaches nach dem Wechsel zurückgesetzt werden.

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e0f517f083279fca77f97b1bb556