### PR TITLE
Debug-Bericht-Knopf für vollständige Zustandsanalyse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.228
+* Neuer Debug-Bericht-Knopf exportiert den vollständigen Zustand von Projekten, Dateien und Einstellungen als JSON.
 ## 🛠️ Patch in 1.40.227
 * Speichern über File System Access nutzt jetzt temporäre Dateien und ein `journal.json`, um Schreibvorgänge atomar abzuschließen.
 ## 🛠️ Patch in 1.40.226

--- a/README.md
+++ b/README.md
@@ -954,6 +954,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **🖥️ Erweiterte Systemdaten:** Das Debug-Fenster zeigt jetzt Betriebssystem, CPU-Modell und freien Arbeitsspeicher an.
 * **📸 VideoFrame-Details:** Zusätzlich werden der Pfad zum Frame-Ordner und die Versionen der Video-Abhängigkeiten angezeigt.
 * **📝 Ausführliche API-Logs:** Alle Anfragen und Antworten werden im Dubbing-Log protokolliert
+* **📋 Debug-Bericht exportieren:** Ein Knopf erzeugt eine JSON-Datei mit dem kompletten Zustand von Projekten und Dateien.
 * **🛠 Debug-Logging aktivieren:** Setze `localStorage.setItem('hla_debug_mode','true')` im Browser, um zusätzliche Konsolen-Ausgaben zu erhalten
 * **🐞 Ausführliche Fehlerprotokolle:** Im Debug-Modus erscheinen unbehandelte Promise-Ablehnungen sowie Datei-, Zeilen- und Stack-Informationen
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -64,6 +64,7 @@
                         </div>
                     </div>
                     <button id="devToolsButton" class="btn btn-secondary" onclick="toggleDevTools()">🐞 DevTools</button>
+                    <button class="btn btn-secondary" onclick="exportDebugReport()">📋 Debug-Bericht</button>
                     <button class="btn btn-secondary" onclick="openDubbingLog()">📝 Protokoll</button>
                     <button class="btn btn-secondary" onclick="startMigration()">Migration starten</button>
                     <button class="btn btn-secondary" onclick="loadMigration()">Migration laden</button>


### PR DESCRIPTION
## Zusammenfassung
- Ergänzt `collectDebugInfo` und `exportDebugReport`, um System-, Projekt- und Dateiinfos als JSON zu exportieren.
- Fügt einen neuen "Debug-Bericht"-Button in der Toolbar hinzu.
- Dokumentation in README und CHANGELOG aktualisiert.

## Testen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1ecb7f6288327a42fc37bcb9e211a