### PR TITLE
Projektwechsel bereinigt GPT-Zustand zuverlässig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.275
+* Projektkarten nutzen `switchProjectSafe` und `selectProject` löscht vorsorglich den GPT-Zustand.
 ## 🛠️ Patch in 1.40.274
 * Abbrechbare GPT-Bewertungen: Projekt- und Speicherwechsel verwerfen offene GPT-Jobs und protokollieren den Abbruch.
 ## 🛠️ Patch in 1.40.273

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.270-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.275-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -52,6 +52,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Sicherer Projektwechsel:** `pauseAutosave`, `flushPendingWrites` und weitere Helfer räumen Speicher und Listener auf
 * **Sauberer GPT-Reset beim Projektwechsel:** Beendet laufende Bewertungen, entfernt Vorschlagsboxen und verhindert dadurch Fehlermeldungen
 * **Abbrechbare GPT-Bewertungen:** Beim Projekt- oder Speicherwechsel werden laufende und wartende Jobs verworfen und im Log vermerkt
+* **Sicherer Projektwechsel für GPT:** Projektkarten rufen jetzt `switchProjectSafe` auf und `selectProject` leert den GPT-Zustand vorsorglich
 * **Level-Kapitel** zur besseren Gruppierung und ein-/ausklappbaren Bereichen
 * **Kapitel bearbeiten:** Name, Farbe und Löschung im Projekt möglich
 * **Kapitelwahl beim Erstellen:** Neue oder bestehende Kapitel direkt auswählen
@@ -1102,6 +1103,6 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`journalWiederherstellen(basis)`** – prüft ein vorhandenes `journal.json` und schließt abgebrochene Schreibvorgänge atomar ab.
   * **`garbageCollect(manifeste, basis, dryRun)`** – entfernt nicht referenzierte Dateien aus `.hla_store/objects` und meldet wahlweise nur den potentiellen Speichergewinn.
   * **`validateProjectManifest(data)`** – prüft `project.json` gegen ein Zod-Schema und stellt sicher, dass `schemaVersion` und Name vorhanden sind.
-  * **`switchProjectSafe(id)`** – wechselt Projekte atomar, bricht laufende Vorgänge ab und repariert Verweise.
+  * **`switchProjectSafe(id)`** – wechselt Projekte atomar, bricht laufende Vorgänge ab, leert GPT-Zustände und repariert Verweise.
   * **`switchStorageSafe(mode)`** – wechselt das Speichersystem mit bereinigten Caches und gestopptem Autosave.
   * **Beim Start** wird jetzt `navigator.storage.persist()` ausgeführt; zusammen mit `navigator.storage.estimate()` zeigt die Oberfläche an, wie viel lokaler Speicher verfügbar bleibt.

--- a/tests/projectSwitchClearGptState.test.js
+++ b/tests/projectSwitchClearGptState.test.js
@@ -1,0 +1,36 @@
+/** @jest-environment jsdom */
+// Testet, ob beim Projektwechsel der GPT-Zustand geleert wird
+const fs = require('fs');
+const path = require('path');
+
+test('switchProjectSafe setzt gptEvaluationResults auf null', async () => {
+    // Overlay für den Ladebalken bereitstellen
+    document.body.innerHTML = '<div id="projectLoadingOverlay" class="hidden"></div>';
+
+    // GPT-Zustand und Reset-Funktion simulieren
+    gptEvaluationResults = { score: 99 };
+    function clearGptState() { gptEvaluationResults = null; }
+    window.clearGptState = jest.fn(clearGptState);
+    const spy = window.clearGptState;
+
+    // Benötigte Helferfunktionen für switchProjectSafe mocken
+    window.pauseAutosave = jest.fn(async () => {});
+    window.flushPendingWrites = jest.fn(async () => {});
+    window.detachAllEventListeners = jest.fn();
+    window.clearInMemoryCachesHard = jest.fn();
+    window.closeProjectData = jest.fn(async () => {});
+    window.loadProjectData = jest.fn(async () => {});
+    window.getStorageAdapter = jest.fn(() => ({}));
+    window.repairProjectIntegrity = jest.fn(async () => {});
+    window.resumeAutosave = jest.fn(async () => {});
+    window.cancelGptRequests = jest.fn();
+
+    // switchProjectSafe aus projectSwitch.js laden
+    const psCode = fs.readFileSync(path.join(__dirname, '../web/src/projectSwitch.js'), 'utf8');
+    eval(psCode);
+
+    await window.switchProjectSafe('p1');
+
+    expect(spy).toHaveBeenCalled();
+    expect(gptEvaluationResults).toBeNull();
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2507,7 +2507,7 @@ function renderProjects() {
                 `• GPT: ${stats.scoreMin}  • Dateien: ${stats.totalFiles}`;
 
             card.onclick = () => {
-                selectProject(p.id);
+                switchProjectSafe(p.id); // Sicherer Wechsel löst clearGptState aus
             };
             card.addEventListener('contextmenu', e => showProjectMenu(e, p.id));
             card.addEventListener('dragstart', handleProjectDragStart);
@@ -2721,6 +2721,7 @@ function quickAddProject(levelName) {
 
 // =========================== SELECT PROJECT START ===========================
 function selectProject(id){
+    clearGptState(); // GPT-Zustand vorsorglich zurücksetzen
     stopProjectPlayback();
     saveCurrentProject();
     storeSegmentState();


### PR DESCRIPTION
## Zusammenfassung
- Projektkarten nutzen nun `switchProjectSafe`, wodurch beim Wechsel automatisch `clearGptState` ausgeführt wird.
- `selectProject` ruft vorsorglich `clearGptState()` auf, um veraltete GPT-Bewertungen zu vermeiden.
- Neuer Jest-Test bestätigt, dass `gptEvaluationResults` nach dem Projektwechsel auf `null` gesetzt wird.

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b885aa08c88327822819e24c95cbb4