### PR TITLE
Projektwechsel: Dateien vor GPT-Reset sichern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.277
+* Projektwechsel sichert Dateien, bevor der GPT-Zustand bereinigt wird.
 ## 🛠️ Patch in 1.40.276
 * GPT-Auswertung vergleicht Datei-IDs nun als Strings, sodass Ganzzahl- und Gleitkomma-IDs korrekt zugeordnet werden.
 ## 🛠️ Patch in 1.40.275

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.276-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.277-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -53,6 +53,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Sauberer GPT-Reset beim Projektwechsel:** Beendet laufende Bewertungen, entfernt Vorschlagsboxen und verhindert dadurch Fehlermeldungen
 * **Abbrechbare GPT-Bewertungen:** Beim Projekt- oder Speicherwechsel werden laufende und wartende Jobs verworfen und im Log vermerkt
 * **Sicherer Projektwechsel für GPT:** Projektkarten rufen jetzt `switchProjectSafe` auf und `selectProject` leert den GPT-Zustand vorsorglich
+* **Gesicherte Dateien vor GPT-Reset:** Beim Projektwechsel werden Dateien zuerst gespeichert und erst danach der GPT-Zustand bereinigt
 * **Level-Kapitel** zur besseren Gruppierung und ein-/ausklappbaren Bereichen
 * **Kapitel bearbeiten:** Name, Farbe und Löschung im Projekt möglich
 * **Kapitelwahl beim Erstellen:** Neue oder bestehende Kapitel direkt auswählen

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2720,10 +2720,10 @@ function quickAddProject(levelName) {
 
 // =========================== SELECT PROJECT START ===========================
 function selectProject(id){
-    clearGptState(); // GPT-Zustand vorsorglich zurücksetzen
     stopProjectPlayback();
-    saveCurrentProject();
-    storeSegmentState();
+    saveCurrentProject(); // Aktuelles Projekt sichern, bevor der GPT-Zustand gelöscht wird
+    storeSegmentState(); // Segmentzustand vor dem Reset speichern
+    clearGptState(); // GPT-Zustand anschließend bereinigen
 
     currentProject = projects.find(p => p.id === id);
     if(!currentProject) return;


### PR DESCRIPTION
## Zusammenfassung
- Dateien und Segmentzustände werden beim Projektwechsel vor dem Bereinigen des GPT-Zustands gespeichert.
- README und Changelog dokumentieren den neuen Ablauf mit aktualisierter Versionsanzeige.

## Testen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b89036bd648327a651a669b36162ff