### PR TITLE
Behandle verwaiste Vorschläge über Quarantäne

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 # Changelog
+## 🛠️ Patch in 1.40.272
+* Fehlende Vorschlagsdatei verschiebt den Eintrag automatisch in die Quarantäne und informiert per Toast.
+
+## 🛠️ Patch in 1.40.271
+* Protokoll-Dialog zeigt die Quarantäne verwaister Vorschläge mit Optionen zum Wiederherstellen, Entfernen und Exportieren.
+
+## 🛠️ Patch in 1.40.270
+* Hilfsfunktion `repairProjectIntegrity` ist global verfügbar und per Test abgesichert.
+## 🛠️ Patch in 1.40.269
+* Löschen einer Datei verschiebt verknüpfte Vorschläge automatisch in die Quarantäne.
+## 🛠️ Patch in 1.40.268
+* Projektwechsel repariert verwaiste Vorschläge automatisch und informiert per Toast.
+## 🛠️ Patch in 1.40.267
+* Automatische Quarantäne verschiebt verwaiste Vorschläge beim Laden in einen gesicherten Bereich.
+
 ## 🛠️ Patch in 1.40.266
 * Pro Projekt zuschaltbarer Reste-Modus, der GPT mitteilt, dass Zeilen unabhängig und nicht chronologisch sind.
 ## 🛠️ Patch in 1.40.265

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.266-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.271-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -115,8 +115,10 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Score in Prozent:** Die Bewertung wird in der Tabelle mit Prozentzeichen dargestellt
 * **Aktive Score-Events:** Nach jedem Rendern bindet `attachScoreHandlers` Tooltip und Klick
 * **Bugfix:** Verwaiste Vorschlagsfelder lösen beim Laden kein Fehlerereignis mehr aus
-* **Validierte Vorschlagsfelder:** Fehlt die zugehörige Datei, wird der Eintrag entfernt und eine Meldung weist darauf hin
-* **Debug-Bericht bei fehlender Vorschlagsdatei:** Nach dem Entfernen öffnet sich ein Fenster zum Speichern einzelner Berichte
+* **Automatische Quarantäne:** Fehlt die zugehörige Datei, wandert der Vorschlag ohne Rückfrage in die Quarantäne
+* **Info-Toast statt Debug-Bericht:** Ein kurzer Hinweis informiert über die Verschiebung; der Debug-Dialog entfällt
+* **Quarantäne bei Dateilöschungen:** Wird eine Datei entfernt, wandern verknüpfte Vorschläge automatisch in die Quarantäne
+* **Quarantäne-Ansicht:** Im Protokoll zeigt ein eigener Dialog alle verwaisten Vorschläge mit Aktionen zum Wiederherstellen, Entfernen oder Exportieren
 * **Kommentar-Anzeige auf ganzer Fläche:** Der Tooltip reagiert jetzt auf das gesamte Score-Feld
 * **Direkter Daten-Refresh:** Nach jeder Bewertung wird die Tabelle mit den aktualisierten Dateien neu gerendert
 * **Farbiger GPT-Vorschlag:** Der empfohlene DE-Text erscheint nun oberhalb des Textfelds und nutzt die Score-Farbe
@@ -1079,6 +1081,9 @@ verwendet werden, um optionale Downloads zu überspringen.
 * **`ipcContracts.ts`** – definiert Typen für die IPC-Kommunikation zwischen Preload und Hauptprozess.
 * **`syncProjectData(projects, filePathDatabase, textDatabase)`** – gleicht Projekte mit der Datenbank ab, korrigiert Dateiendungen und überträgt Texte.
 * **`repairFileExtensions(projects, filePathDatabase, textDatabase)`** – aktualisiert veraltete Dateiendungen in Projekten und verschiebt vorhandene Texte.
+* **`repairOrphans(project, saveFn)`** – verschiebt Vorschläge ohne passende Datei in die Quarantäne und gibt die Anzahl verschobener Einträge zurück.
+* **`moveSuggestionsToQuarantine(project, items, reason)`** – schiebt gezielt übergebene Vorschläge mit Grundangabe in die Quarantäne.
+* **`repairProjectIntegrity(adapter, projectId, ui)`** – prüft ein geladenes Projekt auf verwaiste Vorschläge, verschiebt sie in die Quarantäne und informiert per Toast.
   Die Funktionen stehen im Browser direkt unter `window` zur Verfügung und können ohne Import genutzt werden.
   * **`safeCopy(text)`** – kopiert Text in die Zwischenablage und greift bei Fehlern auf Electron zurück.
   * **`saveProjectToFile(data)`** – speichert das übergebene Objekt per File System Access API als JSON auf der Festplatte.

