### PR TITLE
Warnung statt Fehler bei fehlenden Projekten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.291
+* Fehlende Projekte führen nur zu einer Warnung; `switchProjectSafe` protokolliert keinen Fehler mehr, wenn ein Projekt endgültig fehlt.
 ## 🛠️ Patch in 1.40.290
 * Fehlende Projekte lösen nun einen erneuten Ladeversuch aus; `switchProjectSafe` lädt dafür die Projektliste neu und startet den Wechsel erneut.
 ## 🛠️ Patch in 1.40.289

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.288-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.291-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -61,6 +61,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Abbrechbare GPT-Bewertungen:** Beim Projekt- oder Speicherwechsel werden laufende und wartende Jobs verworfen und im Log vermerkt
 * **Sicherer Projektwechsel für GPT:** Projektkarten rufen jetzt `switchProjectSafe` auf und `selectProject` leert den GPT-Zustand vorsorglich
 * **Automatischer Neustart bei fehlenden Projekten:** Schlägt das Laden mit „Projekt nicht gefunden“ fehl, lädt `switchProjectSafe` die Liste neu und versucht den Wechsel erneut
+* **Fehlende Projekte nur als Warnung:** Bleibt ein Projekt auch danach unauffindbar, meldet `switchProjectSafe` lediglich eine Warnung statt eines Fehlers
 * **Robuster Projektaufruf:** Doppelklicks werden ignoriert, fehlende Listen werden nachgeladen und nicht gefundene Projekte melden einen klaren Fehler
 * **Projektliste ohne Auto-Auswahl:** `loadProjects` nimmt optional `skipSelect` entgegen; `reloadProjectList` lädt dadurch nur die Liste und öffnet kein altes Projekt
 * **Gesicherte Dateien vor GPT-Reset:** Beim Projektwechsel werden Dateien zuerst gespeichert und erst danach der GPT-Zustand bereinigt

--- a/web/src/projectSwitch.js
+++ b/web/src/projectSwitch.js
@@ -95,7 +95,12 @@ function switchProjectSafe(projectId) {
     }
   }).catch(err => {
     setBusy(false);
-    console.error('switchProjectSafe error', err);
+    if (err && String(err.message).includes('nicht gefunden')) {
+      // Fehlende Projekte führen nur zu einer Warnung
+      console.warn('Projektwechsel abgebrochen:', err.message);
+    } else {
+      console.error('switchProjectSafe error', err);
+    }
   });
   return switchQueue;
 }


### PR DESCRIPTION
## Zusammenfassung
- `switchProjectSafe` meldet fehlende Projekte jetzt nur noch als Warnung.
- Dokumentation aktualisiert und Version auf 1.40.291 erhöht.

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8affd8e2c832782656141c9e89b47