### PR TITLE
Projektwechsel leert jetzt Zeilenreihenfolge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.278
+* Projektwechsel leert zusätzlich die Zeilenreihenfolge, indem `displayOrder` zurückgesetzt wird.
 ## 🛠️ Patch in 1.40.277
 * Projektwechsel sichert Dateien, bevor der GPT-Zustand bereinigt wird.
 ## 🛠️ Patch in 1.40.276

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.277-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.278-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -54,6 +54,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Abbrechbare GPT-Bewertungen:** Beim Projekt- oder Speicherwechsel werden laufende und wartende Jobs verworfen und im Log vermerkt
 * **Sicherer Projektwechsel für GPT:** Projektkarten rufen jetzt `switchProjectSafe` auf und `selectProject` leert den GPT-Zustand vorsorglich
 * **Gesicherte Dateien vor GPT-Reset:** Beim Projektwechsel werden Dateien zuerst gespeichert und erst danach der GPT-Zustand bereinigt
+* **Leere Zeilenreihenfolge beim Projektwechsel:** Neben den GPT-Daten wird auch die Anzeige-Reihenfolge gelöscht
 * **Level-Kapitel** zur besseren Gruppierung und ein-/ausklappbaren Bereichen
 * **Kapitel bearbeiten:** Name, Farbe und Löschung im Projekt möglich
 * **Kapitelwahl beim Erstellen:** Neue oder bestehende Kapitel direkt auswählen

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -535,6 +535,7 @@ function clearGptState() {
     if (typeof files !== 'undefined') files = [];
     if (typeof gptPromptData !== 'undefined') gptPromptData = null;
     if (typeof gptEvaluationResults !== 'undefined') gptEvaluationResults = null;
+    if (typeof displayOrder !== 'undefined') displayOrder = []; // Zeilenreihenfolge zurücksetzen
     // Vorschlagsboxen und Kommentare aus dem DOM entfernen
     if (typeof document !== 'undefined') {
         document.querySelectorAll('.suggestion-box, .comment-box, .emo-reason-box').forEach(el => el.remove());


### PR DESCRIPTION
## Zusammenfassung
- `clearGptState` setzt `displayOrder` auf einen leeren Zustand
- Dokumentation erwähnt, dass beim Projektwechsel nun auch die Zeilenreihenfolge zurückgesetzt wird

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b894a7eb5c8327b200a7b2a84a7b02