--- a/tests/moveSuggestionsToQuarantine.test.js
+++ b/tests/moveSuggestionsToQuarantine.test.js
@@ -1,0 +1,18 @@
+const { moveSuggestionsToQuarantine } = require('../utils/repairOrphans');
+
+// Dieser Test prüft die Kaskadenbehandlung beim Löschen einer Datei.
+test('verschobene Vorschläge landen in der Quarantäne', () => {
+  const projekt = {
+    suggestions: [
+      { id: 'a', fileId: '1', createdAt: '', payload: {} },
+      { id: 'b', fileId: '2', createdAt: '', payload: {} }
+    ],
+    meta: {}
+  };
+  const zuLoeschende = [projekt.suggestions[0]];
+  moveSuggestionsToQuarantine(projekt, zuLoeschende, 'missing-file');
+  expect(projekt.suggestions.length).toBe(1);
+  expect(projekt.meta.quarantine.orphanSuggestions).toHaveLength(1);
+  expect(projekt.meta.quarantine.orphanSuggestions[0].suggestion.id).toBe('a');
+  expect(projekt.meta.quarantine.orphanSuggestions[0].reason).toBe('missing-file');
+});

--- a/tests/repairOrphans.test.js
+++ b/tests/repairOrphans.test.js
@@ -1,0 +1,26 @@
+const { repairOrphans } = require('../utils/repairOrphans');
+
+// Dieser Test stellt sicher, dass verwaiste Vorschläge erkannt und korrekt verschoben werden.
+test('verwaiste Vorschläge landen in der Quarantäne', () => {
+  const project = {
+    files: [
+      { id: '1' },
+      { id: '2' }
+    ],
+    suggestions: [
+      { id: 'a', fileId: '1', createdAt: '2024-01-01T00:00:00Z', payload: {} },
+      { id: 'b', fileId: '999', createdAt: '2024-01-01T00:00:00Z', payload: {} },
+      { id: 'c', fileId: '2', createdAt: '2024-01-01T00:00:00Z', payload: {} }
+    ],
+    meta: {}
+  };
+
+  let saved = false;
+  const { movedCount } = repairOrphans(project, () => { saved = true; });
+
+  expect(movedCount).toBe(1);
+  expect(saved).toBe(true);
+  expect(project.suggestions.length).toBe(2);
+  expect(project.meta.quarantine.orphanSuggestions.length).toBe(1);
+  expect(project.meta.quarantine.orphanSuggestions[0].suggestion.id).toBe('b');
+});

--- a/tests/repairProjectIntegrity.test.js
+++ b/tests/repairProjectIntegrity.test.js
@@ -1,0 +1,35 @@
+global.window = {};
+require('../web/src/projectSwitch.js');
+
+const { repairProjectIntegrity } = window;
+
+test('repairProjectIntegrity verschiebt verwaiste Vorschläge und speichert', async () => {
+  // Dummy Projekt mit einem verwaisten Vorschlag
+  global.projects = [{
+    id: '1',
+    files: [],
+    suggestions: [{ id: 's1', fileId: 'x', createdAt: '', payload: {} }],
+    meta: { quarantine: { orphanSuggestions: [] } }
+  }];
+
+  // Fake-Speicheradapter
+  const adapter = { setItem: jest.fn() };
+
+  // Stub für repairOrphans, der einen Eintrag in die Quarantäne verschiebt
+  window.repairOrphans = (project, saveFn) => {
+    const orphan = project.suggestions[0];
+    project.suggestions = [];
+    project.meta.quarantine.orphanSuggestions.push({ suggestion: orphan, reason: 'missing-file', detectedAt: 'now' });
+    saveFn(project);
+    return { movedCount: 1 };
+  };
+
+  let infoText = '';
+  const ui = { info: msg => { infoText = msg; } };
+
+  await repairProjectIntegrity(adapter, '1', ui);
+
+  expect(adapter.setItem).toHaveBeenCalled();
+  expect(infoText).toMatch(/1 verwaiste Vorschläge/);
+  expect(projects[0].meta.quarantine.orphanSuggestions).toHaveLength(1);
+});

