### PR TITLE
Vergleich von GPT-IDs als Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.276
+* GPT-Auswertung vergleicht Datei-IDs nun als Strings, sodass Ganzzahl- und Gleitkomma-IDs korrekt zugeordnet werden.
 ## 🛠️ Patch in 1.40.275
 * Projektkarten nutzen `switchProjectSafe` und `selectProject` löscht vorsorglich den GPT-Zustand.
 ## 🛠️ Patch in 1.40.274

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.275-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.276-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -113,6 +113,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Charaktername im GPT-Prompt:** Das Feld `character` nutzt nun den Ordnernamen
 * **Bugfix:** Scores werden korrekt eingefügt, auch wenn ID und Score als Zeichenketten geliefert werden
 * **Robustere Zuordnung:** GPT-Ergebnisse finden jetzt auch dann die richtige Zeile, wenn die ID leicht abweicht
+* **String-Vergleich der IDs:** Datei-IDs werden als Strings abgeglichen, sodass auch Gleitkomma-IDs eindeutig zugeordnet werden
 * **Eigenständige Score-Komponente:** Tooltip und Klick sind in `web/src/scoreColumn.js` gekapselt
 * **Einheitliche Score-Klassen:** Die Funktion `scoreClass` vergibt überall die gleichen Farbstufen
 * **Feineres Bewertungsschema:** Ab 95 % wird der Score grün, zwischen 85 % und 94 % gelb

--- a/tests/updateGptSummaryIds.test.js
+++ b/tests/updateGptSummaryIds.test.js
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// Testet die Zuordnung von Ganzzahl- und Gleitkomma-IDs in updateGptSummary
+const { updateGptSummary, __setFiles } = require('../web/src/main.js');
+
+describe('updateGptSummary', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '<table id="gptSummaryTable"><tbody></tbody></table>';
+        const files = [
+            { id: 1, name: 'Datei1', folder: 'Ordner1' },
+            { id: 2.5, name: 'Datei2', folder: 'Ordner2' }
+        ];
+        __setFiles(files);
+    });
+
+    test('ordnet Ganzzahl- und Gleitkomma-IDs korrekt zu', () => {
+        const results = [
+            { id: '1', score: 80, suggestion: '', comment: '' },
+            { id: '2.5', score: 90, suggestion: '', comment: '' }
+        ];
+        updateGptSummary(results);
+        const rows = document.querySelectorAll('#gptSummaryTable tbody tr');
+        expect(rows).toHaveLength(2);
+        expect(rows[0].children[1].textContent).toBe('Datei1');
+        expect(rows[1].children[1].textContent).toBe('Datei2');
+    });
+});

--- a/web/src/actions/projectEvaluate.js
+++ b/web/src/actions/projectEvaluate.js
@@ -24,13 +24,8 @@ if (typeof window !== 'undefined' && window.attachScoreHandlers) {
 function applyEvaluationResults(results, files) {
     if (!Array.isArray(results)) return;
     for (const r of results) {
-        // ID in Zahl umwandeln, bei Präzisionsproblemen auch String vergleichen
-        const idNum = Number(r.id);
-        let f = files.find(fl => fl.id === idNum);
-        if (!f) {
-            const idStr = String(r.id);
-            f = files.find(fl => String(fl.id) === idStr);
-        }
+        // IDs als Strings vergleichen, damit auch Gleitkommawerte gefunden werden
+        const f = files.find(fl => String(fl.id) === String(r.id));
         if (f) {
             // Score in Zahl umwandeln, sonst 0
             const sc = Number(r.score);
@@ -70,7 +65,7 @@ async function scoreVisibleLines(opts) {
         return row && row.offsetParent !== null;
     });
     const lines = visible.map(({ file }) => ({
-        id: file.id,
+        id: String(file.id), // ID als String serialisieren
         // Charakter entspricht dem Ordnernamen
         character: file.character || file.folder || '',
         en: file.enText || '',

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1011,9 +1011,8 @@ function updateGptSummary(results) {
     // Tabelle leeren
     body.innerHTML = '';
     for (const r of results) {
-        const idNum = Number(r.id);
-        let f = files.find(fl => fl.id === idNum);
-        if (!f) f = files.find(fl => String(fl.id) === String(r.id));
+        // IDs als Strings vergleichen, um Ganzzahlen und Gleitkommazahlen sicher zu finden
+        const f = files.find(fl => String(fl.id) === String(r.id));
         const name = f?.name || '';
         const folder = f?.folder || '';
         const score = r.score ?? '';
@@ -16494,6 +16493,7 @@ if (typeof module !== "undefined" && module.exports) {
         __setGetAudioDuration: fn => { getAudioDurationFn = fn; },
         autoApplySuggestion,
         insertGptResults,
+        updateGptSummary,
         insertEnglishSegment,
         // Export der Segmentierungsfunktionen fuer Tests und externe Nutzung
         openSegmentDialog,


### PR DESCRIPTION
## Zusammenfassung
- Vergleicht Datei-IDs in GPT-Auswertungen ausschließlich als Strings und exportiert `updateGptSummary` für Tests.
- Serialisiert Datei-IDs bereits beim Senden an den GPT-Service als Zeichenkette.
- Ergänzt einen Test, der die korrekte Zuordnung von Ganzzahl- und Gleitkomma-IDs bestätigt.

## Testdurchführung
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b888b924fc832791e28ca49719cd11