### PR TITLE
Zeige EN-Originalzeit im Tempo-Bereich

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.261
+* DE-Audio-Editor zeigt neben der DE-Zeit nun auch die EN-Originalzeit an.
 ## 🛠️ Patch in 1.40.260
 * Markierte Zeilen erscheinen nun mit leichtem Abstand unter dem Tabellenkopf und bleiben bei jeder Bildschirmauflösung komplett sichtbar.
 ## 🛠️ Patch in 1.40.259

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Manuelles Zuschneiden:** Start- und Endzeit lassen sich per Millisekundenfeld oder durch Ziehen eines Bereichs direkt im DE-Wellenbild setzen; die Felder synchronisieren sich bidirektional.
 * **Automatische Pausenkürzung und Time‑Stretching:** Längere Pausen erkennt das Tool auf Wunsch selbst. Mit einem Regler lässt sich das Tempo von 1,00–3,00 anpassen oder automatisch auf die EN-Länge setzen. Kleine ➖/➕‑Knöpfe erlauben präzise Schritte. Ein Button „🎯 Anpassen & Anwenden“ kombiniert beide Schritte und eine farbige Anzeige warnt bei Abweichungen.
 * **Zwei Tempo‑Auto‑Knöpfe:** Der erste setzt den Wert auf 1,00, markiert ihn gelb und erhöht das Tempo automatisch, bis „DE (bearbeiten)“ orange leuchtet (Abweichung unter 10 %). Der zweite stellt den gespeicherten Wert wieder her und färbt die Anzeige grau.
+* **EN-Originalzeit neben DE-Zeit:** Rechts neben der DE-Dauer zeigt der Editor nun die englische Originalzeit an.
 * **Sanftere Pausenkürzung:** Beim Entfernen langer Pausen bleiben jetzt 2 ms an jedem Übergang stehen, damit die Schnitte nicht zu hart wirken.
 * **Längenvergleich visualisiert:** Unter der DE-Wellenform zeigt ein Tooltip die neue Dauer. Abweichungen über 5 % werden orange oder rot hervorgehoben.
 * **Effektparameter speicherbar:** Trimmen, Pausenkürzung und Tempo werden im Projekt gesichert und lassen sich über "🔄 Zurücksetzen" rückgängig machen.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -724,7 +724,7 @@
                         <div class="tempo-auto">
                             <button id="tempoAutoBtn" class="copy-btn" title="Tempo auf Minimum setzen und anpassen">Auto</button>
                             <button id="tempoAutoResetBtn" class="copy-btn" title="Tempo auf gespeicherten Wert zurücksetzen">Auto</button>
-                            <span id="tempoInfo"></span>
+                            <span id="tempoInfo"></span><span id="tempoEnInfo"></span>
                         </div>
                     </div>
                     <!-- Button Anpassen & Anwenden -->

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -13518,9 +13518,12 @@ function updateLengthInfo() {
     const diff = deMs - enMs;
     const perc = Math.abs(diff) / enMs * 100;
     const info = document.getElementById('tempoInfo');
+    const enInfo = document.getElementById('tempoEnInfo');
     const lbl = document.getElementById('waveLabelEdited');
     if (!info || !lbl) return;
     info.textContent = `${(deMs/1000).toFixed(2)}s`;
+    // EN-Originalzeit ebenfalls anzeigen
+    if (enInfo) enInfo.textContent = `EN: ${(enMs/1000).toFixed(2)}s`;
     lbl.title = (diff > 0 ? '+' : '') + Math.round(diff) + 'ms';
     lbl.style.color = perc > 10 ? 'red' : (perc > 5 ? '#ff8800' : '');
 }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1998,6 +1998,12 @@ th:nth-child(8) {
     color: #ccc;
 }
 
+/* EN-Originalzeit rechts neben der DE-Zeit in normaler Schriftfarbe */
+#deEditDialog #tempoEnInfo {
+    color: #ccc;
+    font-weight: normal;
+}
+
 #deEditDialog #autoAdjustBtn {
     grid-column: 1 / -1;
     width: 100%;


### PR DESCRIPTION
## Zusammenfassung
- DE-Editor zeigt neben der DE-Dauer jetzt auch die EN-Originalzeit

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b54c181bb0832795b2925575860de0