### PR TITLE
UI: Timing-Bereich als Kartenraster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.251
+* Abschnitt „Timing & Bereiche“ im DE-Audio-Editor nutzt jetzt ein zweispaltiges Kartenlayout, das bei schmaler Breite sauber auf eine Spalte umbricht.
 ## 🛠️ Patch in 1.40.250
 * Bereiche in EN- und DE-Wellenformen lassen sich direkt per Ziehen markieren, Start-/End-Felder synchronisieren sich bidirektional und ungültige Eingaben werden markiert.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.250-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.251-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -41,6 +41,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Saubere Einheiten:** Prozentwerte nutzen nun ein geschütztes Leerzeichen und deutsches Dezimaltrennzeichen.
 * **Verbessertes Scrollen in der Dateitabelle:** Nach dem Rendern springt die Tabelle nur zur gemerkten Zeile, wenn keine neue Datei markiert wird; andernfalls wird nach der Auswahl gescrollt.
 * **Auto-Scroll blockiert Zeilennummer-Aktualisierung:** Der Fallback in `selectRow` setzt kurzzeitig `isAutoScrolling`, damit `updateNumberFromScroll` nicht dazwischenfunkt.
+* **Überarbeitetes Timing-Layout:** Der Abschnitt „Timing & Bereiche“ nutzt ein zweispaltiges Kartenraster, das bei schmaler Breite automatisch auf eine Spalte umbricht.
 * **Detailliertes Fehlerfenster:** Fehlende oder beschädigte Projekte melden sich mit einer genauen Ursache und einem Reparaturhinweis.
 * **Debug-Bericht bei Fehlern:** Nach jeder Fehlermeldung kann ein Fenster mit auswählbaren Berichten samt Umgebung geöffnet werden.
 * **Abgesicherte Ordnerauswahl:** Verweigert der Browser den Dateisystem-Zugriff, erscheint eine verständliche Fehlermeldung.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -665,32 +665,25 @@
                 </div>
             </div>
             <div class="edit-flex">
-                <div class="edit-left">
-                    <div class="edit-range">
-                        <label>Start (ms): <input type="number" id="editStart" value="0" step="100"></label>
-                        <label>Ende (ms): <input type="number" id="editEnd" value="0" step="100"></label>
+                <!-- Bereich: Timing & Bereiche -->
+                <div class="timing-grid">
+                    <!-- Karte Trimmen -->
+                    <div class="timing-card trim-card">
+                        <h4>Trimmen</h4>
+                        <div class="trim-fields">
+                            <div class="field">
+                                <label for="editStart">Start (ms)</label>
+                                <div class="input-unit"><input type="number" id="editStart" value="0" step="100"><span class="unit">ms</span></div>
+                            </div>
+                            <div class="field">
+                                <label for="editEnd">Ende (ms)</label>
+                                <div class="input-unit"><input type="number" id="editEnd" value="0" step="100"><span class="unit">ms</span></div>
+                            </div>
+                        </div>
                         <button id="autoTrimBtn" class="copy-btn" title="Stille automatisch erkennen">Auto</button>
                     </div>
-                    <div class="trim-options">
-                        <label title="Längere Pausen automatisch entfernen"><input type="checkbox" id="autoIgnoreChk"> Pausen &gt; <input type="number" id="autoIgnoreMs" value="400" step="100" style="width:70px;"> ms entfernen</label>
-                    </div>
-                    <div class="stretch-options">
-                        <label title="Passt die Geschwindigkeit des DE-Audios an"><input type="checkbox" id="autoTempoChk"> Tempo automatisch an EN anpassen</label>
-                        <label class="tempo-control">Tempo:
-                            <button id="tempoMinusBtn" class="copy-btn" title="Tempo in kleinen Schritten verringern">➖</button>
-                            <input type="range" id="tempoRange" min="1" max="3" step="0.01" value="1" title="Aktuelles Wiedergabetempo">
-                            <button id="tempoPlusBtn" class="copy-btn" title="Tempo in kleinen Schritten erhöhen">➕</button>
-                            <span id="tempoDisplay">1.00</span>
-                        </label>
-                        <button id="tempoAutoBtn" class="copy-btn" title="Tempo auf Minimum setzen und anpassen">Auto</button>
-                        <button id="tempoAutoResetBtn" class="copy-btn" title="Tempo auf gespeicherten Wert zurücksetzen">Auto</button>
-                        <span id="tempoInfo" style="margin-left:10px;"></span>
-                    </div>
-                    <button class="btn btn-secondary" id="autoAdjustBtn" style="margin-top:5px;" title="Pausen kürzen und Tempo angleichen">🎯 Anpassen &amp; Anwenden</button>
-                </div>
-                <!-- Mittlere Spalte für Ignorier- und Stillebereiche -->
-                <div class="edit-center">
-                    <div class="ignore-container">
+                    <!-- Karte Ignorierbereiche -->
+                    <div class="timing-card ignore-card">
                         <h4>Ignorierbereiche</h4>
                         <div id="ignoreList"></div>
                         <div class="ignore-buttons">
@@ -698,7 +691,13 @@
                             <button class="btn btn-secondary" onclick="adjustIgnoreRanges(50)" title="Ignorierbereich verlängern">Länger ▶</button>
                         </div>
                     </div>
