### PR TITLE
Reste-Modus für GPT-Bewertungen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.266
+* Pro Projekt zuschaltbarer Reste-Modus, der GPT mitteilt, dass Zeilen unabhängig und nicht chronologisch sind.
 ## 🛠️ Patch in 1.40.265
 * Notiz-Hinweis zeigt jetzt auch die Anzahl gleicher Einträge im gesamten Kapitel.
 ## 🛠️ Patch in 1.40.264

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.263-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.266-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -93,6 +93,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Projekte in allen Leveln:** Nur geöffnete Level zeigen ihre Projekte in einer zweizeiligen Liste aus `<li>`‑Elementen. Gibt es keine Einträge, erscheint „– Keine Projekte vorhanden –“.
 * **Hinweis-Symbol bei Übersetzungen:** Unter der Lupe erscheint ein kleines 📝, wenn der DE-Text ein Wort aus dem Wörterbuch enthält.
 * **GPT-Bewertungen:** Zeilen lassen sich per ChatGPT bewerten. Bei großen Szenen erscheint ein Fortschrittsdialog, Fehler zeigt ein rotes Banner mit "Erneut versuchen". Beim Überfahren oder Anklicken des Scores erscheint nur der Kommentar. Den vorgeschlagenen Text übernimmst du jetzt durch Klick auf die farbige Box über dem DE-Feld
+* **Reste-Modus:** Ein pro Projekt speicherbarer Haken informiert GPT, dass die Zeilen nicht chronologisch sind und unabhängig bewertet oder mit Emotionen versehen werden müssen.
 * **Debug-Ausgabe für GPT:** Ist der Debug-Modus aktiv, erscheinen gesendete Daten und Antworten der GPT-API in der Konsole
 * **GPT-Konsole:** Beim Klick auf "Bewerten (GPT)" öffnet sich ein Fenster mit einem Log aller gesendeten Prompts und Antworten
 * **Prompt-Vorschau:** Vor dem eigentlichen Versand zeigt ein Dialog den kompletten Prompt an. Erst nach Klick auf "Senden" wird die Anfrage gestellt und die Antwort im selben Fenster angezeigt

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -149,6 +149,7 @@
                     <button id="copyAssistant2Button" class="btn btn-secondary">Kopierhilfe 2</button>
                     <button id="copyAllEmosButton" class="btn btn-secondary">Emotionen kopieren</button>
                     <button id="subtitleSearchAllButton" class="btn btn-secondary" title="Sucht fehlende deutsche Texte im gesamten Projekt">UT-Suche alles</button>
+                    <label class="copy-option"><input type="checkbox" id="restTranslationCheckbox"> Reste-Modus</label>
                     <label class="copy-option"><input type="checkbox" id="copyIncludeTime" checked> Zeit voranstellen</label>
                     <label class="copy-option"><input type="checkbox" id="copyAddDashes"> --- anhängen</label>
                 </div>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -809,6 +809,20 @@ if (typeof document !== "undefined" && typeof document.getElementById === "funct
     if (subtitleAllBtn) {
         subtitleAllBtn.addEventListener("click", runGlobalSubtitleSearch);
     }
+    const restBox = document.getElementById("restTranslationCheckbox");
+    if (restBox) {
+        restBox.addEventListener("change", e => {
+            if (currentProject) {
+                currentProject.restTranslation = e.target.checked;
+                saveProjects();
+                if (window.setRestMode) {
+                    window.setRestMode(e.target.checked);
+                } else {
+                    window.restTranslationFlag = e.target.checked;
+                }
+            }
+        });
+    }
 }
 
 // Öffnet die gespeicherten GPT-Tabs ohne neue Bewertung
@@ -2133,6 +2147,7 @@ async function loadProjects() {
                 if (!p.hasOwnProperty('segmentAudio')) { p.segmentAudio = null; migrated = true; }
                 if (!p.hasOwnProperty('segmentAudioPath')) { p.segmentAudioPath = null; migrated = true; }
                 if (!p.hasOwnProperty('segmentIgnored')) { p.segmentIgnored = []; migrated = true; }
+                if (!p.hasOwnProperty('restTranslation')) { p.restTranslation = false; migrated = true; }
             });
 
             // 🔥 WICHTIG: Level-Farben auf Projekte anwenden (FIX)
@@ -2164,6 +2179,7 @@ async function loadProjects() {
                 levelPart: 1,
                 files: [],
                 color: '#ff6b1a',
+                restTranslation: false,
                 gptTests: [],
                 gptTabIndex: 0,
                 segmentAssignments: {},
@@ -2187,6 +2203,7 @@ async function loadProjects() {
                 levelPart: 1,
                 files: [],
                 color: '#ff6b1a',
+                restTranslation: false,
                 gptTests: [],
                 gptTabIndex: 0,
                 segmentAssignments: {},
@@ -2210,6 +2227,7 @@ async function loadProjects() {
                 levelPart: 2,
                 files: [],
                 color: '#ff6b1a',
+                restTranslation: false,
                 gptTests: [],
                 gptTabIndex: 0,
                 segmentAssignments: {},
@@ -2618,7 +2636,8 @@ function addProject() {
         levelPart: 1,
         files: [],
         icon: '🗂️',
-        color: '#54428E'
+        color: '#54428E',
+        restTranslation: false
     };
 
     // Dialog öffnen; erst nach Bestätigung wird es gespeichert
@@ -2647,7 +2666,8 @@ function quickAddProject(levelName) {
         levelPart: 1,
         files: [],
         icon: '🗂️',
-        color: getLevelColor(levelName)
+        color: getLevelColor(levelName),
+        restTranslation: false
     };
 
     projects.push(prj);
@@ -2684,6 +2704,19 @@ function selectProject(id){
 
     currentProject = projects.find(p => p.id === id);
     if(!currentProject) return;
+
+    // Fehlendes Flag für Reste-Modus ergänzen
+    if (!currentProject.hasOwnProperty('restTranslation')) {
+        currentProject.restTranslation = false;
+    }
+
+    const restBox = document.getElementById('restTranslationCheckbox');
+    if (restBox) restBox.checked = !!currentProject.restTranslation;
+    if (window.setRestMode) {
+        window.setRestMode(!!currentProject.restTranslation);
+    } else {
+        window.restTranslationFlag = !!currentProject.restTranslation;
+    }
 
     // Vorherigen Lock freigeben und neuen anfordern
     if (currentProjectLock) {


### PR DESCRIPTION
## Zusammenfassung
- Reste-Modus pro Projekt: Checkbox aktiviert speziellen GPT-Hinweis für nicht chronologische Zeilen
- gptService erweitert System- und Emotion-Prompts um Hinweis bei aktivem Reste-Modus
- README und CHANGELOG mit neuer Funktion und Version 1.40.266 aktualisiert

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6230ff6648327b98ba255aeb1449d