### PR TITLE
UI: Effekt-Toolbar im DE-Audio-Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.244
+* DE-Audio-Editor besitzt nun eine untere Effekt-Toolbar mit schnellen Aktionsknöpfen.
+
 ## 🛠️ Patch in 1.40.243
 * DE-Audio-Editor nutzt jetzt ein dreispaltiges Layout mit scrollbaren Listen, damit sich Elemente nicht überlappen.
 ## 🛠️ Patch in 1.40.242

--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ Seit Patch 1.40.126 darf beim Anpassen-Kürzen die deutsche Übersetzung leicht 
 Seit Patch 1.40.127 besitzt der DE-Audio-Editor überarbeitete Buttons mit hilfreichen Tooltips.
 Seit Patch 1.40.242 zeigt der DE-Audio-Editor seine Bedienelemente in zwei Spalten, sodass kein Scrollen mehr nötig ist.
 Seit Patch 1.40.243 ordnet der DE-Audio-Editor Bereiche und Effekte in drei Spalten an. Lange Listen besitzen eigene Scrollleisten, sodass nichts überlappt.
+Seit Patch 1.40.244 bietet der DE-Audio-Editor eine untere Effekt-Toolbar und eigene Anwenden-Knöpfe in den Effekt-Kästen.
 Seit Patch 1.40.194 durchsucht ein neuer Knopf das gesamte Projekt nach passenden Untertiteln und fügt eindeutige Treffer automatisch ein.
 
 Beispiel einer gültigen CSV:

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -710,6 +710,12 @@
                 <!-- Rechte Spalte für Effekt-Einstellungen -->
                 <div class="edit-right">
 
+            <!-- Lautstärke angleichen als eigener Kasten -->
+            <fieldset class="effect-group">
+                <legend>🔊 Lautstärke angleichen</legend>
+                <button id="volumeMatchBoxBtn" class="effect-btn" onclick="applyVolumeMatch()" title="Pegel an EN anpassen">Lautstärke angleichen</button>
+            </fieldset>
+
             <fieldset class="effect-group">
                 <legend>📡 Funkgerät-Effekt</legend>
                 <div class="radio-settings">
@@ -737,6 +743,10 @@
                     <button id="deleteRadioPresetBtn" type="button" title="Gewähltes Preset löschen">🗑 Löschen</button>
                 </div>
                 </div>
+                <div class="effect-actions">
+                    <button id="radioEffectBoxBtn" class="effect-btn" onclick="applyRadioEffect()" title="Funkgerät-Effekt anwenden">Funkgerät-Effekt anwenden</button>
+                    <button class="btn-reset-settings" onclick="resetRadioSettings()" title="Funkgeräteinstellungen zurücksetzen">⟳ Standardwerte</button>
+                </div>
             </fieldset>
             <fieldset class="effect-group">
                 <legend>🎚️ Hall-Effekt</legend>
@@ -761,20 +771,26 @@
                         <input type="range" id="emiLevel" min="0" max="1" step="0.05">
                     </label>
                 </div>
-                <button class="btn-reset-settings" onclick="resetEmiSettings()" title="EM-Störgeräusch zurücksetzen">⟳ Standardwerte</button>
+                <div class="effect-actions">
+                    <button id="emiEffectBoxBtn" class="effect-btn" onclick="applyEmiEffect()" title="EM-Störgeräusch anwenden">EM-Störgeräusch anwenden</button>
+                    <button class="btn-reset-settings" onclick="resetEmiSettings()" title="EM-Störgeräusch zurücksetzen">⟳ Standardwerte</button>
+                </div>
             </fieldset>
-            <div class="effect-buttons">
-                <button id="volumeMatchBtn" class="effect-btn" onclick="applyVolumeMatch()" title="Lautstärke an EN anpassen">🔊 Lautstärke angleichen</button>
-                <button id="radioEffectBtn" class="effect-btn" onclick="applyRadioEffect()" title="Funkgerät-Effekt anwenden">📻 Funkgerät-Effekt</button>
-                <button id="emiEffectBtn" class="effect-btn" onclick="applyEmiEffect()" title="EM-Störgeräusch anwenden">⚡ EM-Störgeräusch</button>
-                <button class="btn-reset-settings" onclick="resetRadioSettings()" title="Funkgeräteinstellungen zurücksetzen">⟳ Standardwerte</button>
-            </div>
                 </div> <!-- edit-right Ende -->
             </div> <!-- edit-flex Ende -->
