### PR TITLE
Fallback für fehlendes switchProjectSafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.294
+* Fehlender `switchProjectSafe` verhindert das Öffnen nicht mehr; Projektkarten greifen auf `selectProject` zurück.
 ## 🛠️ Patch in 1.40.293
 * Projektkarten nutzen jetzt einen delegierten Click-Listener; doppelte `selectProject`-Aufrufe entfallen.
 * `repairProjectIntegrity` wartet auf alle Schreibvorgänge und aktualisiert den In-Memory-Projektcache sofort.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Fehlende Projekte nur als Warnung:** Bleibt ein Projekt auch danach unauffindbar, meldet `switchProjectSafe` lediglich eine Warnung statt eines Fehlers
 * **Robuster Projektaufruf:** Doppelklicks werden ignoriert, fehlende Listen werden nachgeladen und nicht gefundene Projekte melden einen klaren Fehler
 * **Einziger Click-Listener für Projektkarten:** Ereignisdelegation verhindert doppelte `selectProject`-Aufrufe beim Neurendern
+* **Fallback ohne `switchProjectSafe`:** Sollte das Skript fehlen, öffnen Klicks Projekte direkt über `selectProject`
 * **Synchronisierte Projektreparatur:** `repairProjectIntegrity` wartet auf alle Speicherzugriffe und aktualisiert den In-Memory-Cache sofort
 * **Projektliste ohne Auto-Auswahl:** `loadProjects` nimmt optional `skipSelect` entgegen; `reloadProjectList` lädt dadurch nur die Liste und öffnet kein altes Projekt
 * **Gesicherte Dateien vor GPT-Reset:** Beim Projektwechsel werden Dateien zuerst gespeichert und erst danach der GPT-Zustand bereinigt

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2361,7 +2361,12 @@ function renderProjects() {
         list.addEventListener('click', e => {
             const item = e.target.closest('.project-item');
             if (item && !e.target.closest('button')) {
-                switchProjectSafe(item.dataset.projectId);
+                // Falls der sichere Wechsel fehlt, direktes selectProject verwenden
+                if (typeof window.switchProjectSafe === 'function') {
+                    window.switchProjectSafe(item.dataset.projectId);
+                } else {
+                    selectProject(item.dataset.projectId);
+                }
             }
         });
         projectListClickBound = true;


### PR DESCRIPTION
## Zusammenfassung
- Projektklicks funktionieren auch ohne geladenes `switchProjectSafe`
- Dokumentation um Hinweis auf den Fallback ergänzt
- Changelog mit entsprechendem Patch-Eintrag erweitert

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8b56bc1c48327ba0a7c6f1b6767dc