### PR TITLE
Fehlende Projekte nach Reparatur neu laden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.282
+* Fehlende Projekte werden nach der Reparatur automatisch neu geladen.
 ## 🛠️ Patch in 1.40.281
 * Projektladen fängt Speicherfehler ab und zeigt einen Dialog.
 ## 🛠️ Patch in 1.40.280

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.281-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.282-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -34,6 +34,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 * **Asynchrones Speichern:** Beim Start werden Level- und Kapitel-Daten jetzt korrekt geladen, auch wenn das neue IndexedDB-System verwendet wird.
 * **Stabiles Projektladen:** Fehler beim Lesen aus dem Speicher werden abgefangen und als Hinweis angezeigt.
+* **Automatische Projektreparatur:** Wird ein Projekt nicht gefunden, legt das Tool eine leere Struktur an und lädt sie direkt erneut.
 * **Überarbeitete Hilfsskripte:** Python-Tools nutzen jetzt `subprocess.run` mit `check=True` ohne `shell=True` und schließen Dateien konsequent über `with`-Blöcke.
 * **Robuster npm-Test:** Fehlt `npm` (z. B. bei Node 22), bricht das Startskript nicht mehr ab, sondern weist auf `corepack enable` oder eine separate Installation hin.
 * **Automatische npm-Aktivierung:** `reset_repo.py` versucht bei fehlendem `npm`, es über `corepack` einzurichten, bevor das Tool startet.

--- a/tests/projectSwitchReloadMissingProject.test.js
+++ b/tests/projectSwitchReloadMissingProject.test.js
@@ -1,0 +1,27 @@
+/** @jest-environment jsdom */
+// Testet, ob ein fehlendes Projekt nach Reparatur erneut geladen wird
+const fs = require('fs');
+const path = require('path');
+
+test('switchProjectSafe lädt fehlendes Projekt erneut', async () => {
+  document.body.innerHTML = '<div id="projectLoadingOverlay" class="hidden"></div>';
+
+  let loadCount = 0;
+  window.pauseAutosave = jest.fn(async () => {});
+  window.flushPendingWrites = jest.fn(async () => {});
+  window.detachAllEventListeners = jest.fn();
+  window.clearInMemoryCachesHard = jest.fn();
+  window.closeProjectData = jest.fn(async () => {});
+  window.loadProjectData = jest.fn(async () => { loadCount++; });
+  window.getStorageAdapter = jest.fn(() => ({}));
+  window.repairProjectIntegrity = jest.fn(async () => true);
+  window.resumeAutosave = jest.fn(async () => {});
+  window.cancelGptRequests = jest.fn();
+  window.clearGptState = jest.fn();
+
+  const psCode = fs.readFileSync(path.join(__dirname, '../web/src/projectSwitch.js'), 'utf8');
+  eval(psCode);
+
+  await window.switchProjectSafe('p1');
+  expect(window.loadProjectData).toHaveBeenCalledTimes(2);
+});

--- a/web/src/projectHelpers.js
+++ b/web/src/projectHelpers.js
@@ -118,15 +118,18 @@ function setStorageAdapter(adapter) {
 }
 
 // Repariert offensichtliche Inkonsistenzen im Projekt
+// Liefert true zurück, wenn das Projekt neu angelegt wurde
 async function repairProjectIntegrity(adapter, projectId, ui = {}) {
-  if (!adapter || !adapter.getItem) return;
+  if (!adapter || !adapter.getItem) return false;
   const key = 'project:' + projectId;
   const data = await adapter.getItem(key);
   if (!data) {
     ui.warn && ui.warn(`Projekt ${projectId} nicht gefunden – leere Struktur angelegt`);
     await adapter.setItem(key, JSON.stringify({ id: projectId, files: [] }));
+    return true;
   } else {
     ui.info && ui.info(`Projekt ${projectId} geprüft`);
+    return false;
   }
 }
 

--- a/web/src/projectSwitch.js
+++ b/web/src/projectSwitch.js
@@ -65,7 +65,12 @@ function switchProjectSafe(projectId) {
       if (currentSession !== mySession) return;
       // Direkt im Anschluss verwaiste Einträge reparieren
       const adapter = getStorageAdapter('current');
-      await repairProjectIntegrity(adapter, projectId, ui);
+      const neuAngelegt = await repairProjectIntegrity(adapter, projectId, ui);
+      if (neuAngelegt) {
+        // Projekt wurde angelegt und muss erneut geladen werden
+        await loadProjectData(projectId, { signal: projectAbort.signal });
+        if (currentSession !== mySession) return;
+      }
     } finally {
       // Autosave wieder aktivieren
       if (autosavePaused) {


### PR DESCRIPTION
## Zusammenfassung
- Lege bei fehlenden Projekten eine leere Struktur an und lade sie erneut
- Ergänze Rückgabewert in `repairProjectIntegrity` zur Erkennung neu angelegter Projekte
- Dokumentiere automatische Projektreparatur in README und CHANGELOG

## Testabdeckung
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b89d442698832781ded7807c6e7d7a