### PR TITLE
Rahmen für DE-Audio-Funktionen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.244
+* Alle Audio-Funktionen im DE-Editor besitzen nun eigene Rahmen mit zugehörigen Knöpfen.
 ## 🛠️ Patch in 1.40.243
 * DE-Audio-Editor nutzt jetzt ein dreispaltiges Layout mit scrollbaren Listen, damit sich Elemente nicht überlappen.
 ## 🛠️ Patch in 1.40.242

--- a/README.md
+++ b/README.md
@@ -271,9 +271,9 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **EM-Störgeräusch mit Intensitätsregler:** fügt elektromagnetische Störungen hinzu; die Stärke ist frei wählbar.
 * **Presets für Funkgeräte-Effekt:** Beliebige Einstellungen lassen sich unter eigenem Namen speichern und später wieder laden.
 * **Neues Dialogfeld beim Speichern eines Funkgeräte-Presets:** Die Namenseingabe erfolgt jetzt in einem eigenen Fenster.
-* **Getrennte Effektbereiche:** Funkgerät-, Hall- und Störgeräusch-Einstellungen liegen nun in eigenen Abschnitten des Dialogs.
+* **Getrennte Effektbereiche:** Lautstärke angleichen sowie Funkgerät-, Hall- und Störgeräusch-Einstellungen liegen jeweils in eigenen Abschnitten des Dialogs.
 * **Verbesserte Buttons:** Die kräftig gefärbten Schalter heben sich im aktiven Zustand blau hervor.
-* **Schneller Zugriff:** Die Funktionen Lautstärke angleichen – 🔊, Funkgerät-Effekt – 📻 und EM-Störgeräusch – ⚡ besitzen eigene Buttons mit Symbolen. Der Button **⟳ Standardwerte** befindet sich direkt daneben.
+* **Schneller Zugriff:** Die Funktionen Lautstärke angleichen – 🔊, Funkgerät-Effekt – 📻 und EM-Störgeräusch – ⚡ besitzen in ihren Rahmen eigene Buttons mit Symbolen. Der Button **⟳ Standardwerte** steht jeweils daneben.
 * **Hall-Standardwerte:** Im Hall-Bereich setzt **⟳ Hall-Standardwerte** alle Parameter auf ihre Ausgangswerte zurück.
 * **Störgeräusch-Standardwerte:** Im Störgeräusch-Bereich stellt **⟳ Standardwerte** die Intensität zurück.
 * **Verbessertes Speichern:** Nach dem Anwenden von Lautstärke angleichen oder Funkgerät‑Effekt bleiben die Änderungen nun zuverlässig erhalten.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -710,6 +710,14 @@
                 <!-- Rechte Spalte für Effekt-Einstellungen -->
                 <div class="edit-right">
 
+            <!-- Lautstärkeangleichung mit eigenem Rahmen -->
+            <fieldset class="effect-group">
+                <legend>🔊 Lautstärke angleichen</legend>
+                <div class="effect-buttons">
+                    <button id="volumeMatchBtn" class="effect-btn" onclick="applyVolumeMatch()" title="Lautstärke an EN anpassen">🔊 Lautstärke angleichen</button>
+                </div>
+            </fieldset>
+            <!-- Funkgerät-Effekt mit zugeordneten Knöpfen -->
             <fieldset class="effect-group">
                 <legend>📡 Funkgerät-Effekt</legend>
                 <div class="radio-settings">
@@ -737,6 +745,10 @@
                     <button id="deleteRadioPresetBtn" type="button" title="Gewähltes Preset löschen">🗑 Löschen</button>
                 </div>
                 </div>
+                <div class="effect-buttons">
+                    <button id="radioEffectBtn" class="effect-btn" onclick="applyRadioEffect()" title="Funkgerät-Effekt anwenden">📻 Funkgerät-Effekt</button>
+                    <button class="btn-reset-settings" onclick="resetRadioSettings()" title="Funkgeräteinstellungen zurücksetzen">⟳ Standardwerte</button>
+                </div>
             </fieldset>
             <fieldset class="effect-group">
                 <legend>🎚️ Hall-Effekt</legend>
@@ -752,7 +764,9 @@
                         <input type="number" id="hallDelay" min="0" max="500" step="10">
                     </label>
                 </div>
-                <button class="btn-reset-settings" onclick="resetHallSettings()" title="Hall-Effekt zurücksetzen">⟳ Hall-Standardwerte</button>
+                <div class="effect-buttons">
+                    <button class="btn-reset-settings" onclick="resetHallSettings()" title="Hall-Effekt zurücksetzen">⟳ Hall-Standardwerte</button>
+                </div>
             </fieldset>
             <fieldset class="effect-group">
                 <legend>⚡ EM-Störgeräusch</legend>
@@ -761,14 +775,11 @@
                         <input type="range" id="emiLevel" min="0" max="1" step="0.05">
                     </label>
                 </div>
-                <button class="btn-reset-settings" onclick="resetEmiSettings()" title="EM-Störgeräusch zurücksetzen">⟳ Standardwerte</button>
+                <div class="effect-buttons">
+                    <button id="emiEffectBtn" class="effect-btn" onclick="applyEmiEffect()" title="EM-Störgeräusch anwenden">⚡ EM-Störgeräusch</button>
+                    <button class="btn-reset-settings" onclick="resetEmiSettings()" title="EM-Störgeräusch zurücksetzen">⟳ Standardwerte</button>
+                </div>
             </fieldset>
-            <div class="effect-buttons">
-                <button id="volumeMatchBtn" class="effect-btn" onclick="applyVolumeMatch()" title="Lautstärke an EN anpassen">🔊 Lautstärke angleichen</button>
-                <button id="radioEffectBtn" class="effect-btn" onclick="applyRadioEffect()" title="Funkgerät-Effekt anwenden">📻 Funkgerät-Effekt</button>
-                <button id="emiEffectBtn" class="effect-btn" onclick="applyEmiEffect()" title="EM-Störgeräusch anwenden">⚡ EM-Störgeräusch</button>
-                <button class="btn-reset-settings" onclick="resetRadioSettings()" title="Funkgeräteinstellungen zurücksetzen">⟳ Standardwerte</button>
-            </div>
                 </div> <!-- edit-right Ende -->
             </div> <!-- edit-flex Ende -->
             <div class="dialog-buttons">


### PR DESCRIPTION
## Zusammenfassung
- Lautstärkeangleichung erhält einen eigenen Rahmen mit Button
- Funkgerät-, Hall- und Störgeräusch-Funktionen enthalten nun ihre Aktionsknöpfe im jeweiligen Rahmen
- Dokumentation im README und CHANGELOG aktualisiert

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b43e2007188327a4784e911a12c1ab