### PR TITLE
LocalStorage beim Speichermodus-Wechsel aufräumen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.236
+* Wechsel des Speichersystems löscht jetzt automatisch alte LocalStorage-Daten und setzt den gewählten Modus direkt wieder.
 ## 🛠️ Patch in 1.40.235
 * Debug-Bericht-Export kopiert Daten in die Zwischenablage, wenn das Speichern fehlschlägt.
 ## 🛠️ Patch in 1.40.234

--- a/README.md
+++ b/README.md
@@ -835,7 +835,7 @@ Der Startdialog fragt einmalig nach dem bevorzugten Modus und merkt sich die Ent
 
 ### Anzeige und Wechsel
 
-In der Werkzeugleiste informiert ein Indikator über den aktuell genutzten Speicher. Ein danebenliegender Knopf wechselt auf Wunsch das System, ohne dabei Daten zu kopieren. Für eine Übernahme steht weiterhin **Daten migrieren** bereit. Beim Wechsel erscheinen kurze Hinweise, und die Statusleiste nennt beim Speichern das aktive System. Dabei werden alle internen Caches geleert, damit keine Daten aus dem zuvor aktiven Backend sichtbar bleiben.
+In der Werkzeugleiste informiert ein Indikator über den aktuell genutzten Speicher. Ein danebenliegender Knopf wechselt auf Wunsch das System, ohne dabei Daten zu kopieren. Für eine Übernahme steht weiterhin **Daten migrieren** bereit. Beim Wechsel erscheinen kurze Hinweise, und die Statusleiste nennt beim Speichern das aktive System. Dabei werden alle internen Caches geleert, damit keine Daten aus dem zuvor aktiven Backend sichtbar bleiben. Zusätzlich werden sämtliche alten LocalStorage-Einträge entfernt; der gewählte Modus und bestehende Projekt-Locks bleiben erhalten.
 Ein weiterer Knopf öffnet den Ordner, in dem das neue Speichersystem seine Daten ablegt.
 
 ### Kontrolle

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -84,7 +84,20 @@ async function switchStorage(targetMode) {
     // Beim Wechsel werden keine Daten übertragen
     resetGlobalState();
     window.storage = newBackend;
+    // Aktive Projekt-Locks sichern, damit parallele Tabs ihre Sperren behalten
+    const gesicherteLocks = {};
+    for (const key of Object.keys(window.localStorage)) {
+        if (key.startsWith('project-lock:')) {
+            gesicherteLocks[key] = window.localStorage.getItem(key);
+        }
+    }
+    // LocalStorage leeren und Modus direkt wieder setzen
+    window.localStorage.clear();
     window.localStorage.setItem('hla_storageMode', newMode);
+    // Gesicherte Lock-Einträge wiederherstellen
+    for (const [key, value] of Object.entries(gesicherteLocks)) {
+        window.localStorage.setItem(key, value);
+    }
     updateStorageIndicator(newMode);
     // Abschlussmeldung ausgeben
     updateStatus(`${zielLabel} geladen`);


### PR DESCRIPTION
## Summary
- entfernt beim Wechsel des Speichersystems alle bestehenden LocalStorage-Einträge und stellt Projekt-Locks wieder her
- Hinweis im README und Changelog zum automatischen Bereinigen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b20754c1ec8327b0e9e269b8fb1fa7