### PR TITLE
Projektwechsel ignoriert fehlendes Ausgangsprojekt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.303
+* Tests bereinigen nun Timer und Mocks in `saveFormats.test.js`, wodurch Jest sauber beendet wird.
+## 🛠️ Patch in 1.40.302
+* Projektwechsel bricht nicht mehr ab, wenn das vorherige Projekt fehlt; `reloadProjectList` reindiziert die Projektliste automatisch
 ## 🛠️ Patch in 1.40.301
 * Start und Speichermodus-Wechsel rufen `reloadProjectList` auf und ergänzen fehlende Projekte, bevor eines geöffnet wird.
 ## 🛠️ Patch in 1.40.300

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Automatischer Neustart bei fehlenden Projekten:** Schlägt das Laden mit „Projekt nicht gefunden“ fehl, lädt `switchProjectSafe` die Liste neu und versucht den Wechsel erneut
 * **Reparatur vor erneutem Laden:** Fehlt ein Projekt, führt `switchProjectSafe` zuerst `repairProjectIntegrity` aus und legt fehlende Strukturen automatisch an
 * **Fehlende Projekte nur als Warnung:** Bleibt ein Projekt auch danach unauffindbar, meldet `switchProjectSafe` lediglich eine Warnung und lädt die Projektliste neu
+* **Fehlendes Ausgangsprojekt blockiert den Wechsel nicht mehr:** Ist das vorherige Projekt verschwunden, gibt `switchProjectSafe` nur eine Warnung aus und `reloadProjectList` indiziert die Liste neu
 * **Englische Fehlermeldung erkannt:** Meldungen wie „Project not found“ werden ebenfalls erkannt und die Projektliste neu geladen
 * **Robuster Projektaufruf:** Doppelklicks werden ignoriert, fehlende Listen werden nachgeladen und nicht gefundene Projekte melden einen klaren Fehler
 * **Einziger Click-Listener für Projektkarten:** Ereignisdelegation verhindert doppelte `selectProject`-Aufrufe beim Neurendern
@@ -1068,6 +1069,11 @@ Das Test-Skript ruft deshalb Jest mit `node --unhandled-rejections=warn` auf, so
 1. Tests starten
    ```bash
    npm test
+   ```
+
+   Zur Fehlersuche bei offenen Handles kann Jest auch so gestartet werden:
+   ```bash
+   npm test -- tests/saveFormats.test.js --detectOpenHandles
    ```
 
 Die wichtigsten Tests befinden sich im Ordner `tests/` und prüfen die Funktionen `calculateProjectStats`, die ElevenLabs‑Anbindung und den Datei‑Watcher. Ein GitHub‑Workflow führt sie automatisch mit Node 18–22 aus.

--- a/tests/saveFormats.test.js
+++ b/tests/saveFormats.test.js
@@ -1,12 +1,23 @@
 /**
  * @jest-environment jsdom
  */
+
+// Verhindert offene Timer und unterdrückt Konsolen-Ausgaben
+jest.useFakeTimers();
+jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
 let bufferToWav;
 
 beforeAll(() => {
     ({ bufferToWav } = require('../web/src/main.js'));
-    jest.spyOn(console, 'log').mockImplementation(() => {});
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterAll(() => {
+    // Nach den Tests alle Mocks und Timer zurücksetzen
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
 });
 
 function createBuffer(samples, sampleRate = 44100) {

--- a/web/src/projectSwitch.js
+++ b/web/src/projectSwitch.js
@@ -102,10 +102,18 @@ function switchProjectSafe(projectId) {
     }
 }).catch(async err => {
   setBusy(false);
-  // Fehlermeldung sowohl auf Deutsch als auch auf Englisch erkennen
+  // Text der Fehlermeldung für Auswertung zwischenspeichern
   const msg = err ? String(err.message) : '';
-  if (/(nicht gefunden|not found)/i.test(msg)) {
-    // Fehlende Projekte führen nur zu einer Warnung und die Liste wird aktualisiert
+  if (/(from|vorherige[s]? Projekt).*?(nicht gefunden|not found)/i.test(msg)) {
+    // Fehlendes Ausgangsprojekt nur protokollieren und Liste neu indizieren
+    console.warn('Vorheriges Projekt nicht gefunden, versuche es erneut:', msg);
+    try {
+      await reloadProjectList();
+    } catch {}
+    // Wechsel erneut anstoßen, damit er abgeschlossen wird
+    return switchProjectSafe(projectId);
+  } else if (/(nicht gefunden|not found)/i.test(msg)) {
+    // Allgemeiner Projektfehler: Warnung ausgeben und Liste auffrischen
     console.warn('Projektwechsel abgebrochen:', msg);
     try {
       await reloadProjectList();


### PR DESCRIPTION
## Zusammenfassung
- Protokolliert fehlendes Ausgangsprojekt nur als Warnung und versucht den Wechsel nach einer Reindizierung erneut
- Dokumentation in README und CHANGELOG ergänzt
- `saveFormats.test.js` nutzt Fake-Timer und räumt Mocks auf, damit Jest ohne hängende Handles beendet

## Test
- `npm test -- tests/saveFormats.test.js --detectOpenHandles`
- `npm test -- --detectOpenHandles` *(meldet noch offene Handles in anderen Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b91e7ce8e883278a7cdae6459c48b5