### PR TITLE
fix: DevTools toggle and extended debug info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 🛠️ Patch in 1.40.268
+* DevTools- und Debug-Bericht-Knöpfe reagieren wieder auf Klicks.
+## 🛠️ Patch in 1.40.267
+* DevTools lassen sich wieder per Knopf und F12 öffnen.
+* Debug-Fenster zeigt nun Prozesslaufzeit und RAM-Verbrauch an.
 ## 🛠️ Patch in 1.40.266
 * Pro Projekt zuschaltbarer Reste-Modus, der GPT mitteilt, dass Zeilen unabhängig und nicht chronologisch sind.
 ## 🛠️ Patch in 1.40.265

--- a/README.md
+++ b/README.md
@@ -971,13 +971,14 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **🔍 Debug‑Spalte:** Zeigt aufgelöste Pfade und Status
 * **📊 Datenquellen‑Analyse:** Console‑Logs für Entwickler
 * **🎯 Access‑Status:** Echtzeit‑Anzeige der Dateiberechtigungen
-* **🔧 Debug-Konsole:** Diese Konsole ist standardmäßig verborgen und erscheint nur bei Entwickleraktionen (z. B. Dev-Button). In der Desktop-Version öffnen sich die DevTools automatisch in einem separaten Fenster oder per `Ctrl+Shift+I`.
+* **🔧 Debug-Konsole:** Diese Konsole ist standardmäßig verborgen und erscheint nur bei Entwickleraktionen (z. B. Dev-Button). In der Desktop-Version öffnen sich die DevTools automatisch in einem separaten Fenster oder per `F12` bzw. `Ctrl+Shift+I`. Der zugehörige Knopf reagiert wieder wie erwartet und blendet zusätzlich die Debug-Infos ein.
 * **💡 Neues Debug-Fenster:** Gruppiert System- und Pfadinformationen übersichtlich und bietet eine Kopierfunktion.
 * **📦 Modul-Status:** Neue Spalte im Debug-Fenster zeigt, ob alle Module korrekt geladen wurden und aus welcher Quelle sie stammen.
 * **🖥️ Erweiterte Systemdaten:** Das Debug-Fenster zeigt jetzt Betriebssystem, CPU-Modell und freien Arbeitsspeicher an.
+* **🧠 Laufzeit-Infos:** Zusätzlich werden Prozesslaufzeit und RAM-Verbrauch angezeigt.
 * **📸 VideoFrame-Details:** Zusätzlich werden der Pfad zum Frame-Ordner und die Versionen der Video-Abhängigkeiten angezeigt.
 * **📝 Ausführliche API-Logs:** Alle Anfragen und Antworten werden im Dubbing-Log protokolliert
-* **📋 Debug-Bericht exportieren:** Ein Knopf öffnet ein Fenster mit einzelnen Debug-Berichten samt Dateigröße in MB; jede Datei kann separat exportiert werden. Scheitert das Speichern, wird der Inhalt automatisch in die Zwischenablage kopiert.
+* **📋 Debug-Bericht exportieren:** Ein Knopf öffnet ein Fenster mit einzelnen Debug-Berichten samt Dateigröße in MB; jede Datei kann separat exportiert werden. Scheitert das Speichern, wird der Inhalt automatisch in die Zwischenablage kopiert. Der Button funktioniert nach einer internen Umstellung wieder zuverlässig.
 * **🛠 Debug-Logging aktivieren:** Setze `localStorage.setItem('hla_debug_mode','true')` im Browser, um zusätzliche Konsolen-Ausgaben zu erhalten
 * **🐞 Ausführliche Fehlerprotokolle:** Im Debug-Modus erscheinen unbehandelte Promise-Ablehnungen sowie Datei-, Zeilen- und Stack-Informationen
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -251,6 +251,15 @@ function createWindow() {
       win.webContents.openDevTools();
     }
   });
+  // F12 ebenfalls als DevTools-Schalter anbieten
+  globalShortcut.register('F12', () => {
+    if (win.webContents.isDevToolsOpened()) {
+      win.webContents.closeDevTools();
+    } else {
+      // Immer im separaten Fenster öffnen
+      win.webContents.openDevTools({ mode: 'detach' });
+    }
+  });
 
   return win;
 }
