### PR TITLE
Modernisiere Nutzeragent-Erkennung mit userAgentData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.296
+* Ersetzt `navigator.userAgent` und `navigator.platform` durch `navigator.userAgentData` mit Fallback, um künftige User-Agent-Reduktionen zu unterstützen.
 ## 🛠️ Patch in 1.40.295
 * Bleibt ein Projekt trotz Reparatur unauffindbar, lädt `switchProjectSafe` die Projektliste erneut, um verwaiste Einträge zu entfernen.
 ## 🛠️ Patch in 1.40.294

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.291-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.296-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -51,6 +51,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Detailliertes Fehlerfenster:** Fehlende oder beschädigte Projekte melden sich mit einer genauen Ursache und einem Reparaturhinweis.
 * **Debug-Bericht bei Fehlern:** Nach jeder Fehlermeldung kann ein Fenster mit auswählbaren Berichten samt Umgebung geöffnet werden.
 * **Zusätzliche Debug-Ausgaben:** `selectProject` meldet Start und Ende, `loadProjectData` protokolliert den Aufruf von `finalize()`.
+* **Aktualisierte Nutzeragent-Erkennung:** Der Debug-Bericht nutzt jetzt `navigator.userAgentData` mit Rückfall.
 * **Abgesicherte Ordnerauswahl:** Verweigert der Browser den Dateisystem-Zugriff, erscheint eine verständliche Fehlermeldung.
 * **Robustes Datei-Laden:** Beim Import werden Lese- und JSON-Fehler abgefangen; danach prüft das Tool Pflichtfelder und entfernt unbekannte Datei-IDs.
 * **Mehrere Projekte** mit Icon, Farbe, Level‑Namen & Teil‑Nummer

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -11093,6 +11093,12 @@ async function scanAudioDuplicates() {
         async function collectDebugInfo() {
             // Grundobjekt für alle gesammelten Daten
             let info = {};
+            // User-Agent-Information mit moderner API und Rückfall
+            const browserInfo = navigator.userAgentData
+                ? navigator.userAgentData.brands.map(b => `${b.brand}/${b.version}`).join(', ')
+                : navigator.userAgent;
+            // Plattform-Erkennung mit Fallback für ältere Browser
+            const platformInfo = navigator.userAgentData?.platform || navigator.platform;
             if (window.electronAPI && window.electronAPI.getDebugInfo) {
                 // Desktop-Version: Anfrage an den Hauptprozess
                 info = await window.electronAPI.getDebugInfo();
@@ -11101,9 +11107,9 @@ async function scanAudioDuplicates() {
                 info = {
                     Hinweis: 'Browser-Version ohne Electron-API',
                     appVersion: APP_VERSION,
-                    Browser: navigator.userAgent,
+                    Browser: browserInfo,
                     URL: location.href,
-                    Plattform: navigator.platform,
+                    Plattform: platformInfo,
                     Sprache: navigator.language,
                     'Electron-API vorhanden': isElectron,
                     'Im Browser gestartet': true
@@ -11137,7 +11143,8 @@ async function scanAudioDuplicates() {
             info['Seitenzustand'] = document.readyState;
             info['Sicherer Kontext'] = window.isSecureContext;
             info['Protokoll'] = location.protocol;
-            info['Benutzeragent'] = navigator.userAgent;
+            // Einheitlicher Benutzeragent mit moderner API
+            info['Benutzeragent'] = browserInfo;
             info['Verwendete Sprache'] = navigator.language;
             info.URL = location.href;
             info['Electron-API vorhanden'] = isElectron;


### PR DESCRIPTION
## Zusammenfassung
- ersetze direkte Zugriffe auf `navigator.userAgent` und `navigator.platform` durch `navigator.userAgentData` mit Fallback
- aktualisiere README und Changelog mit dem neuen Verhalten

## Testen
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8b7a39ef083278e2781a6a2473394