### PR TITLE
Fix: Nebenraum-Effekt speichert korrekt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.255
+* Nebenraum-Effekt wird beim Speichern korrekt angewendet.
 ## 🛠️ Patch in 1.40.254
 * Neuer Nebenraum-Effekt simuliert gedämpfte Stimmen aus dem angrenzenden Raum.
 ## 🛠️ Patch in 1.40.253

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.254-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.255-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -272,6 +272,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Hall-Effekt mit Raumgröße, Hallintensität und Verzögerung:** alle Werte lassen sich justieren und bleiben erhalten.
 * **EM-Störgeräusch mit Intensitätsregler:** fügt elektromagnetische Störungen hinzu; die Stärke ist frei wählbar.
 * **Nebenraum-Effekt:** simuliert gedämpfte Sprache aus einem angrenzenden Raum.
+* **Zuverlässiges Speichern des Nebenraum-Effekts:** der Effekt wird nun dauerhaft beim Speichern übernommen.
 * **Presets für Funkgeräte-Effekt:** Beliebige Einstellungen lassen sich unter eigenem Namen speichern und später wieder laden.
 * **Neues Dialogfeld beim Speichern eines Funkgeräte-Presets:** Die Namenseingabe erfolgt jetzt in einem eigenen Fenster.
 * **Getrennte Effektbereiche:** Funkgerät-, Hall- und Störgeräusch-Einstellungen liegen nun in eigenen Abschnitten des Dialogs.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -13811,6 +13811,10 @@ async function applyDeEdit() {
         if (isHallEffect) {
             baseBuffer = await applyReverbEffect(baseBuffer);
         }
+        // Nebenraum-Effekt anwenden, falls aktiv
+        if (isNeighborEffect) {
+            baseBuffer = await applyNeighborRoomEffect(baseBuffer);
+        }
         if (isEmiEffect) {
             baseBuffer = await applyInterferenceEffect(baseBuffer);
         }
@@ -13892,6 +13896,10 @@ async function applyDeEdit() {
         }
         if (isHallEffect) {
             baseBuffer = await applyReverbEffect(baseBuffer);
+        }
+        // Nebenraum-Effekt anwenden, falls aktiv
+        if (isNeighborEffect) {
+            baseBuffer = await applyNeighborRoomEffect(baseBuffer);
         }
         if (isEmiEffect) {
             baseBuffer = await applyInterferenceEffect(baseBuffer);


### PR DESCRIPTION
## Zusammenfassung
- Nebenraum-Effekt wird beim Speichern der DE-Audio-Bearbeitung jetzt korrekt angewendet
- Dokumentation und Changelog um den Bugfix ergänzt

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b53121f75883278c238b158fa0d60b