### PR TITLE
feat: Debug-Bericht pro Level exportieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.271
+* Level-Kontextmenü bietet Export eines Debug-Berichts nur für dieses Level.
 ## 🛠️ Patch in 1.40.270
 * Debug-Fenster ruft `showModal` direkt auf und vermeidet damit den Fehler "ui.showModal ist keine Funktion".
 ## 🛠️ Patch in 1.40.269

--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Context‑Menu** (Rechtsklick): Audio, Kopieren, Einfügen, Ordner öffnen, Löschen
 * **Projekt-Analyse:** Rechtsklick auf ein Projekt prüft Dateien und bietet eine automatische Reparatur an
 * **Schnell hinzufügen:** Rechtsklick auf Level → Schnellprojekt, Rechtsklick auf Kapitel → Schnell‑Level
+* **Debug-Bericht pro Level:** Rechtsklick auf ein Level exportiert relevante Debug-Daten
 * **Drag & Drop:** Projekte und Dateien sortieren
 * **Klick auf Zeilennummer:** Position über Dialog anpassen
 * **Mausrad:** Markiert beim Scrollen automatisch die Zeile in der Bildschirmmitte, ohne sie neu auszurichten

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -332,6 +332,9 @@
         <div class="context-menu-item" onclick="levelMenuAction('quickProject')">
             <span>➕</span> Schnellprojekt
         </div>
+        <div class="context-menu-item" onclick="levelMenuAction('exportDebug')">
+            <span>🐞</span> Debug-Bericht exportieren
+        </div>
         <div class="context-menu-item danger" onclick="levelMenuAction('delete')">
             <span>🗑️</span> Level löschen
         </div>


### PR DESCRIPTION
## Zusammenfassung
- Level-Kontextmenü um Export eines Debug-Berichts erweitert
- Level-spezifischer Debug-Export filtert Projekte, Dateien und Texte
- Dokumentation und Changelog aktualisiert

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b877b4c95883279d196668483fb825