### PR TITLE
Reload project list when project missing persists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.295
+* Bleibt ein Projekt trotz Reparatur unauffindbar, lädt `switchProjectSafe` die Projektliste erneut, um verwaiste Einträge zu entfernen.
 ## 🛠️ Patch in 1.40.294
 * Fehlender `switchProjectSafe` verhindert das Öffnen nicht mehr; Projektkarten greifen auf `selectProject` zurück.
 ## 🛠️ Patch in 1.40.293

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Sicherer Projektwechsel für GPT:** Projektkarten rufen jetzt `switchProjectSafe` auf und `selectProject` leert den GPT-Zustand vorsorglich
 * **Automatischer Neustart bei fehlenden Projekten:** Schlägt das Laden mit „Projekt nicht gefunden“ fehl, lädt `switchProjectSafe` die Liste neu und versucht den Wechsel erneut
 * **Reparatur vor erneutem Laden:** Fehlt ein Projekt, führt `switchProjectSafe` zuerst `repairProjectIntegrity` aus und legt fehlende Strukturen automatisch an
-* **Fehlende Projekte nur als Warnung:** Bleibt ein Projekt auch danach unauffindbar, meldet `switchProjectSafe` lediglich eine Warnung statt eines Fehlers
+* **Fehlende Projekte nur als Warnung:** Bleibt ein Projekt auch danach unauffindbar, meldet `switchProjectSafe` lediglich eine Warnung und lädt die Projektliste neu
 * **Robuster Projektaufruf:** Doppelklicks werden ignoriert, fehlende Listen werden nachgeladen und nicht gefundene Projekte melden einen klaren Fehler
 * **Einziger Click-Listener für Projektkarten:** Ereignisdelegation verhindert doppelte `selectProject`-Aufrufe beim Neurendern
 * **Fallback ohne `switchProjectSafe`:** Sollte das Skript fehlen, öffnen Klicks Projekte direkt über `selectProject`

--- a/tests/projectSwitchReloadListPersistent.test.js
+++ b/tests/projectSwitchReloadListPersistent.test.js
@@ -1,0 +1,29 @@
+/** @jest-environment jsdom */
+// Prüft, ob bei dauerhaft fehlendem Projekt die Liste erneut geladen wird
+const fs = require('fs');
+const path = require('path');
+
+test('switchProjectSafe lädt Liste bei dauerhaft fehlendem Projekt erneut', async () => {
+  document.body.innerHTML = '<div id="projectLoadingOverlay" class="hidden"></div>';
+
+  window.pauseAutosave = jest.fn(async () => {});
+  window.flushPendingWrites = jest.fn(async () => {});
+  window.detachAllEventListeners = jest.fn();
+  window.clearInMemoryCachesHard = jest.fn();
+  window.closeProjectData = jest.fn(async () => {});
+  window.loadProjectData = jest.fn(async () => { throw new Error('Projekt p1 nicht gefunden'); });
+  window.getStorageAdapter = jest.fn(() => ({}));
+  window.repairProjectIntegrity = jest.fn(async () => false);
+  window.reloadProjectList = jest.fn(async () => {});
+  window.resumeAutosave = jest.fn(async () => {});
+  window.cancelGptRequests = jest.fn();
+  window.clearGptState = jest.fn();
+
+  const psCode = fs.readFileSync(path.join(__dirname, '../web/src/projectSwitch.js'), 'utf8');
+  eval(psCode);
+
+  await window.switchProjectSafe('p1');
+
+  expect(window.reloadProjectList).toHaveBeenCalledTimes(2);
+  expect(window.loadProjectData).toHaveBeenCalledTimes(2);
+});

--- a/web/src/projectSwitch.js
+++ b/web/src/projectSwitch.js
@@ -98,15 +98,18 @@ function switchProjectSafe(projectId) {
       }
       if (currentSession === mySession) setBusy(false);
     }
-  }).catch(err => {
-    setBusy(false);
-    if (err && String(err.message).includes('nicht gefunden')) {
-      // Fehlende Projekte führen nur zu einer Warnung
-      console.warn('Projektwechsel abgebrochen:', err.message);
-    } else {
-      console.error('switchProjectSafe error', err);
-    }
-  });
+}).catch(async err => {
+  setBusy(false);
+  if (err && String(err.message).includes('nicht gefunden')) {
+    // Fehlende Projekte führen nur zu einer Warnung und die Liste wird aktualisiert
+    console.warn('Projektwechsel abgebrochen:', err.message);
+    try {
+      await reloadProjectList();
+    } catch {}
+  } else {
+    console.error('switchProjectSafe error', err);
+  }
+});
   return switchQueue;
 }
 


### PR DESCRIPTION
## Summary
- Lade die Projektliste erneut, wenn ein Projekt trotz Reparatur fehlt und nur eine Warnung ausgegeben wird
- Teste den erneuten Listen-Ladevorgang bei dauerhaft fehlenden Projekten
- Dokumentiere das Verhalten in README und CHANGELOG

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8b67623408327811a8c5110cec8a7