### PR TITLE
Verbessere Layout des DE-Audio-Editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.243
+* DE-Audio-Editor nutzt jetzt ein dreispaltiges Layout mit scrollbaren Listen, damit sich Elemente nicht überlappen.
 ## 🛠️ Patch in 1.40.242
 * DE-Audio-Editor stellt Elemente jetzt zweispaltig dar und benötigt kein Scrollen mehr.
 ## 🛠️ Patch in 1.40.241

--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ Seit Patch 1.40.125 führt ein Protokoll neben der Wiedergabeliste die erwartete
 Seit Patch 1.40.126 darf beim Anpassen-Kürzen die deutsche Übersetzung leicht verändert werden, um extrem kurze EN-Zeilen besser abzudecken.
 Seit Patch 1.40.127 besitzt der DE-Audio-Editor überarbeitete Buttons mit hilfreichen Tooltips.
 Seit Patch 1.40.242 zeigt der DE-Audio-Editor seine Bedienelemente in zwei Spalten, sodass kein Scrollen mehr nötig ist.
+Seit Patch 1.40.243 ordnet der DE-Audio-Editor Bereiche und Effekte in drei Spalten an. Lange Listen besitzen eigene Scrollleisten, sodass nichts überlappt.
 Seit Patch 1.40.194 durchsucht ein neuer Knopf das gesamte Projekt nach passenden Untertiteln und fügt eindeutige Treffer automatisch ein.
 
 Beispiel einer gültigen CSV:

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -688,24 +688,28 @@
                     </div>
                     <button class="btn btn-secondary" id="autoAdjustBtn" style="margin-top:5px;" title="Pausen kürzen und Tempo angleichen">🎯 Anpassen &amp; Anwenden</button>
                 </div>
-                <div class="edit-right">
+                <!-- Mittlere Spalte für Ignorier- und Stillebereiche -->
+                <div class="edit-center">
                     <div class="ignore-container">
-                <h4>Ignorierbereiche</h4>
-                <div id="ignoreList"></div>
-                <div class="ignore-buttons">
-                    <button class="btn btn-secondary" onclick="adjustIgnoreRanges(-50)" title="Ignorierbereich verkürzen">◀ Kürzer</button>
-                    <button class="btn btn-secondary" onclick="adjustIgnoreRanges(50)" title="Ignorierbereich verlängern">Länger ▶</button>
+                        <h4>Ignorierbereiche</h4>
+                        <div id="ignoreList"></div>
+                        <div class="ignore-buttons">
+                            <button class="btn btn-secondary" onclick="adjustIgnoreRanges(-50)" title="Ignorierbereich verkürzen">◀ Kürzer</button>
+                            <button class="btn btn-secondary" onclick="adjustIgnoreRanges(50)" title="Ignorierbereich verlängern">Länger ▶</button>
+                        </div>
+                    </div>
+                    <div class="ignore-container">
+                        <h4>Stille-Bereiche</h4>
+                        <div id="silenceList"></div>
+                        <div class="ignore-buttons">
+                            <button class="btn btn-secondary" onclick="adjustSilenceRanges(-50)" title="Stillebereich verkürzen">◀ Kürzer</button>
+                            <button class="btn btn-secondary" onclick="adjustSilenceRanges(50)" title="Stillebereich verlängern">Länger ▶</button>
+                        </div>
+                    </div>
                 </div>
-            </div>
-            <div class="ignore-container">
-                <h4>Stille-Bereiche</h4>
-                <div id="silenceList"></div>
-                <div class="ignore-buttons">
-                    <button class="btn btn-secondary" onclick="adjustSilenceRanges(-50)" title="Stillebereich verkürzen">◀ Kürzer</button>
-                    <button class="btn btn-secondary" onclick="adjustSilenceRanges(50)" title="Stillebereich verlängern">Länger ▶</button>
-                </div>
-            </div>
-            
+                <!-- Rechte Spalte für Effekt-Einstellungen -->
+                <div class="edit-right">
+
             <fieldset class="effect-group">
                 <legend>📡 Funkgerät-Effekt</legend>
                 <div class="radio-settings">

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1864,21 +1864,29 @@ th:nth-child(8) {
 
 /* Speziell breiterer Dialog für die DE-Audio-Bearbeitung */
 #deEditDialog .dialog {
-    max-width: 1100px; /* Mehr Breite für zweispaltiges Layout */
+    max-width: 1100px; /* Mehr Breite für dreispaltiges Layout */
 }
 
-/* Zweispaltiges Layout für den DE-Audio-Editor */
+/* Dreispaltiges Layout für den DE-Audio-Editor */
 #deEditDialog .edit-flex {
     display: flex;
     gap: 20px;
     flex-wrap: wrap;
 }
 
-/* Linke und rechte Spalte des Editors */
+/* Linke, mittlere und rechte Spalte des Editors */
 #deEditDialog .edit-left,
+#deEditDialog .edit-center,
 #deEditDialog .edit-right {
     flex: 1;
     min-width: 320px;
+}
+
+/* Listen mit fester Höhe und Scrollbar, damit nichts überlappt */
+#deEditDialog #ignoreList,
+#deEditDialog #silenceList {
+    max-height: 150px;
+    overflow-y: auto;
 }
 
 /* Effekt-Knöpfe umbrechen bei schmaler Breite */


### PR DESCRIPTION
## Zusammenfassung
- DE-Audio-Editor in drei Spalten aufgeteilt, damit Ignorierlisten und Effekte klar getrennt sind.
- Scrollbare Listen verhindern überlappende Elemente bei vielen Einträgen.
- Dokumentation über neues Layout in README und CHANGELOG ergänzt.

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b43cd96f388327a5833a7ff10ce32b