### PR TITLE
Debug-Logs für Projektwechsel ergänzt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.287
+* Ergänzt Debug-Logs: `selectProject` protokolliert Start und Ende, `loadProjectData` meldet den Aufruf von `finalize()`.
 ## 🛠️ Patch in 1.40.286
 * Behebt einen Fehler, bei dem nach dem Projektladen keine Elemente mehr klickbar waren.
 ## 🛠️ Patch in 1.40.285

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.286-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.287-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -50,6 +50,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Überarbeitetes Timing-Layout:** Der Abschnitt „Timing & Bereiche“ nutzt ein zweispaltiges Kartenraster, das bei schmaler Breite automatisch auf eine Spalte umbricht.
 * **Detailliertes Fehlerfenster:** Fehlende oder beschädigte Projekte melden sich mit einer genauen Ursache und einem Reparaturhinweis.
 * **Debug-Bericht bei Fehlern:** Nach jeder Fehlermeldung kann ein Fenster mit auswählbaren Berichten samt Umgebung geöffnet werden.
+* **Zusätzliche Debug-Ausgaben:** `selectProject` meldet Start und Ende, `loadProjectData` protokolliert den Aufruf von `finalize()`.
 * **Abgesicherte Ordnerauswahl:** Verweigert der Browser den Dateisystem-Zugriff, erscheint eine verständliche Fehlermeldung.
 * **Robustes Datei-Laden:** Beim Import werden Lese- und JSON-Fehler abgefangen; danach prüft das Tool Pflichtfelder und entfernt unbekannte Datei-IDs.
 * **Mehrere Projekte** mit Icon, Farbe, Level‑Namen & Teil‑Nummer

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2725,12 +2725,16 @@ function quickAddProject(levelName) {
 
 // =========================== SELECT PROJECT START ===========================
 function selectProject(id){
+    // Debug-Ausgabe: Start der Projektwahl
+    console.log('[DEBUG] selectProject gestartet', { id, projektAnzahl: projects.length });
+
     stopProjectPlayback();
     saveCurrentProject(); // Aktuelles Projekt sichern, bevor der GPT-Zustand gelöscht wird
     storeSegmentState(); // Segmentzustand vor dem Reset speichern
     clearGptState(); // GPT-Zustand anschließend bereinigen
 
     currentProject = projects.find(p => p.id === id);
+    console.log('[DEBUG] selectProject: Projekt gefunden', currentProject);
     if(!currentProject) return;
 
     // Fehlendes Flag für Reste-Modus ergänzen
@@ -2824,6 +2828,8 @@ function selectProject(id){
     updateProgressStats();
     updateGlobalProjectProgress();
     updateProjectMetaBar();          //  <-- NEU!
+    // Debug-Ausgabe: Ende der Projektwahl
+    console.log('[DEBUG] selectProject abgeschlossen', { id, name: currentProject?.name, dateien: files.length });
 }
 // =========================== SELECT PROJECT END ===========================
 

--- a/web/src/projectHelpers.js
+++ b/web/src/projectHelpers.js
@@ -73,6 +73,8 @@ async function loadProjectData(id, opts = {}) {
     }
     let abgeschlossen = false;
     const finalize = () => {
+      // Debug-Ausgabe zur Überprüfung, ob finalize() erreicht wird
+      console.log('[DEBUG] finalize() aufgerufen für Projekt', id);
       if (abgeschlossen) return;
       abgeschlossen = true;
       if (typeof opts.callback === 'function') {


### PR DESCRIPTION
## Zusammenfassung
- Protokolliert Start und Ende von `selectProject` für bessere Fehlersuche
- Meldet Aufruf von `finalize()` in `loadProjectData`
- Dokumentation und Changelog entsprechend erweitert

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8a8c6026c83279243e4478529b80a