-            <div class="dialog-buttons">
-                <button class="btn btn-secondary" onclick="resetDeEdit()" title="Letzte Speicherung wiederherstellen">Zurücksetzen</button>
-                <button class="btn btn-secondary" onclick="applyDeEdit()" title="Bearbeitung speichern">Speichern</button>
-                <button class="btn btn-secondary" onclick="closeDeEdit()" title="Fenster schließen">Abbrechen</button>
+
+            <!-- Untere Leiste: Effekt-Toolbar links, Aktionen rechts -->
+            <div class="edit-bottom">
+                <div class="effect-toolbar">
+                    <button id="volumeMatchBtn" class="effect-btn" onclick="applyVolumeMatch()" title="Lautstärke an EN anpassen">🔊 Lautstärke angleichen</button>
+                    <button id="radioEffectBtn" class="effect-btn" onclick="applyRadioEffect()" title="Funkgerät-Effekt anwenden">📻 Funkgerät-Effekt anwenden</button>
+                    <button id="emiEffectBtn" class="effect-btn" onclick="applyEmiEffect()" title="EM-Störgeräusch anwenden">⚡ EM-Störgeräusch anwenden</button>
+                </div>
+                <div class="dialog-buttons">
+                    <button class="btn btn-secondary" onclick="resetDeEdit()" title="Letzte Speicherung wiederherstellen">Zurücksetzen</button>
+                    <button class="btn btn-secondary" onclick="applyDeEdit()" title="Bearbeitung speichern">Speichern</button>
+                    <button class="btn btn-secondary" onclick="closeDeEdit()" title="Fenster schließen">Abbrechen</button>
+                </div>
             </div>
         </div>
     </div>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -12746,17 +12746,25 @@ async function openDeEdit(fileId) {
 // Aktualisiert die Aktiv-Markierung der Effekt-Buttons
 function updateEffectButtons() {
     const radioBtn = document.getElementById('radioEffectBtn');
+    const radioBoxBtn = document.getElementById('radioEffectBoxBtn');
     if (radioBtn) {
         // Je nach Status den aktiven Stil setzen oder entfernen
         radioBtn.classList.toggle('active', isRadioEffect);
+    }
+    if (radioBoxBtn) {
+        radioBoxBtn.classList.toggle('active', isRadioEffect);
     }
     const hallLabel = document.getElementById('hallToggleLabel');
     if (hallLabel) {
         hallLabel.classList.toggle('active', isHallEffect);
     }
     const emiBtn = document.getElementById('emiEffectBtn');
+    const emiBoxBtn = document.getElementById('emiEffectBoxBtn');
     if (emiBtn) {
         emiBtn.classList.toggle('active', isEmiEffect);
+    }
+    if (emiBoxBtn) {
+        emiBoxBtn.classList.toggle('active', isEmiEffect);
     }
 }
 

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1302,11 +1302,31 @@ th:nth-child(8) {
 }
 
 /* Gruppen für Effekt-Einstellungen */
-.edit-range,
-.effect-buttons {
+.edit-range {
     display: flex;
     gap: 10px;
     margin-bottom: 15px;
+}
+
+/* Aktionen innerhalb eines Effekt-Kastens */
+.effect-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+/* Untere Leiste mit Effekt-Toolbar und globalen Buttons */
+.edit-bottom {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 15px;
+}
+
+.effect-toolbar {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
 }
 
 /* Bereich zur Übernahme eines EN-Ausschnitts */
@@ -1889,10 +1909,6 @@ th:nth-child(8) {
     overflow-y: auto;
 }
 
-/* Effekt-Knöpfe umbrechen bei schmaler Breite */
-#deEditDialog .effect-buttons {
-    flex-wrap: wrap;
-}
 .dialog-close-btn:hover{
     color:#ff6b1a;
     transform:scale(1.2);


### PR DESCRIPTION
## Zusammenfassung
- Funktions-Kästen im DE-Audio-Editor ergänzt und Effekt-Toolbar am unteren Rand eingeführt
- JavaScript aktualisiert, um Aktiv-Zustände für neue Effektknöpfe zu synchronisieren
- Dokumentation in README und CHANGELOG um neue Toolbar erweitert

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b44300d36883278d5e9fab452c89c3