### PR TITLE
Fix: Hall-Option im Nebenraum-Effekt speichern und anzeigen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.258
+* Optionaler Hall im Nebenraum-Effekt wird in Vorschau und beim Speichern korrekt übernommen.
 ## 🛠️ Patch in 1.40.257
 * Nebenraum-Effekt bietet einen optional zuschaltbaren Hall.
 ## 🛠️ Patch in 1.40.256

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.256-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.258-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -273,7 +273,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Hall-Effekt mit Raumgröße, Hallintensität und Verzögerung:** alle Werte lassen sich justieren und bleiben erhalten.
 * **EM-Störgeräusch mit Intensitätsregler:** fügt elektromagnetische Störungen hinzu; die Stärke ist frei wählbar.
 * **Nebenraum-Effekt:** simuliert gedämpfte Sprache aus einem angrenzenden Raum; optionaler Hall kann zugeschaltet werden.
-* **Zuverlässiges Speichern des Nebenraum-Effekts:** der Effekt wird nun dauerhaft beim Speichern übernommen.
+* **Optionaler Hall im Nebenraum-Effekt:** wird nun in der Vorschau und beim Speichern korrekt übernommen.
 * **Presets für Funkgeräte-Effekt:** Beliebige Einstellungen lassen sich unter eigenem Namen speichern und später wieder laden.
 * **Neues Dialogfeld beim Speichern eines Funkgeräte-Presets:** Die Namenseingabe erfolgt jetzt in einem eigenen Fenster.
 * **Getrennte Effektbereiche:** Funkgerät-, Hall- und Störgeräusch-Einstellungen liegen nun in eigenen Abschnitten des Dialogs.

