### PR TITLE
EN- und Emotionaltext im DE-Audio-Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.253
+* EN-Text und emotionaler DE-Text werden unter den Wellenformen im DE-Audio-Editor angezeigt.
 ## 🛠️ Patch in 1.40.252
 * Zoom-Funktion per Maus in EN- und DE-Wellenformen des DE-Audio-Editors entfernt.
 ## 🛠️ Patch in 1.40.251

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.252-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.253-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -283,6 +283,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Stille einfügen:** Mit gedrückter Alt‑Taste lassen sich Bereiche markieren, an denen beim Speichern Stille eingefügt wird. So lassen sich Audios zeitlich verschieben.
 * **EN-Abschnitt einfügen:** Ziehe mit der Maus im EN-Original einen Bereich auf. Über den Pfeil zwischen den beiden Wellen lässt sich der markierte Ausschnitt am Anfang, am Ende oder an der aktuellen Cursor-Position in das DE-Audio kopieren. Doppelklick oder Esc entfernt die Markierung, beim Schließen des Bearbeitungsdialogs werden Start, Ende und Einfügeposition zurückgesetzt.
 * **Start/Ende verschieben:** Die Markierungsgriffe im EN-Original lassen sich mit der Maus bewegen; die Felder „Start EN" und „Ende EN" passen sich automatisch an.
+* **Texte unter den Wellenformen:** Unter der EN-Welle erscheint der englische Text und unter der DE-Welle der emotionale deutsche Text.
 * **Manuelles Zuschneiden:** Start- und Endzeit lassen sich per Millisekundenfeld oder durch Ziehen eines Bereichs direkt im DE-Wellenbild setzen; die Felder synchronisieren sich bidirektional.
 * **Automatische Pausenkürzung und Time‑Stretching:** Längere Pausen erkennt das Tool auf Wunsch selbst. Mit einem Regler lässt sich das Tempo von 1,00–3,00 anpassen oder automatisch auf die EN-Länge setzen. Kleine ➖/➕‑Knöpfe erlauben präzise Schritte. Ein Button „🎯 Anpassen & Anwenden“ kombiniert beide Schritte und eine farbige Anzeige warnt bei Abweichungen.
 * **Zwei Tempo‑Auto‑Knöpfe:** Der erste setzt den Wert auf 1,00, markiert ihn gelb und erhöht das Tempo automatisch, bis „DE (bearbeiten)“ orange leuchtet (Abweichung unter 10 %). Der zweite stellt den gespeicherten Wert wieder her und färbt die Anzeige grau.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -639,6 +639,8 @@
                         <button id="playOrigPreview" class="de-play-btn" onclick="playOriginalPreview()" title="Original abspielen">▶</button>
                         <button class="de-stop-btn" onclick="stopEditPlayback()" title="Wiedergabe stoppen">⏹</button>
                     </div>
+                    <!-- EN-Text unter der Original-Welle -->
+                    <div id="editEnText" class="wave-text"></div>
                 </div>
                 <!-- Steuerung zum Runterkopieren des markierten EN-Bereichs -->
                 <div class="insert-en-section">
@@ -662,6 +664,9 @@
                         <button id="playDePreview" class="de-play-btn" onclick="playDePreview()" title="DE-Vorschau abspielen">▶</button>
                         <button class="de-stop-btn" onclick="stopEditPlayback()" title="Wiedergabe stoppen">⏹</button>
                     </div>
+                    <!-- DE-Text und Emotional-Text unter der Bearbeitungs-Welle -->
+                    <div id="editDeText" class="wave-text"></div>
+                    <div id="editEmoText" class="wave-text"></div>
                 </div>
             </div>
             <div class="edit-flex">

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -12495,6 +12495,14 @@ async function openDeEdit(fileId) {
     document.getElementById('waveLabelOriginal').textContent = `EN (Original) - ${enSeconds.toFixed(2)}s`;
     document.getElementById('waveLabelEdited').textContent = `DE (bearbeiten) - ${deSeconds.toFixed(2)}s`;
 
+    // EN-Text, DE-Text und Emotional-Text unter den Wellen anzeigen
+    const enTextEl = document.getElementById('editEnText');
+    if (enTextEl) enTextEl.textContent = file.enText || '';
+    const deTextEl = document.getElementById('editDeText');
+    if (deTextEl) deTextEl.textContent = file.deText || '';
+    const emoTextEl = document.getElementById('editEmoText');
+    if (emoTextEl) emoTextEl.textContent = file.emotionalText || '';
+
     updateDeEditWaveforms();
     document.getElementById('deEditDialog').classList.remove('hidden');
 

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1074,6 +1074,13 @@ th:nth-child(8) {
             white-space: nowrap;
         }
 
+        /* Kleiner Text unter den Wellenformen */
+        .wave-text {
+            font-size: 12px;
+            color: #ccc;
+            margin-top: 2px;
+        }
+
         .delete-row-btn {
             background: none;
             border: none;


### PR DESCRIPTION
## Zusammenfassung
- Englischen Text unter der EN-Welle anzeigen
- Deutschen Text und Emotional-Text unter der DE-Welle einblenden
- Versionshinweise und Doku aktualisiert

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b52cdba2788327bd410e8aa324197b