@@ -637,6 +646,7 @@ app.whenReady().then(() => {
       nodeVersion: process.version,
       electronVersion: process.versions.electron,
       chromeVersion: process.versions.chrome,
+      v8Version: process.versions.v8,
       processPlatform: process.platform,
       cpuArch: process.arch,
       osType: os.type(),
@@ -645,6 +655,8 @@ app.whenReady().then(() => {
       cpuCount: os.cpus().length,
       totalMemMB: Math.round(os.totalmem() / 1024 / 1024),
       freeMemMB: Math.round(os.freemem() / 1024 / 1024),
+      memoryRssMB: Math.round(process.memoryUsage().rss / 1024 / 1024),
+      uptimeSec: Math.round(process.uptime()),
       processType: 'browser',
       contextIsolation: true,
       sandbox: mainWindow ? mainWindow.webContents.getLastWebPreferences().sandbox : false,
@@ -905,10 +917,12 @@ app.whenReady().then(() => {
   // DevTools per IPC ein-/ausblenden
   ipcMain.on('toggle-devtools', (event) => {
     const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win) return; // Falls das Fenster bereits geschlossen wurde
     if (win.webContents.isDevToolsOpened()) {
       win.webContents.closeDevTools();
     } else {
-      win.webContents.openDevTools();
+      // Beim Öffnen immer ein separates Fenster verwenden
+      win.webContents.openDevTools({ mode: 'detach' });
     }
   });
 

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -70,8 +70,8 @@
                             <div class="settings-item" onclick="repairProjectFolders()">🔧 Ordner reparieren</div>
                         </div>
                     </div>
-                    <button id="devToolsButton" class="btn btn-secondary" onclick="toggleDevTools()">🐞 DevTools</button>
-                    <button class="btn btn-secondary" onclick="exportDebugReport()">📋 Debug-Bericht</button>
+                    <button id="devToolsButton" class="btn btn-secondary">🐞 DevTools</button>
+                    <button id="debugReportButton" class="btn btn-secondary">📋 Debug-Bericht</button>
                     <button class="btn btn-secondary" onclick="openDubbingLog()">📝 Protokoll</button>
                     <button class="btn btn-secondary" onclick="startMigration()">Migration starten</button>
                     <button class="btn btn-secondary" onclick="loadMigration()">Migration laden</button>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -10873,6 +10873,19 @@ async function scanAudioDuplicates() {
         }
         // Funktion global verfügbar machen, damit der Button im HTML immer wirkt
         window.toggleDevTools = toggleDevTools;
+        // Klick-Events für DevTools- und Debug-Bericht-Knopf registrieren
+        // (nur ausführen, wenn ein echtes DOM verfügbar ist)
+        if (typeof document !== 'undefined' && document.getElementById) {
+            document.getElementById('devToolsButton')?.addEventListener('click', toggleDevTools);
+            document.getElementById('debugReportButton')?.addEventListener('click', exportDebugReport);
+        }
+        // F12-Shortcut auch im Renderer abfangen
+        window.addEventListener('keydown', e => {
+            if (e.key === 'F12') {
+                e.preventDefault();
+                toggleDevTools();
+            }
+        });
 
         // Startet Half-Life: Alyx über die Desktop-Version
         async function startHla() {
@@ -11097,12 +11110,14 @@ async function scanAudioDuplicates() {
                 'App-Version': info.appVersion ?? info['App-Version'] ?? APP_VERSION,
                 'Node-Version': info.nodeVersion ?? info['Node-Version'] ?? (nodeDefined ? process.version : 'n/a'),
                 'Electron-Version': info.electronVersion ?? info['Electron-Version'] ?? (nodeDefined && process.versions ? process.versions.electron || 'n/a' : 'n/a'),
-                'Chrome-Version': info.chromeVersion ?? info['Chrome-Version'] ?? (nodeDefined && process.versions ? process.versions.chrome || 'n/a' : 'n/a')
+                'Chrome-Version': info.chromeVersion ?? info['Chrome-Version'] ?? (nodeDefined && process.versions ? process.versions.chrome || 'n/a' : 'n/a'),
+                'V8-Version': info.v8Version ?? info['V8-Version'] ?? (nodeDefined && process.versions ? process.versions.v8 || 'n/a' : 'n/a')
             };
             delete info.appVersion; delete info['App-Version'];
             delete info.nodeVersion; delete info['Node-Version'];
             delete info.electronVersion; delete info['Electron-Version'];
             delete info.chromeVersion; delete info['Chrome-Version'];
+            delete info.v8Version; delete info['V8-Version'];
 
             // Hilfsfunktion zur Anzeige
             function formatVal(v) {
@@ -11130,6 +11145,13 @@ async function scanAudioDuplicates() {
                         'Kontext-Isolation': info.contextIsolation,
                         'Sandbox aktiviert': info.sandbox,
                         'Adminrechte': info.admin
+                    }
+                },
+                {
+                    title: 'Laufzeit & Ressourcen',
+                    data: {
+                        'Prozess-Uptime (s)': info.uptimeSec,
+                        'RAM-Verbrauch (MB)': info.memoryRssMB
                     }
                 },
                 {


### PR DESCRIPTION
## Summary
- DevTools und Debug-Bericht lassen sich wieder per Klick bedienen
- Dokumentation um reparierte Knöpfe ergänzt

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7520f680c832790295f942313a449