### PR TITLE
Verhindere Autoauswahl beim Projektlisten-Reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.289
+* Projektliste lässt sich neu laden, ohne automatisch ein Projekt zu öffnen; `loadProjects(skipSelect)` verhindert veraltete Projekt-IDs.
 ## 🛠️ Patch in 1.40.288
 * Projektladen verhindert Doppelaufrufe, lädt bei leerer Liste automatisch nach und vergleicht Projekt-IDs als Strings. Fehlende Projekte brechen mit Meldung ab.
 ## 🛠️ Patch in 1.40.287

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Abbrechbare GPT-Bewertungen:** Beim Projekt- oder Speicherwechsel werden laufende und wartende Jobs verworfen und im Log vermerkt
 * **Sicherer Projektwechsel für GPT:** Projektkarten rufen jetzt `switchProjectSafe` auf und `selectProject` leert den GPT-Zustand vorsorglich
 * **Robuster Projektaufruf:** Doppelklicks werden ignoriert, fehlende Listen werden nachgeladen und nicht gefundene Projekte melden einen klaren Fehler
+* **Projektliste ohne Auto-Auswahl:** `loadProjects` nimmt optional `skipSelect` entgegen; `reloadProjectList` lädt dadurch nur die Liste und öffnet kein altes Projekt
 * **Gesicherte Dateien vor GPT-Reset:** Beim Projektwechsel werden Dateien zuerst gespeichert und erst danach der GPT-Zustand bereinigt
 * **Leere Zeilenreihenfolge beim Projektwechsel:** Neben den GPT-Daten wird auch die Anzeige-Reihenfolge gelöscht
 * **Level-Kapitel** zur besseren Gruppierung und ein-/ausklappbaren Bereichen

--- a/tests/reloadProjectListSkipSelect.test.js
+++ b/tests/reloadProjectListSkipSelect.test.js
@@ -1,0 +1,14 @@
+/** @jest-environment jsdom */
+const fs = require('fs');
+const path = require('path');
+
+test('reloadProjectList ruft loadProjects ohne Autoauswahl auf', async () => {
+  // loadProjects-Mock, der Parameter protokolliert
+  window.loadProjects = jest.fn(async () => {});
+
+  const helpersCode = fs.readFileSync(path.join(__dirname, '../web/src/projectHelpers.js'), 'utf8');
+  eval(helpersCode);
+
+  await window.reloadProjectList();
+  expect(window.loadProjects).toHaveBeenCalledWith(true);
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2107,7 +2107,8 @@ function handleAccessStatusClick() {
 
 // =========================== LOAD PROJECTS START ===========================
 // Lädt Projekte und zugehörige Einstellungen asynchron aus dem Speicher
-async function loadProjects() {
+// Parameter "skipSelect" verhindert das automatische Öffnen eines Projekts
+async function loadProjects(skipSelect = false) {
     // Hilfsfunktion für Fehlerhinweise
     const showError = msg => {
         if (window.electronAPI && window.electronAPI.showProjectError) {
@@ -2276,9 +2277,12 @@ async function loadProjects() {
         renderProjects();
         updateGlobalProjectProgress();
 
-        const lastActive = await storage.getItem('hla_lastActiveProject');
-        const first     = projects.find(p => p.id == lastActive) || projects[0];
-        if (first) selectProject(first.id);
+        // Nur ein Projekt wählen, wenn dies nicht explizit unterbunden wurde
+        if (!skipSelect) {
+            const lastActive = await storage.getItem('hla_lastActiveProject');
+            const first     = projects.find(p => p.id == lastActive) || projects[0];
+            if (first) selectProject(first.id);
+        }
     } catch (err) {
         // Fehler beim Zugriff auf den Speicher melden und zurücksetzen
         showError(`Projekte konnten nicht geladen werden: ${err.message}`);

--- a/web/src/projectHelpers.js
+++ b/web/src/projectHelpers.js
@@ -238,9 +238,10 @@ async function repairProjectIntegrity(adapter, projectId, ui = {}) {
 }
 
 // Lädt die Projektliste neu
-async function reloadProjectList() {
+// Über den Parameter "skipSelect" wird verhindert, dass loadProjects ein Projekt öffnet
+async function reloadProjectList(skipSelect = true) {
   if (typeof window.loadProjects === 'function') {
-    await window.loadProjects();
+    await window.loadProjects(skipSelect);
   }
 }
 


### PR DESCRIPTION
## Zusammenfassung
- Erweiterung von `loadProjects` um optionalen Parameter `skipSelect` zur Unterdrückung der automatischen Projektwahl
- `reloadProjectList` übergibt `skipSelect` und vermeidet damit das Öffnen veralteter Projekte
- Neuer Test stellt sicher, dass die Projektliste ohne Auto-Auswahl neu geladen wird

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8ad669bb48327ba642df5086c5abc