### PR TITLE
Fehlerbehebung: Debug-Fenster nutzt showModal direkt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.270
+* Debug-Fenster ruft `showModal` direkt auf und vermeidet damit den Fehler "ui.showModal ist keine Funktion".
 ## 🛠️ Patch in 1.40.269
 * Debug-Bericht-Knopf öffnet Fenster nun auch ohne Dateisystem-API und kopiert die Daten direkt in die Zwischenablage.
 ## 🛠️ Patch in 1.40.268

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.266-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.270-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -976,6 +976,7 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * **📦 Modul-Status:** Neue Spalte im Debug-Fenster zeigt, ob alle Module korrekt geladen wurden und aus welcher Quelle sie stammen.
 * **🖥️ Erweiterte Systemdaten:** Das Debug-Fenster zeigt jetzt Betriebssystem, CPU-Modell und freien Arbeitsspeicher an.
 * **🧠 Laufzeit-Infos:** Zusätzlich werden Prozesslaufzeit und RAM-Verbrauch angezeigt.
+* **🐞 Fehlerbehebung:** Das Debug-Fenster nutzt eine interne `showModal`-Funktion und vermeidet so den Fehler „ui.showModal ist keine Funktion“.
 * **📸 VideoFrame-Details:** Zusätzlich werden der Pfad zum Frame-Ordner und die Versionen der Video-Abhängigkeiten angezeigt.
 * **📝 Ausführliche API-Logs:** Alle Anfragen und Antworten werden im Dubbing-Log protokolliert
 * **📋 Debug-Bericht exportieren:** Ein Knopf öffnet ein Fenster mit einzelnen Debug-Berichten samt Dateigröße in MB; jede Datei kann separat exportiert werden. Fehlt die Dateisystem-API oder scheitert das Speichern, wandern die Inhalte automatisch in die Zwischenablage. Der Button funktioniert nach einer internen Umstellung wieder zuverlässig.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -11221,7 +11221,8 @@ async function scanAudioDuplicates() {
                 html += '</ul>';
             });
             html += '<button id="copyDebugInfoBtn" class="btn btn-secondary">Kopieren</button>';
-            ui.showModal(html);
+            // Dialog direkt anzeigen, ohne auf window.ui zuzugreifen
+            showModal(html);
 
             // Kopier-Knopf zum schnellen Übernehmen in die Zwischenablage
             const copyBtn = document.getElementById('copyDebugInfoBtn');
@@ -11234,8 +11235,8 @@ async function scanAudioDuplicates() {
                         .map(([k, v]) => `${k}: ${v}`)
                         .join('\n');
                     safeCopy(text)
-                        .then(ok => { if (ok) ui.notify('Debug-Daten kopiert'); })
-                        .catch(err => ui.notify('Kopieren fehlgeschlagen: ' + err, 'error'));
+                        .then(ok => { if (ok) showToast('Debug-Daten kopiert'); })
+                        .catch(err => showToast('Kopieren fehlgeschlagen: ' + err, 'error'));
                 });
             }
         }
@@ -11287,7 +11288,8 @@ async function scanAudioDuplicates() {
                 html += `<li><span><strong>${escapeHtml(r.name)}</strong></span><span><code>${r.sizeMB} MB</code> <button class="btn btn-secondary" data-report="${r.key}">Exportieren</button></span></li>`;
             });
             html += '</ul>';
-            ui.showModal(html);
+            // Dialog direkt anzeigen, ohne auf window.ui zuzugreifen
+            showModal(html);
 
             // Export-Buttons verbinden
             document.querySelectorAll('[data-report]').forEach(btn => {


### PR DESCRIPTION
## Zusammenfassung
- Debug-Fenster nutzt nun die interne `showModal`-Funktion anstelle von `ui.showModal`
- Kopierfunktion verwendet `showToast` für Rückmeldungen
- Dokumentation und Changelog um Fehlerbehebung ergänzt

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b75fa83e9c8327879b8fe628db708f