### PR TITLE
Zoom-Funktion im DE-Audio-Editor entfernt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.252
+* Zoom-Funktion per Maus in EN- und DE-Wellenformen des DE-Audio-Editors entfernt.
 ## 🛠️ Patch in 1.40.251
 * Abschnitt „Timing & Bereiche“ im DE-Audio-Editor nutzt jetzt ein zweispaltiges Kartenlayout, das bei schmaler Breite sauber auf eine Spalte umbricht.
 ## 🛠️ Patch in 1.40.250

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.251-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.252-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -352,6 +352,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Drag & Drop:** Projekte und Dateien sortieren
 * **Klick auf Zeilennummer:** Position über Dialog anpassen
 * **Mausrad:** Markiert beim Scrollen automatisch die Zeile in der Bildschirmmitte, ohne sie neu auszurichten
+* **Kein Zoom in Wellenformen:** Beim Ziehen in EN- und DE-Spuren des DE-Audio-Editors erfolgt kein automatisches Zoom mehr
 * **Zeilenauswahl:** Gewählte Zeilen werden vollständig unter dem Tabellenkopf positioniert
 * **Doppelklick:** Projekt umbenennen
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -12788,7 +12788,8 @@ async function openDeEdit(fileId) {
             } else {
                 if (startField) startField.value = Math.round(start);
                 if (endField)   endField.value = Math.round(end);
-                zoomCanvasToRange(origCanvas, start, end, editEnBuffer.length / editEnBuffer.sampleRate * 1000);
+                // Zoom der Wellenform wurde entfernt
+                // zoomCanvasToRange(origCanvas, start, end, editEnBuffer.length / editEnBuffer.sampleRate * 1000);
             }
             validateEnSelection();
             updateDeEditWaveforms();
@@ -12818,7 +12819,8 @@ async function openDeEdit(fileId) {
                     audio.currentTime = Math.min(Math.max(editDeCursor - editStartTrim, 0), dur) / 1000;
                 }
             } else {
-                zoomCanvasToRange(deCanvas, start, end, editDurationMs);
+                // Zoom der Wellenform wurde entfernt
+                // zoomCanvasToRange(deCanvas, start, end, editDurationMs);
             }
             validateDeSelection();
             updateDeEditWaveforms();


### PR DESCRIPTION
## Zusammenfassung
- Zoom per Maus in EN- und DE-Wellenformen deaktiviert
- Dokumentation und Changelog entsprechend aktualisiert

## Testen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b49f004bc48327a9a60c1d3b181a6d