-                    <div class="ignore-container">
+                    <!-- Karte Pausen entfernen -->
+                    <div class="timing-card pause-card">
+                        <h4>Pausen entfernen</h4>
+                        <label class="checkbox-line" title="Längere Pausen automatisch entfernen"><input type="checkbox" id="autoIgnoreChk"> Pausen &gt; <span class="input-unit"><input type="number" id="autoIgnoreMs" value="400" step="100" style="width:70px;"><span class="unit">ms</span></span> entfernen</label>
+                    </div>
+                    <!-- Karte Stille-Bereiche -->
+                    <div class="timing-card silence-card">
                         <h4>Stille-Bereiche</h4>
                         <div id="silenceList"></div>
                         <div class="ignore-buttons">
@@ -706,6 +705,25 @@
                             <button class="btn btn-secondary" onclick="adjustSilenceRanges(50)" title="Stillebereich verlängern">Länger ▶</button>
                         </div>
                     </div>
+                    <!-- Karte Tempo -->
+                    <div class="timing-card tempo-card">
+                        <h4>Tempo</h4>
+                        <label class="checkbox-line" title="Passt die Geschwindigkeit des DE-Audios an"><input type="checkbox" id="autoTempoChk"> Tempo automatisch an EN anpassen</label>
+                        <div class="tempo-row">
+                            <span class="tempo-icon">⏱️</span>
+                            <button id="tempoMinusBtn" class="copy-btn" title="Tempo in kleinen Schritten verringern">➖</button>
+                            <input type="range" id="tempoRange" min="1" max="3" step="0.01" value="1" title="Aktuelles Wiedergabetempo">
+                            <button id="tempoPlusBtn" class="copy-btn" title="Tempo in kleinen Schritten erhöhen">➕</button>
+                            <span id="tempoDisplay" class="tempo-value">1.00</span>
+                        </div>
+                        <div class="tempo-auto">
+                            <button id="tempoAutoBtn" class="copy-btn" title="Tempo auf Minimum setzen und anpassen">Auto</button>
+                            <button id="tempoAutoResetBtn" class="copy-btn" title="Tempo auf gespeicherten Wert zurücksetzen">Auto</button>
+                            <span id="tempoInfo"></span>
+                        </div>
+                    </div>
+                    <!-- Button Anpassen & Anwenden -->
+                    <button class="btn btn-secondary" id="autoAdjustBtn" title="Pausen kürzen und Tempo angleichen">🎯 Anpassen &amp; Anwenden</button>
                 </div>
                 <!-- Rechte Spalte für Effekt-Einstellungen -->
                 <div class="edit-right">

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1361,17 +1361,9 @@ th:nth-child(8) {
     justify-content: center;
 }
 
-.ignore-container { margin-bottom: 15px; }
 .ignore-row { display:flex; gap:6px; margin-bottom:4px; }
 .ignore-row input { width:70px; }
 .ignore-buttons { display:flex; gap:6px; margin:4px 0; }
-.trim-options,
-.stretch-options {
-    display: flex;
-    gap: 10px;
-    margin-bottom: 10px;
-    align-items: center;
-}
 
 .stretch-options span {
     min-width: 80px;
@@ -1916,12 +1908,91 @@ th:nth-child(8) {
     flex-wrap: wrap;
 }
 
-/* Linke, mittlere und rechte Spalte des Editors */
-#deEditDialog .edit-left,
-#deEditDialog .edit-center,
+/* Rechte Spalte für Effekte */
 #deEditDialog .edit-right {
     flex: 1;
     min-width: 320px;
+}
+
+/* Grid für Timing & Bereiche */
+#deEditDialog .timing-grid {
+    flex: 1;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 20px;
+}
+
+#deEditDialog .timing-card {
+    background: #1a1a1a;
+    border: 1px solid #444;
+    border-radius: 6px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+#deEditDialog .trim-fields {
+    display: flex;
+    gap: 10px;
+}
+
+#deEditDialog .trim-fields .field {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+#deEditDialog .input-unit {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+#deEditDialog .input-unit .unit {
+    font-size: 0.9em;
+    color: #bbb;
+}
+
+#deEditDialog .checkbox-line {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+#deEditDialog .checkbox-line input[type="checkbox"] {
+    margin-top: 2px;
+}
+
+#deEditDialog .tempo-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+#deEditDialog .tempo-row .tempo-value {
+    width: 50px;
+    text-align: center;
+    border: 1px solid #444;
+    padding: 2px;
+    border-radius: 4px;
+}
+
+#deEditDialog .tempo-auto {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+
+#deEditDialog #tempoInfo {
+    margin-left: 10px;
+    color: #ccc;
+}
+
+#deEditDialog #autoAdjustBtn {
+    grid-column: 1 / -1;
+    width: 100%;
 }
 
 /* Listen mit fester Höhe und Scrollbar, damit nichts überlappt */


### PR DESCRIPTION
## Zusammenfassung
- Abschnitt „Timing & Bereiche“ im DE-Audio-Editor auf zweispaltiges Kartenraster mit responsivem Einspalten-Fallback umgestellt
- Einheitliche Karten mit klaren Überschriften, Abstand und Button „Anpassen & Anwenden“ über volle Breite
- README und CHANGELOG für Version 1.40.251 aktualisiert

## Testanweisungen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b44f5b3a0483278f1e98fcda1622c3