### PR TITLE
Verbesserte Tempo-Auto-Knöpfe im DE-Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.262
+* Zweiter Tempo-Auto-Knopf erhöht das Tempo automatisch, bis die DE-Zeit etwa der EN-Zeit entspricht; der erste setzt nur auf das Minimum.
 ## 🛠️ Patch in 1.40.261
 * DE-Audio-Editor zeigt neben der DE-Zeit nun auch die EN-Originalzeit an.
 ## 🛠️ Patch in 1.40.260

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Texte unter den Wellenformen:** Unter der EN-Welle erscheint der englische Text und unter der DE-Welle der emotionale deutsche Text.
 * **Manuelles Zuschneiden:** Start- und Endzeit lassen sich per Millisekundenfeld oder durch Ziehen eines Bereichs direkt im DE-Wellenbild setzen; die Felder synchronisieren sich bidirektional.
 * **Automatische Pausenkürzung und Time‑Stretching:** Längere Pausen erkennt das Tool auf Wunsch selbst. Mit einem Regler lässt sich das Tempo von 1,00–3,00 anpassen oder automatisch auf die EN-Länge setzen. Kleine ➖/➕‑Knöpfe erlauben präzise Schritte. Ein Button „🎯 Anpassen & Anwenden“ kombiniert beide Schritte und eine farbige Anzeige warnt bei Abweichungen.
-* **Zwei Tempo‑Auto‑Knöpfe:** Der erste setzt den Wert auf 1,00, markiert ihn gelb und erhöht das Tempo automatisch, bis „DE (bearbeiten)“ orange leuchtet (Abweichung unter 10 %). Der zweite stellt den gespeicherten Wert wieder her und färbt die Anzeige grau.
+* **Zwei Tempo‑Auto‑Knöpfe:** Der erste setzt den Wert auf 1,00 und markiert ihn gelb. Der zweite erhöht das Tempo automatisch, bis die DE-Länge ungefähr der EN-Zeit entspricht.
 * **EN-Originalzeit neben DE-Zeit:** Rechts neben der DE-Dauer zeigt der Editor nun die englische Originalzeit an.
 * **Sanftere Pausenkürzung:** Beim Entfernen langer Pausen bleiben jetzt 2 ms an jedem Übergang stehen, damit die Schnitte nicht zu hart wirken.
 * **Längenvergleich visualisiert:** Unter der DE-Wellenform zeigt ein Tooltip die neue Dauer. Abweichungen über 5 % werden orange oder rot hervorgehoben.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -722,8 +722,8 @@
                             <span id="tempoDisplay" class="tempo-value">1.00</span>
                         </div>
                         <div class="tempo-auto">
-                            <button id="tempoAutoBtn" class="copy-btn" title="Tempo auf Minimum setzen und anpassen">Auto</button>
-                            <button id="tempoAutoResetBtn" class="copy-btn" title="Tempo auf gespeicherten Wert zurücksetzen">Auto</button>
+                            <button id="tempoAutoBtn" class="copy-btn" title="Tempo auf Minimum setzen">Auto</button>
+                            <button id="tempoAutoMatchBtn" class="copy-btn" title="Tempo automatisch auf EN-Zeit anpassen">Auto</button>
                             <span id="tempoInfo"></span><span id="tempoEnInfo"></span>
                         </div>
                     </div>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -12398,23 +12398,30 @@ async function openDeEdit(fileId) {
         };
         const tempoAuto = document.getElementById('tempoAutoBtn');
         if (tempoAuto) tempoAuto.onclick = () => {
-            // Startwert auf Minimum setzen und Eingabe hervorheben
+            // Setzt den Tempofaktor auf das definierte Minimum
             tempoFactor = parseFloat(tempoRange.min);
             tempoRange.value = tempoFactor.toFixed(2);
             tempoDisp.textContent = tempoFactor.toFixed(2);
             tempoDisp.classList.add('tempo-auto');
             updateLengthInfo();
-
-            // Schrittweite und Ziel festlegen
+        };
+        // Zweiter Auto-Knopf gleicht die DE-Zeit an die EN-Zeit an
+        const tempoAutoMatch = document.getElementById('tempoAutoMatchBtn');
+        if (tempoAutoMatch) tempoAutoMatch.onclick = () => {
+            // Schrittweite und Zielwerte bestimmen
             const step = parseFloat(tempoRange.step) || 0.01;
             const max  = parseFloat(tempoRange.max);
             const enMs = editEnBuffer.length / editEnBuffer.sampleRate * 1000;
 
-            // Erhöht den Faktor, bis die Differenz < 10 % aber > 5 % beträgt
+            tempoDisp.classList.add('tempo-auto');
+
+            // Erhöht das Tempo so lange, bis DE ungefähr EN entspricht
             const raise = () => {
                 const deMs = calcFinalLength();
-                const perc = Math.abs(deMs - enMs) / enMs * 100;
-                if ((perc <= 10 && perc > 5) || tempoFactor >= max) return;
+                if (deMs <= enMs || tempoFactor >= max) {
+                    updateLengthInfo();
+                    return;
+                }
                 tempoFactor = Math.min(tempoFactor + step, max);
                 tempoRange.value = tempoFactor.toFixed(2);
                 tempoDisp.textContent = tempoFactor.toFixed(2);
@@ -12422,15 +12429,6 @@ async function openDeEdit(fileId) {
                 requestAnimationFrame(raise);
             };
             requestAnimationFrame(raise);
-        };
-        // Zweiter Auto-Knopf stellt den gespeicherten Wert wieder her
-        const tempoAutoReset = document.getElementById('tempoAutoResetBtn');
-        if (tempoAutoReset) tempoAutoReset.onclick = () => {
-            tempoFactor = loadedTempoFactor;
-            tempoRange.value = tempoFactor.toFixed(2);
-            tempoDisp.textContent = tempoFactor.toFixed(2);
-            tempoDisp.classList.remove('tempo-auto');
-            updateLengthInfo();
         };
     }
     const autoChk = document.getElementById('autoIgnoreChk');


### PR DESCRIPTION
## Zusammenfassung
- Erster Tempo-Auto-Knopf setzt den Wert nun klar auf das Minimum.
- Zweiter Tempo-Auto-Knopf passt die DE-Länge automatisch an die EN-Zeit an.
- Dokumentation und Changelog entsprechend aktualisiert.

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54fa9ec008327b2f93218cc28c9bb