--- a/utils/repairOrphans.js
+++ b/utils/repairOrphans.js
@@ -1,0 +1,95 @@
+'use strict';
+
+// Diese Datei enthält Hilfsfunktionen, um verwaiste Vorschläge zu erkennen
+// und in eine Quarantäne innerhalb des Projekts zu verschieben.
+
+/**
+ * Verschiebt alle Vorschläge ohne gültige Datei-ID in die Projektquarantäne.
+ * @param {Object} project   Das Projektobjekt mit Dateien und Vorschlägen.
+ * @param {Function} [saveProject]  Optionale Speicherfunktion für sofortiges Persistieren.
+ * @returns {{project: Object, movedCount: number}}  Rückgabe des Projekts und Anzahl verschobener Vorschläge.
+ */
+function repairOrphans(project, saveProject = () => {}) {
+  // Gültige Datei-IDs sammeln
+  const validFileIds = new Set((project.files || []).map(f => f.id));
+  const all = project.suggestions || [];
+  const valid = [];
+  const orphans = [];
+  const now = new Date().toISOString();
+
+  for (const s of all) {
+    if (validFileIds.has(s.fileId)) {
+      // Vorschlag referenziert eine existierende Datei
+      valid.push(s);
+    } else {
+      // Datei fehlt → Vorschlag wandert in die Quarantäne
+      orphans.push({
+        suggestion: s,
+        reason: 'missing-file',
+        missingFileId: s.fileId,
+        detectedAt: now
+      });
+    }
+  }
+
+  if (!project.meta) project.meta = {};
+  if (!project.meta.quarantine) project.meta.quarantine = { orphanSuggestions: [] };
+
+  project.meta.quarantine.orphanSuggestions.push(...orphans);
+  project.meta.quarantine.lastAutoRepairAt = now;
+
+  project.suggestions = valid;
+
+  if (orphans.length > 0) {
+    // Bei Änderungen sofortiges Speichern anstoßen
+    try {
+      saveProject(project);
+    } catch (e) {
+      // Speichern darf die Reparatur nicht blockieren
+      console.warn('Speichern nach Reparatur fehlgeschlagen:', e);
+    }
+  }
+
+  return { project, movedCount: orphans.length };
+}
+
+/**
+ * Verschiebt angegebene Vorschläge mit Grundangabe in die Quarantäne.
+ * @param {Object} project    Projektobjekt.
+ * @param {Array} items       Liste der zu verschiebenden Vorschläge.
+ * @param {string} reason     Grund, z.B. 'missing-file' oder 'file-renamed'.
+ */
+function moveSuggestionsToQuarantine(project, items, reason) {
+  if (!project.meta) project.meta = {};
+  if (!project.meta.quarantine) {
+    project.meta.quarantine = { orphanSuggestions: [] };
+  }
+
+  const q = project.meta.quarantine;
+  const now = new Date().toISOString();
+
+  for (const s of items) {
+    q.orphanSuggestions.push({
+      suggestion: s,
+      reason,
+      missingFileId: s.fileId,
+      detectedAt: now
+    });
+  }
+
+  const ids = new Set(items.map(i => i.id));
+  project.suggestions = (project.suggestions || []).filter(s => !ids.has(s.id));
+}
+
+// Die Funktionen sowohl für Node (module.exports) als auch für den Browser bereitstellen
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    repairOrphans,
+    moveSuggestionsToQuarantine
+  };
+} else {
+  // Im Browser global verfügbar machen
+  window.repairOrphans = repairOrphans;
+  window.moveSuggestionsToQuarantine = moveSuggestionsToQuarantine;
+}
+

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -73,6 +73,7 @@
                     <button id="devToolsButton" class="btn btn-secondary" onclick="toggleDevTools()">🐞 DevTools</button>
                     <button class="btn btn-secondary" onclick="exportDebugReport()">📋 Debug-Bericht</button>
                     <button class="btn btn-secondary" onclick="openDubbingLog()">📝 Protokoll</button>
+                    <button class="btn btn-secondary" onclick="openQuarantine()">🦠 Quarantäne</button>
                     <button class="btn btn-secondary" onclick="startMigration()">Migration starten</button>
                     <button class="btn btn-secondary" onclick="loadMigration()">Migration laden</button>
                     <button class="btn btn-secondary" onclick="migrateData()">Daten migrieren</button>
