### PR TITLE
Synchronisiere Projektliste beim Start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.301
+* Start und Speichermodus-Wechsel rufen `reloadProjectList` auf und ergänzen fehlende Projekte, bevor eines geöffnet wird.
 ## 🛠️ Patch in 1.40.300
 * Integritätsprüfung ergänzt fehlende Projekte beim Start automatisch.
 * LocalStorage-Bereinigung entfernt `hla_projects` nur noch ohne neue Projektschlüssel.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Fallback ohne `switchProjectSafe`:** Sollte das Skript fehlen, öffnen Klicks Projekte direkt über `selectProject`
 * **Synchronisierte Projektreparatur:** `repairProjectIntegrity` wartet auf alle Speicherzugriffe und aktualisiert den In-Memory-Cache sofort
 * **Projektliste ohne Auto-Auswahl:** `loadProjects` nimmt optional `skipSelect` entgegen; `reloadProjectList` lädt dadurch nur die Liste und öffnet kein altes Projekt
+* **Proaktive Listen-Synchronisierung:** Beim Start und nach einem Speichermodus-Wechsel gleicht `reloadProjectList` alle `project:<id>`-Schlüssel mit `hla_projects` ab und ergänzt fehlende Projekte automatisch
 * **Gesicherte Dateien vor GPT-Reset:** Beim Projektwechsel werden Dateien zuerst gespeichert und erst danach der GPT-Zustand bereinigt
 * **Leere Zeilenreihenfolge beim Projektwechsel:** Neben den GPT-Daten wird auch die Anzeige-Reihenfolge gelöscht
 * **Level-Kapitel** zur besseren Gruppierung und ein-/ausklappbaren Bereichen

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -115,7 +115,10 @@ async function switchStorage(targetMode) {
     // Abschlussmeldung ausgeben
     updateStatus(`${zielLabel} geladen`);
     showToast(`Jetzt im ${zielLabel}`);
-    if (typeof loadProjects === 'function') {
+    // Projektliste nach Speichermodus-Wechsel vollständig neu laden
+    if (typeof reloadProjectList === 'function') {
+        await reloadProjectList(false);
+    } else if (typeof loadProjects === 'function') {
         await loadProjects();
     }
 }
@@ -1805,7 +1808,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Wichtig: Kapitel-Daten müssen vor dem Laden der Projekte vorhanden sein,
     // sonst sortiert sich die Liste beim ersten Start falsch
-    await loadProjects();
+    // Projektliste dabei direkt mit gespeicherten Projekten abgleichen
+    if (typeof reloadProjectList === 'function') {
+        await reloadProjectList(false);
+    } else {
+        await loadProjects();
+    }
 
     initializeEventListeners();
 


### PR DESCRIPTION
## Zusammenfassung
- Projektliste wird beim Start und nach einem Speichermodus-Wechsel vollständig über `reloadProjectList` neu geladen
- Dokumentation und Changelog zu proaktischer Listen-Synchronisierung aktualisiert

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b91afd82908327b20df9da98b42060