### PR TITLE
Fix UI freeze after loading project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.286
+* Behebt einen Fehler, bei dem nach dem Projektladen keine Elemente mehr klickbar waren.
 ## 🛠️ Patch in 1.40.285
 * Fehlende Projekte werden der Projektliste hinzugefügt und die Liste wird nach der Reparatur neu geladen.
 ## 🛠️ Patch in 1.40.284

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.285-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.286-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -34,6 +34,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 * **Asynchrones Speichern:** Beim Start werden Level- und Kapitel-Daten jetzt korrekt geladen, auch wenn das neue IndexedDB-System verwendet wird.
 * **Stabiles Projektladen:** Fehler beim Lesen aus dem Speicher werden abgefangen und als Hinweis angezeigt.
+* **Bugfix:** Nach dem Laden eines Projekts reagierte die Oberfläche nicht mehr auf Klicks.
 * **Automatische Projektreparatur:** Wird ein Projekt nicht gefunden, legt das Tool eine leere Struktur an, ergänzt die Projektliste und lädt alles direkt erneut.
 * **Kompatible Projektschlüssel:** Das Tool erkennt das Schema `project:<id>:meta` und lädt vorhandene Projekte korrekt.
 * **Schonende Altlasten-Bereinigung:** Die LocalStorage-Reinigung entfernt nur alte Schlüssel und lässt neue Projektdaten unberührt.

--- a/web/src/projectHelpers.js
+++ b/web/src/projectHelpers.js
@@ -30,6 +30,12 @@ function detachAllEventListeners() {
   document.querySelectorAll('*').forEach(el => {
     if (el.tagName === 'SCRIPT') return; // Skripte nicht anfassen
     const clone = el.cloneNode(true);
+    // Inline-Event-Handler erhalten
+    for (const attr of el.getAttributeNames()) {
+      if (attr.startsWith('on')) {
+        clone[attr] = el[attr];
+      }
+    }
     el.replaceWith(clone);
   });
 }


### PR DESCRIPTION
## Summary
- Bewahre Inline-Event-Handler beim Entfernen alter Eventlistener, damit die Oberfläche nach dem Projektladen weiter klickbar bleibt
- Dokumentation aktualisiert: Version 1.40.286, Changelog-Eintrag und Hinweis auf den Bugfix im README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8a333836883278e8a57d7f924335e