@@ -1032,6 +1033,8 @@
     <script src="src/colorUtils.js"></script>
     <script src="src/fileStorage.js"></script>
     <script src="src/migrationUI.js"></script>
+    <script src="../utils/repairOrphans.js"></script>
+    <script src="src/quarantineUI.js"></script>
     <script src="src/projectSwitch.js"></script>
     <script src="src/main.js"></script>
     <script type="module" src="renderer.js"></script>

--- a/web/src/projectSwitch.js
+++ b/web/src/projectSwitch.js
@@ -1,6 +1,8 @@
 // Sorgt für sicheren Projekt- und Speicherwechsel, um Race-Conditions zu vermeiden
 // Kommentare sind auf Deutsch gehalten
 
+// Quarantäne-Helfer werden über repairOrphans.js global geladen
+
 // Warteschlange, damit Wechsel nacheinander abgearbeitet werden
 let switchQueue = Promise.resolve();
 // Laufende Sitzung zur Vermeidung veralteter Rückläufer
@@ -17,6 +19,32 @@ const ui = {
   // Fortschrittsanzeige optional
   progress: (d, t) => {}
 };
+
+/**
+ * Repariert verwaiste Vorschläge und speichert das Projekt sofort.
+ * @param {Object} adapter   Aktueller Speicheradapter zum Persistieren.
+ * @param {string|number} projectId ID des zu prüfenden Projekts.
+ * @param {Object} ui        Hilfsobjekt für Hinweise.
+ */
+async function repairProjectIntegrity(adapter, projectId, ui) {
+  const index = (projects || []).findIndex(p => p.id === projectId);
+  if (index === -1) return; // Kein Projekt vorhanden
+
+  const project = projects[index];
+  const { movedCount } = window.repairOrphans(project, p => {
+    projects[index] = p;
+    adapter.setItem('hla_projects', JSON.stringify(projects));
+  });
+
+  if (movedCount > 0) {
+    const msg = `${movedCount} verwaiste Vorschläge in Quarantäne verschoben – Debug › Quarantäne.`;
+    if (typeof window.showToast === 'function') {
+      window.showToast(msg);
+    } else if (ui && typeof ui.info === 'function') {
+      ui.info(msg);
+    }
+  }
+}
 
 /**
  * Blendet einen globalen Ladebalken ein oder aus,
@@ -115,3 +143,4 @@ async function switchStorageSafe(mode) {
 // Globale Bereitstellung für die Oberfläche
 window.switchProjectSafe = switchProjectSafe;
 window.switchStorageSafe = switchStorageSafe;
+window.repairProjectIntegrity = repairProjectIntegrity;

--- a/web/src/quarantineUI.js
+++ b/web/src/quarantineUI.js
@@ -1,0 +1,115 @@
+// UI-Komponenten zur Anzeige und Verwaltung verwaister Vorschläge
+
+(function(){
+  // Öffnet die Quarantäne-Übersicht als Dialog
+  window.openQuarantine = function() {
+    if (!window.currentProject) {
+      return;
+    }
+    const ov = window.showModal(`<h3>🦠 Quarantäne</h3>
+      <div class="dialog-buttons">
+        <button class="btn btn-secondary" onclick="exportQuarantine()">Alle exportieren</button>
+        <button class="btn btn-secondary" onclick="confirmClearQuarantine()">Alle endgültig entfernen</button>
+        <button class="btn btn-secondary" onclick="this.closest('.dialog-overlay').remove()">Schließen</button>
+      </div>
+      <table class="quarantine-table">
+        <thead><tr><th>ID</th><th>Fehlende Datei</th><th>Erkannt</th><th>Vorschau</th><th>Aktion</th></tr></thead>
+        <tbody id="quarantineTableBody"></tbody>
+      </table>`);
+    renderQuarantineTable();
+  };
+
+  // Rendert die Tabelle neu anhand der aktuellen Projektdaten
+  window.renderQuarantineTable = function() {
+    const body = document.getElementById('quarantineTableBody');
+    if (!body || !window.currentProject) return;
+    const list = (window.currentProject.meta?.quarantine?.orphanSuggestions) || [];
+    body.innerHTML = list.map((o,i) => {
+      const preview = typeof o.suggestion.payload === 'string' ? o.suggestion.payload : JSON.stringify(o.suggestion.payload);
+      return `<tr>
+        <td>${escapeHtml(o.suggestion.id)}</td>
+        <td>${escapeHtml(o.missingFileId || '')}</td>
+        <td>${escapeHtml(new Date(o.detectedAt).toLocaleString())}</td>
+        <td>${escapeHtml(preview.substring(0,30))}</td>
+        <td>
+          <button class="btn btn-secondary" onclick="restoreOrphan(${i})">Wiederherstellen</button>
+          <button class="btn btn-secondary" onclick="removeOrphan(${i})">Entfernen</button>
+        </td>
+      </tr>`;
+    }).join('');
+  };
+
+  // Stellt einen einzelnen Eintrag wieder her
+  window.restoreOrphan = function(index) {
+    const q = window.currentProject?.meta?.quarantine?.orphanSuggestions;
+    if (!q) return;
+    const orphan = q[index];
+    const options = (window.currentProject.files||[]).map(f => `<option value="${f.id}">${escapeHtml(f.filename||f.id)}</option>`).join('');
+    const ov = window.showModal(`<h3>Vorschlag wiederherstellen</h3>
+      <label>Datei wählen:</label>
+      <select id="restoreTarget">${options}</select>
+      <div class="dialog-buttons">
+        <button class="btn btn-secondary" onclick="this.closest('.dialog-overlay').remove()">Abbrechen</button>
+        <button class="btn btn-success" onclick="confirmRestore(${index})">Wiederherstellen</button>
+      </div>`);
+    const sel = ov.querySelector('#restoreTarget');
+    if (sel && orphan.missingFileId) sel.value = orphan.missingFileId;
+  };
+
+  // Bestätigt das Wiederherstellen
+  window.confirmRestore = function(index) {
+    const q = window.currentProject?.meta?.quarantine?.orphanSuggestions;
+    if (!q) return;
+    const ov = document.getElementById('restoreTarget')?.closest('.dialog-overlay');
+    const fileId = document.getElementById('restoreTarget')?.value;
+    if (!fileId) return;
+    const orphan = q[index];
+    orphan.suggestion.fileId = fileId;
+    window.currentProject.suggestions = window.currentProject.suggestions || [];
+    window.currentProject.suggestions.push(orphan.suggestion);
+    q.splice(index,1);
+    if (typeof saveCurrentProject === 'function') saveCurrentProject();
+    window.showToast('Vorschlag wiederhergestellt');
+    if (ov) ov.remove();
+    renderQuarantineTable();
+  };
+
+  // Entfernt einen Eintrag dauerhaft
+  window.removeOrphan = function(index) {
+    const q = window.currentProject?.meta?.quarantine?.orphanSuggestions;
+    if (!q) return;
+    q.splice(index,1);
+    if (typeof saveCurrentProject === 'function') saveCurrentProject();
+    renderQuarantineTable();
+  };
+
+  // Exportiert alle Waisen als JSON-Datei
+  window.exportQuarantine = function() {
+    const data = JSON.stringify(window.currentProject?.meta?.quarantine?.orphanSuggestions || [], null, 2);
+    const blob = new Blob([data], {type:'application/json'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'quarantine.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  // Fragt nach Bestätigung und leert die Quarantäne
+  window.confirmClearQuarantine = function() {
+    const ov = window.showModal(`<p>Alle Einträge endgültig entfernen?</p>
+      <div class="dialog-buttons">
+        <button class="btn btn-secondary" onclick="this.closest('.dialog-overlay').remove()">Abbrechen</button>
+        <button class="btn btn-danger" onclick="clearQuarantine()">Entfernen</button>
+      </div>`);
+  };
+
+  window.clearQuarantine = function() {
+    const q = window.currentProject?.meta?.quarantine?.orphanSuggestions;
+    if (!q) return;
+    q.length = 0;
+    if (typeof saveCurrentProject === 'function') saveCurrentProject();
+    renderQuarantineTable();
+    document.querySelector('.dialog-overlay')?.remove();
+  };
+})();


### PR DESCRIPTION
## Zusammenfassung
- Fehlende Vorschlagsdateien landen jetzt automatisch in der Quarantäne und erzeugen nur einen Info-Toast
- README und Changelog dokumentieren die neue automatische Quarantäne und den Verzicht auf den Debug-Dialog

## Testanweisungen
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b743e3669c832784e018ccfccefcdd