--- a/tests/dubbingResetsFlags.test.js
+++ b/tests/dubbingResetsFlags.test.js
@@ -10,6 +10,7 @@ function afterDubbingMock(file) {
     file.hallEffect = false;
     file.emiEffect = false;
     file.neighborEffect = false;
+    file.neighborHall = false;
 }
 
 test('Dubbing setzt Bearbeitungs-Flags zurück', () => {
@@ -20,7 +21,8 @@ test('Dubbing setzt Bearbeitungs-Flags zurück', () => {
         radioEffect: true,
         hallEffect: true,
         emiEffect: true,
-        neighborEffect: true
+        neighborEffect: true,
+        neighborHall: true
     };
     afterDubbingMock(file);
     expect(file.trimStartMs).toBe(0);
@@ -30,4 +32,5 @@ test('Dubbing setzt Bearbeitungs-Flags zurück', () => {
     expect(file.hallEffect).toBe(false);
     expect(file.emiEffect).toBe(false);
     expect(file.neighborEffect).toBe(false);
+    expect(file.neighborHall).toBe(false);
 });

--- a/tests/neighborHallFlag.test.js
+++ b/tests/neighborHallFlag.test.js
@@ -1,0 +1,14 @@
+const { expect, test } = require('@jest/globals');
+
+// Einfacher Mock: simuliert das Speichern mit Nebenraum-Hall
+function applyDeEditMock(file, withHall) {
+    file.neighborEffect = true;
+    file.neighborHall = withHall;
+}
+
+test('neighborHall bleibt nach applyDeEdit gesetzt', () => {
+    const file = { neighborEffect: false, neighborHall: false };
+    applyDeEditMock(file, true);
+    expect(file.neighborEffect).toBe(true);
+    expect(file.neighborHall).toBe(true);
+});

--- a/tests/segmentImportResetsFlags.test.js
+++ b/tests/segmentImportResetsFlags.test.js
@@ -9,6 +9,7 @@ function importSegmentsMock(file) {
     file.hallEffect = false;
     file.emiEffect = false;
     file.neighborEffect = false;
+    file.neighborHall = false;
 }
 
 test('Segment-Import setzt Bearbeitungs-Flags zurück', () => {
@@ -19,7 +20,8 @@ test('Segment-Import setzt Bearbeitungs-Flags zurück', () => {
         radioEffect: true,
         hallEffect: true,
         emiEffect: true,
-        neighborEffect: true
+        neighborEffect: true,
+        neighborHall: true
     };
     importSegmentsMock(file);
     expect(file.trimStartMs).toBe(0);
@@ -29,4 +31,5 @@ test('Segment-Import setzt Bearbeitungs-Flags zurück', () => {
     expect(file.hallEffect).toBe(false);
     expect(file.emiEffect).toBe(false);
     expect(file.neighborEffect).toBe(false);
+    expect(file.neighborHall).toBe(false);
 });

--- a/tests/uploadResetsFlags.test.js
+++ b/tests/uploadResetsFlags.test.js
@@ -11,6 +11,7 @@ function uploadFileMock(file) {
     file.hallEffect = false;
     file.emiEffect = false;
     file.neighborEffect = false;
+    file.neighborHall = false;
 }
 
 test('Upload setzt Bearbeitungs-Flags zurück', () => {
@@ -21,7 +22,8 @@ test('Upload setzt Bearbeitungs-Flags zurück', () => {
         radioEffect: true,
         hallEffect: true,
         emiEffect: true,
-        neighborEffect: true
+        neighborEffect: true,
+        neighborHall: true
     };
     uploadFileMock(file);
     expect(file.trimStartMs).toBe(0);
@@ -31,4 +33,5 @@ test('Upload setzt Bearbeitungs-Flags zurück', () => {
     expect(file.hallEffect).toBe(false);
     expect(file.emiEffect).toBe(false);
     expect(file.neighborEffect).toBe(false);
+    expect(file.neighborHall).toBe(false);
 });

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2721,6 +2721,7 @@ function selectProject(id){
         if(!f.hasOwnProperty('hallEffect')){f.hallEffect=false;migrated=true;}
         if(!f.hasOwnProperty('emiEffect')){f.emiEffect=false;migrated=true;}
         if(!f.hasOwnProperty('neighborEffect')){f.neighborEffect=false;migrated=true;}
+        if(!f.hasOwnProperty('neighborHall')){f.neighborHall=false;migrated=true;}
         if(!f.hasOwnProperty('autoTranslation')){f.autoTranslation='';}
         if(!f.hasOwnProperty('autoSource')){f.autoSource='';}
         if(!f.hasOwnProperty('emotionalText')){f.emotionalText='';}
@@ -2967,6 +2968,7 @@ function addFiles() {
                 hallEffect: false,
                 emiEffect: false,
                 neighborEffect: false,
+                neighborHall: false,
                 version: 1
             };
 
@@ -4497,7 +4499,7 @@ return `
                         ${file.trimStartMs !== 0 || file.trimEndMs !== 0 ? '<span class="edit-status-icon" title="Audio gekürzt">✂️</span>' : ''}
                         ${file.volumeMatched ? '<span class="edit-status-icon" title="Lautstärke angepasst">🔊</span>' : ''}
                         ${file.radioEffect ? '<span class="edit-status-icon" title="Funkgerät-Effekt">📻</span>' : ''}
-                        ${file.hallEffect ? '<span class="edit-status-icon" title="Hall-Effekt">🏛️</span>' : ''}
+                        ${(file.hallEffect || file.neighborHall) ? '<span class="edit-status-icon" title="Hall-Effekt">🏛️</span>' : ''}
                         ${file.emiEffect ? '<span class="edit-status-icon" title="EM-Störgeräusch">⚡</span>' : ''}
                         ${file.neighborEffect ? '<span class="edit-status-icon" title="Nebenraum-Effekt">🚪</span>' : ''}
                     </div>
@@ -8461,6 +8463,7 @@ async function exportSegmentsToProject() {
             file.hallEffect = false;
             file.emiEffect = false;
             file.neighborEffect = false;
+            file.neighborHall = false;
         }
     }
     updateStatus('Segmente importiert');
@@ -8936,6 +8939,7 @@ function addFileFromFolderBrowser(filename, folder, fullPath) {
         hallEffect: false,
         emiEffect: false,
         neighborEffect: false,
+        neighborHall: false,
         version: 1
     };
 
@@ -11573,6 +11577,7 @@ async function handleDeUpload(input) {
         file.hallEffect = false;
         file.emiEffect = false;
         file.neighborEffect = false;
+        file.neighborHall = false;
         file.tempoFactor = 1.0; // Tempo-Faktor auf Standard zurücksetzen
         if (currentEditFile === file) {
             tempoFactor = 1.0;
@@ -12302,6 +12307,8 @@ async function openDeEdit(fileId) {
     isEmiEffect = false;
     neighborEffectBuffer = null;
     isNeighborEffect = false;
+    // Hall-Einstellung des Nebenraum-Effekts aus der Datei laden
+    neighborHall = !!file.neighborHall;
     const enBuffer = await loadAudioBuffer(enSrc);
     editEnBuffer = enBuffer;
     // Länge der beiden Dateien in Sekunden bestimmen
@@ -13736,7 +13743,7 @@ async function resetDeEdit() {
     if (currentEditFile.tempoFactor && currentEditFile.tempoFactor !== 1) steps.push('Tempo');
     if (currentEditFile.volumeMatched) steps.push('Lautstärke angleichen');
     if (currentEditFile.radioEffect) steps.push('Funkgerät-Effekt');
-    if (currentEditFile.hallEffect) steps.push('Hall-Effekt');
+    if (currentEditFile.hallEffect || currentEditFile.neighborHall) steps.push('Hall-Effekt');
     if (currentEditFile.emiEffect) steps.push('EM-Störgeräusch');
     if (currentEditFile.neighborEffect) steps.push('Nebenraum-Effekt');
     const msg = steps.length ? `Folgende Schritte gehen verloren:\n• ${steps.join('\n• ')}` : 'Keine ungespeicherten Schritte.';
@@ -13788,6 +13795,7 @@ async function resetDeEdit() {
         currentEditFile.hallEffect = false;
         currentEditFile.emiEffect = false;
         currentEditFile.neighborEffect = false;
+        currentEditFile.neighborHall = false;
         volumeMatchedBuffer = null;
         isVolumeMatched = false;
         radioEffectBuffer = null;
@@ -13798,6 +13806,7 @@ async function resetDeEdit() {
         isEmiEffect = false;
         neighborEffectBuffer = null;
         isNeighborEffect = false;
+        neighborHall = false;
         updateEffectButtons();
         // Projekt als geändert markieren, damit Rücksetzungen gespeichert werden
         isDirty = true;
@@ -13969,6 +13978,8 @@ async function applyDeEdit() {
         currentEditFile.hallEffect = isHallEffect;
         currentEditFile.emiEffect = isEmiEffect;
         currentEditFile.neighborEffect = isNeighborEffect;
+        // Optionaler Hall im Nebenraum-Effekt speichern
+        currentEditFile.neighborHall = neighborHall;
         currentEditFile.tempoFactor = tempoFactor;
         // Nach dem Speichern Start- und Endwerte zurücksetzen
         editStartTrim = 0;
@@ -14888,6 +14899,7 @@ function addFileToProject(filename, folder, originalResult) {
         hallEffect: false,
         emiEffect: false,
         neighborEffect: false,
+        neighborHall: false,
         version: 1
     };
 
@@ -15777,6 +15789,7 @@ function quickAddLevel(chapterName) {
                 f.hallEffect = false;
                 f.emiEffect = false;
                 f.neighborEffect = false;
+                f.neighborHall = false;
                 // Tempo bei neuem Upload auf Standard zurücksetzen
                 f.tempoFactor = 1.0;
                 // Fertig-Status ergibt sich nun automatisch
@@ -15963,6 +15976,7 @@ function quickAddLevel(chapterName) {
             file.hallEffect = false;
             file.emiEffect = false;
             file.neighborEffect = false;
+            file.neighborHall = false;
             renderFileTable();
             saveCurrentProject();
         }


### PR DESCRIPTION
## Zusammenfassung
- speichert die Hall-Option des Nebenraum-Effekts dauerhaft pro Datei
- lädt die Hall-Einstellung beim Bearbeiten und kennzeichnet sie im Status-Icon
- aktualisiert Tests, README und Changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b53838d528832791958dda42c9f4b4