### PR TITLE
UI: Reset-Knöpfe vereinheitlicht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 🛠️ Patch in 1.40.248
+* Tippfehler im vorherigen Eintrag korrigiert und Versionsabzeichen in der README auf 1.40.248 aktualisiert.
+## 🛠️ Patch in 1.40.247
+* HTML-Kommentare der Reset-Knöpfe verwenden nun durchgehend den Hinweis „Setzt nur diesen Effekt zurück“.
+## 🛠️ Patch in 1.40.246
+* Reset-Knöpfe in allen Effektbereichen heißen jetzt einheitlich **⟳ Standardwerte** und das Tooltip erläutert: „Setzt nur diesen Effekt zurück.“
 ## 🛠️ Patch in 1.40.245
 * Score-Zellen zeigen Prozentwerte mit geschütztem Leerzeichen und deutschem Dezimaltrennzeichen an.
 ## 🛠️ Patch in 1.40.244

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.245-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.248-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -275,8 +275,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Getrennte Effektbereiche:** Funkgerät-, Hall- und Störgeräusch-Einstellungen liegen nun in eigenen Abschnitten des Dialogs.
 * **Verbesserte Buttons:** Die kräftig gefärbten Schalter heben sich im aktiven Zustand blau hervor.
 * **Schneller Zugriff:** Die Funktionen Lautstärke angleichen – 🔊, Funkgerät-Effekt – 📻 und EM-Störgeräusch – ⚡ besitzen eigene Buttons mit Symbolen. Der Button **⟳ Standardwerte** befindet sich direkt daneben.
-* **Hall-Standardwerte:** Im Hall-Bereich setzt **⟳ Hall-Standardwerte** alle Parameter auf ihre Ausgangswerte zurück.
-* **Störgeräusch-Standardwerte:** Im Störgeräusch-Bereich stellt **⟳ Standardwerte** die Intensität zurück.
+* **Standardwerte:** Im Hall- und Störgeräusch-Bereich setzt **⟳ Standardwerte** alle Parameter beziehungsweise die Intensität auf ihre Ausgangswerte zurück. Tooltip und Code-Kommentar erklären übereinstimmend: „Setzt nur diesen Effekt zurück.“
 * **Verbessertes Speichern:** Nach dem Anwenden von Lautstärke angleichen oder Funkgerät‑Effekt bleiben die Änderungen nun zuverlässig erhalten.
 * **Fünf Bearbeitungssymbole:** Der Status neben der Schere zeigt nun bis zu fünf Icons in zwei Reihen für Trimmen, Lautstärkeangleichung, Funkgerät-, Hall- und Störgeräusch-Effekt an.
 * **Ignorier-Bereiche im DE-Editor:** Mit gedrückter Umschalttaste lassen sich beliebige Abschnitte markieren, die beim Abspielen und Speichern übersprungen werden. Die Bereiche bleiben bearbeitbar und erscheinen in einer eigenen Liste. Vorschau und Export überspringen diese Stellen automatisch.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -745,7 +745,8 @@
                 </div>
                 <div class="effect-actions">
                     <button id="radioEffectBoxBtn" class="effect-btn" onclick="applyRadioEffect()" title="Funkgerät-Effekt anwenden">Funkgerät-Effekt anwenden</button>
-                    <button class="btn-reset-settings" onclick="resetRadioSettings()" title="Funkgeräteinstellungen zurücksetzen">⟳ Standardwerte</button>
+                    <!-- Setzt nur diesen Effekt zurück -->
+                    <button class="btn-reset-settings" onclick="resetRadioSettings()" title="Setzt nur diesen Effekt zurück">⟳ Standardwerte</button>
                 </div>
             </fieldset>
             <fieldset class="effect-group">
@@ -762,7 +763,8 @@
                         <input type="number" id="hallDelay" min="0" max="500" step="10">
                     </label>
                 </div>
-                <button class="btn-reset-settings" onclick="resetHallSettings()" title="Hall-Effekt zurücksetzen">⟳ Hall-Standardwerte</button>
+                <!-- Setzt nur diesen Effekt zurück -->
+                <button class="btn-reset-settings" onclick="resetHallSettings()" title="Setzt nur diesen Effekt zurück">⟳ Standardwerte</button>
             </fieldset>
             <fieldset class="effect-group">
                 <legend>⚡ EM-Störgeräusch</legend>
@@ -773,7 +775,8 @@
                 </div>
                 <div class="effect-actions">
                     <button id="emiEffectBoxBtn" class="effect-btn" onclick="applyEmiEffect()" title="EM-Störgeräusch anwenden">EM-Störgeräusch anwenden</button>
-                    <button class="btn-reset-settings" onclick="resetEmiSettings()" title="EM-Störgeräusch zurücksetzen">⟳ Standardwerte</button>
+                    <!-- Setzt nur diesen Effekt zurück -->
+                    <button class="btn-reset-settings" onclick="resetEmiSettings()" title="Setzt nur diesen Effekt zurück">⟳ Standardwerte</button>
                 </div>
             </fieldset>
                 </div> <!-- edit-right Ende -->


### PR DESCRIPTION
## Zusammenfassung
- HTML-Kommentare und Tooltips der Reset-Knöpfe weisen nun einheitlich auf "Setzt nur diesen Effekt zurück" hin
- Alle Effektbereiche nutzen den Knopf **⟳ Standardwerte**
- README-Versionsabzeichen auf 1.40.248 aktualisiert und Changelog-Eintrag korrigiert

## Testanweisungen
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b446912a80832789735358e13c2cc8