### PR TITLE
Sorge für vollständig sichtbare Auswahlzeilen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.256
+* Ausgewählte Zeile bleibt vollständig sichtbar und wird nicht mehr von der Tabellenüberschrift überdeckt.
 ## 🛠️ Patch in 1.40.255
 * Nebenraum-Effekt wird beim Speichern korrekt angewendet.
 ## 🛠️ Patch in 1.40.254

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.255-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.256-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -41,6 +41,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Saubere Einheiten:** Prozentwerte nutzen nun ein geschütztes Leerzeichen und deutsches Dezimaltrennzeichen.
 * **Verbessertes Scrollen in der Dateitabelle:** Nach dem Rendern springt die Tabelle nur zur gemerkten Zeile, wenn keine neue Datei markiert wird; andernfalls wird nach der Auswahl gescrollt.
 * **Auto-Scroll blockiert Zeilennummer-Aktualisierung:** Der Fallback in `selectRow` setzt kurzzeitig `isAutoScrolling`, damit `updateNumberFromScroll` nicht dazwischenfunkt.
+* **Übersichtliche Auswahlzeile:** Die gewählte Zeile bleibt vollständig sichtbar und wird nicht mehr von der Tabellenüberschrift verdeckt.
 * **Überarbeitetes Timing-Layout:** Der Abschnitt „Timing & Bereiche“ nutzt ein zweispaltiges Kartenraster, das bei schmaler Breite automatisch auf eine Spalte umbricht.
 * **Detailliertes Fehlerfenster:** Fehlende oder beschädigte Projekte melden sich mit einer genauen Ursache und einem Reparaturhinweis.
 * **Debug-Bericht bei Fehlern:** Nach jeder Fehlermeldung kann ein Fenster mit auswählbaren Berichten samt Umgebung geöffnet werden.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -3389,10 +3389,10 @@ function addFiles() {
                 if (num !== null) {
                     scrollToNumber(num);
                 } else {
-                    // Fallback: Scrollt den Eintrag an den oberen Rand
+                    // Fallback: Scrollt die Zeile unter Berücksichtigung der Tabellenüberschrift
                     isAutoScrolling = true; // verhindert Updates während des Auto-Scrolls
                     if (autoScrollTimeout) clearTimeout(autoScrollTimeout);
-                    selectedRow.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    scrollRowIntoView(selectedRow);
                     autoScrollTimeout = setTimeout(() => { isAutoScrolling = false; }, 300);
                 }
             }
@@ -3419,6 +3419,25 @@ function addFiles() {
             }
         }
 
+        // Hilfsfunktion: Scrollt eine beliebige Zeile so, dass sie nicht vom Tabellenkopf überdeckt wird
+        function scrollRowIntoView(row) {
+            const container = document.querySelector('.table-container');
+            if (container) {
+                const containerRect = container.getBoundingClientRect();
+                const rowRect = row.getBoundingClientRect();
+                const currentScroll = container.scrollTop;
+                const header = container.querySelector('thead');
+                const headerHeight = header ? header.getBoundingClientRect().height : 0;
+                // Zielposition unterhalb der Überschrift berechnen
+                const rowTopOffset = rowRect.top - containerRect.top + currentScroll;
+                const target = Math.max(0, rowTopOffset - headerHeight);
+                container.scrollTo({ top: target, behavior: 'smooth' });
+            } else {
+                // Fallback ohne speziellen Container
+                row.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        }
+
         // Springt zu einer bestimmten Nummer und sorgt dafür, dass die Zeile unter dem Tabellenkopf vollständig sichtbar bleibt
         function scrollToNumber(num) {
             if (!files.length) return;
@@ -3432,19 +3451,11 @@ function addFiles() {
                     // Scroll-Snap kurz deaktivieren, damit der Tabellenkopf nichts überdeckt
                     const originalSnap = container.style.scrollSnapType;
                     container.style.scrollSnapType = 'none';
-                    const containerRect = container.getBoundingClientRect();
-                    const rowRect = row.getBoundingClientRect();
-                    const currentScroll = container.scrollTop;
-                    const header = container.querySelector('thead');
-                    const headerHeight = header ? header.getBoundingClientRect().height : 0;
-                    // Ziel so setzen, dass Nummer, Name und Ordner unterhalb des Kopfes bleiben
-                    const rowTopOffset = rowRect.top - containerRect.top + currentScroll;
-                    const target = Math.max(0, rowTopOffset - headerHeight);
-                    container.scrollTo({ top: target, behavior: 'smooth' });
+                    scrollRowIntoView(row);
                     // Scroll-Snap nach kurzer Zeit wieder aktivieren
                     setTimeout(() => { container.style.scrollSnapType = originalSnap; }, 300);
                 } else {
-                    row.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    scrollRowIntoView(row);
                 }
                 setActiveRow(row);
                 currentRowNumber = num;


### PR DESCRIPTION
## Zusammenfassung
- Verhindert, dass die Tabellenüberschrift die Auswahlzeile verdeckt
- Dokumentation für die sichtbare Auswahlzeile ergänzt
- Versionshinweis im Changelog auf 1.40.256 erweitert

## Testen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b533092fd48327aac69ff7c39796da