### PR TITLE
Bessere Anfasser für Trimm-Regler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.263
+* DE- und EN-Wellenform besitzen nun oben und unten kleine Anfasser, sodass Start- und Endpunkte leichter verschoben werden können.
 ## 🛠️ Patch in 1.40.262
 * Zweiter Tempo-Auto-Knopf erhöht das Tempo automatisch, bis die DE-Zeit etwa der EN-Zeit entspricht; der erste setzt nur auf das Minimum.
 ## 🛠️ Patch in 1.40.261

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.260-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.263-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -287,6 +287,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **EN-Abschnitt einfügen:** Ziehe mit der Maus im EN-Original einen Bereich auf. Über den Pfeil zwischen den beiden Wellen lässt sich der markierte Ausschnitt am Anfang, am Ende oder an der aktuellen Cursor-Position in das DE-Audio kopieren. Doppelklick oder Esc entfernt die Markierung, beim Schließen des Bearbeitungsdialogs werden Start, Ende und Einfügeposition zurückgesetzt.
 * **Start/Ende verschieben:** Die Markierungsgriffe im EN-Original lassen sich mit der Maus bewegen; die Felder „Start EN" und „Ende EN" passen sich automatisch an.
 * **Live-Markierung beim Ziehen:** Änderungen an Start oder Ende aktualisieren die Wellenformen nun sofort während des Verschiebens.
+* **Bessere Anfasser:** Kleine Griffe oben und unten erleichtern das Verschieben von Start- und Endpunkten in EN- und DE-Wellenform.
 * **Texte unter den Wellenformen:** Unter der EN-Welle erscheint der englische Text und unter der DE-Welle der emotionale deutsche Text.
 * **Manuelles Zuschneiden:** Start- und Endzeit lassen sich per Millisekundenfeld oder durch Ziehen eines Bereichs direkt im DE-Wellenbild setzen; die Felder synchronisieren sich bidirektional.
 * **Automatische Pausenkürzung und Time‑Stretching:** Längere Pausen erkennt das Tool auf Wunsch selbst. Mit einem Regler lässt sich das Tempo von 1,00–3,00 anpassen oder automatisch auf die EN-Länge setzen. Kleine ➖/➕‑Knöpfe erlauben präzise Schritte. Ein Button „🎯 Anpassen & Anwenden“ kombiniert beide Schritte und eine farbige Anzeige warnt bei Abweichungen.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -11929,6 +11929,16 @@ function drawWaveform(canvas, buffer, opts = {}) {
         ctx.moveTo(ex, 0);
         ctx.lineTo(ex, height);
         ctx.stroke();
+        // Griffe oben und unten zeichnen, damit Start- und Endpunkte leichter zu greifen sind
+        const handleW = 10; // Breite der Anfasser
+        const handleH = 6;  // Höhe der Anfasser
+        ctx.fillStyle = '#0f0';
+        // Startgriff oben und unten
+        ctx.fillRect(sx - handleW / 2, 0, handleW, handleH);
+        ctx.fillRect(sx - handleW / 2, height - handleH, handleW, handleH);
+        // Endgriff oben und unten
+        ctx.fillRect(ex - handleW / 2, 0, handleW, handleH);
+        ctx.fillRect(ex - handleW / 2, height - handleH, handleW, handleH);
     }
     if (opts.start !== undefined && opts.end !== undefined) {
         ctx.strokeStyle = '#0f0';
@@ -12496,7 +12506,8 @@ async function openDeEdit(fileId) {
         const dur = editEnBuffer.length / editEnBuffer.sampleRate * 1000;
         const startX = Math.min(enSelectStart, enSelectEnd) / dur * origCanvas.width;
         const endX   = Math.max(enSelectStart, enSelectEnd) / dur * origCanvas.width;
-        const grip = 5;
+        // Größerer Griffbereich für einfacheres Anfassen der EN-Marker
+        const grip = 8;
         if (enSelectStart !== enSelectEnd && Math.abs(x - startX) <= grip) {
             enMarkerDragging = 'start';
             return;
@@ -12779,8 +12790,9 @@ async function openDeEdit(fileId) {
             if (Math.abs(x - sx) < 5) { silenceDragging = { index: i, side: 'start' }; return; }
             if (Math.abs(x - ex) < 5) { silenceDragging = { index: i, side: 'end' }; return; }
         }
-        if (Math.abs(x - startX) < 7) { editDragging = 'start'; return; }
-        if (Math.abs(x - endX) < 7) { editDragging = 'end'; return; }
+        // Breiterer Bereich zum Anfassen der Trimmgrenzen
+        if (Math.abs(x - startX) < 10) { editDragging = 'start'; return; }
+        if (Math.abs(x - endX)   < 10) { editDragging = 'end';   return; }
 
         dePrevStartTrim = editStartTrim;
         dePrevEndTrim = editEndTrim;


### PR DESCRIPTION
## Zusammenfassung
- Trimm-Markierungen in EN- und DE-Wellenform haben jetzt oben und unten kleine Griffe für leichteres Verschieben
- Größere Klickzonen zum Anfassen der Start- und Endmarken
- Dokumentation aktualisiert

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b55dfd2800832786561f6b1641995e