### PR TITLE
Debug-Export kopiert in Zwischenablage bei Fehler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.235
+* Debug-Bericht-Export kopiert Daten in die Zwischenablage, wenn das Speichern fehlschlägt.
 ## 🛠️ Patch in 1.40.234
 * Debug-Bericht-Knopf öffnet nun ein Fenster mit einzelnen Berichten und zeigt die Dateigröße in MB an.
 ## 🛠️ Patch in 1.40.233

--- a/README.md
+++ b/README.md
@@ -957,7 +957,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **🖥️ Erweiterte Systemdaten:** Das Debug-Fenster zeigt jetzt Betriebssystem, CPU-Modell und freien Arbeitsspeicher an.
 * **📸 VideoFrame-Details:** Zusätzlich werden der Pfad zum Frame-Ordner und die Versionen der Video-Abhängigkeiten angezeigt.
 * **📝 Ausführliche API-Logs:** Alle Anfragen und Antworten werden im Dubbing-Log protokolliert
-* **📋 Debug-Bericht exportieren:** Ein Knopf öffnet ein Fenster mit einzelnen Debug-Berichten samt Dateigröße in MB; jede Datei kann separat exportiert werden.
+* **📋 Debug-Bericht exportieren:** Ein Knopf öffnet ein Fenster mit einzelnen Debug-Berichten samt Dateigröße in MB; jede Datei kann separat exportiert werden. Scheitert das Speichern, wird der Inhalt automatisch in die Zwischenablage kopiert.
 * **🛠 Debug-Logging aktivieren:** Setze `localStorage.setItem('hla_debug_mode','true')` im Browser, um zusätzliche Konsolen-Ausgaben zu erhalten
 * **🐞 Ausführliche Fehlerprotokolle:** Im Debug-Modus erscheinen unbehandelte Promise-Ablehnungen sowie Datei-, Zeilen- und Stack-Informationen
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -10982,8 +10982,14 @@ async function scanAudioDuplicates() {
                         await writable.write(JSON.stringify(rep.content, null, 2));
                         await writable.close();
                         showToast('Debug-Datei gespeichert');
-                    } catch {
-                        showToast('Speichern abgebrochen', 'error');
+                    } catch (err) {
+                        // Fallback: Bei fehlgeschlagenem Speichern Inhalte in die Zwischenablage kopieren
+                        try {
+                            await navigator.clipboard.writeText(JSON.stringify(rep.content, null, 2));
+                            showToast('Speichern fehlgeschlagen – Daten in Zwischenablage kopiert');
+                        } catch {
+                            showToast('Speichern fehlgeschlagen: ' + (err?.message || 'unbekannter Fehler'), 'error');
+                        }
                     }
                 });
             });


### PR DESCRIPTION
## Zusammenfassung
- Fallback beim Debug-Bericht-Export: Kann die Datei nicht gespeichert werden, landet der Inhalt automatisch in der Zwischenablage.
- README und CHANGELOG entsprechend aktualisiert.

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2043df4408327a6f2bcc862374411