### PR TITLE
Debug-Bericht exportiert mehrere Dateien

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.231
+* Debug-Bericht exportiert mehrere getrennte Dateien in einem gewählten Ordner.
 ## 🛠️ Patch in 1.40.230
 * Fehlende Vorschlagsdatei bietet an, einen Debug-Bericht zu speichern.
 ## 🛠️ Patch in 1.40.229

--- a/README.md
+++ b/README.md
@@ -956,7 +956,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **🖥️ Erweiterte Systemdaten:** Das Debug-Fenster zeigt jetzt Betriebssystem, CPU-Modell und freien Arbeitsspeicher an.
 * **📸 VideoFrame-Details:** Zusätzlich werden der Pfad zum Frame-Ordner und die Versionen der Video-Abhängigkeiten angezeigt.
 * **📝 Ausführliche API-Logs:** Alle Anfragen und Antworten werden im Dubbing-Log protokolliert
-* **📋 Debug-Bericht exportieren:** Ein Knopf erzeugt eine JSON-Datei mit dem kompletten Zustand von Projekten und Dateien.
+* **📋 Debug-Bericht exportieren:** Ein Knopf legt mehrere JSON-Dateien in einem gewählten Ordner ab und trennt Projekte, Datenbanken und Einstellungen.
 * **🛠 Debug-Logging aktivieren:** Setze `localStorage.setItem('hla_debug_mode','true')` im Browser, um zusätzliche Konsolen-Ausgaben zu erhalten
 * **🐞 Ausführliche Fehlerprotokolle:** Im Debug-Modus erscheinen unbehandelte Promise-Ablehnungen sowie Datei-, Zeilen- und Stack-Informationen
 


### PR DESCRIPTION
## Zusammenfassung
- Debug-Bericht erstellt jetzt mehrere JSON-Dateien in einem wählbaren Unterordner
- README und CHANGELOG entsprechend aktualisiert

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1fdd4cd508327b233726d0a235c23