### PR TITLE
Debug-Bericht: Fallback auf Zwischenablage ohne Dateisystem-API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.269
+* Debug-Bericht-Knopf öffnet Fenster nun auch ohne Dateisystem-API und kopiert die Daten direkt in die Zwischenablage.
 ## 🛠️ Patch in 1.40.268
 * DevTools- und Debug-Bericht-Knöpfe reagieren wieder auf Klicks.
 ## 🛠️ Patch in 1.40.267

--- a/README.md
+++ b/README.md
@@ -978,7 +978,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **🧠 Laufzeit-Infos:** Zusätzlich werden Prozesslaufzeit und RAM-Verbrauch angezeigt.
 * **📸 VideoFrame-Details:** Zusätzlich werden der Pfad zum Frame-Ordner und die Versionen der Video-Abhängigkeiten angezeigt.
 * **📝 Ausführliche API-Logs:** Alle Anfragen und Antworten werden im Dubbing-Log protokolliert
-* **📋 Debug-Bericht exportieren:** Ein Knopf öffnet ein Fenster mit einzelnen Debug-Berichten samt Dateigröße in MB; jede Datei kann separat exportiert werden. Scheitert das Speichern, wird der Inhalt automatisch in die Zwischenablage kopiert. Der Button funktioniert nach einer internen Umstellung wieder zuverlässig.
+* **📋 Debug-Bericht exportieren:** Ein Knopf öffnet ein Fenster mit einzelnen Debug-Berichten samt Dateigröße in MB; jede Datei kann separat exportiert werden. Fehlt die Dateisystem-API oder scheitert das Speichern, wandern die Inhalte automatisch in die Zwischenablage. Der Button funktioniert nach einer internen Umstellung wieder zuverlässig.
 * **🛠 Debug-Logging aktivieren:** Setze `localStorage.setItem('hla_debug_mode','true')` im Browser, um zusätzliche Konsolen-Ausgaben zu erhalten
 * **🐞 Ausführliche Fehlerprotokolle:** Im Debug-Modus erscheinen unbehandelte Promise-Ablehnungen sowie Datei-, Zeilen- und Stack-Informationen
 


### PR DESCRIPTION
## Zusammenfassung
- Debug-Bericht-Fenster öffnet sich jetzt auch ohne `showSaveFilePicker`
- Fallback kopiert Inhalte direkt in die Zwischenablage, wenn kein Dateidialog möglich ist
- Dokumentation und Changelog entsprechend ergänzt

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7585bc0b08327baceba975c1b14d4