### PR TITLE
Projektwechsel lädt Platzhalter bei fehlender ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.304
+* Fehlende Projekt-IDs laden nun einen Platzhalter; der Projektwechsel bricht nicht mehr ab.
 ## 🛠️ Patch in 1.40.303
 * Tests bereinigen nun Timer und Mocks in `saveFormats.test.js`, wodurch Jest sauber beendet wird.
 ## 🛠️ Patch in 1.40.302

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Sicherer Projektwechsel für GPT:** Projektkarten rufen jetzt `switchProjectSafe` auf und `selectProject` leert den GPT-Zustand vorsorglich
 * **Automatischer Neustart bei fehlenden Projekten:** Schlägt das Laden mit „Projekt nicht gefunden“ fehl, lädt `switchProjectSafe` die Liste neu und versucht den Wechsel erneut
 * **Reparatur vor erneutem Laden:** Fehlt ein Projekt, führt `switchProjectSafe` zuerst `repairProjectIntegrity` aus und legt fehlende Strukturen automatisch an
-* **Fehlende Projekte nur als Warnung:** Bleibt ein Projekt auch danach unauffindbar, meldet `switchProjectSafe` lediglich eine Warnung und lädt die Projektliste neu
+* **Fehlende Projekte werden als Platzhalter geladen:** Bleibt ein Projekt auch danach unauffindbar, lädt `switchProjectSafe` einen leeren Platzhalter und setzt den Wechsel fort
 * **Fehlendes Ausgangsprojekt blockiert den Wechsel nicht mehr:** Ist das vorherige Projekt verschwunden, gibt `switchProjectSafe` nur eine Warnung aus und `reloadProjectList` indiziert die Liste neu
 * **Englische Fehlermeldung erkannt:** Meldungen wie „Project not found“ werden ebenfalls erkannt und die Projektliste neu geladen
 * **Robuster Projektaufruf:** Doppelklicks werden ignoriert, fehlende Listen werden nachgeladen und nicht gefundene Projekte melden einen klaren Fehler

--- a/tests/projectSwitchReloadListPersistent.test.js
+++ b/tests/projectSwitchReloadListPersistent.test.js
@@ -25,5 +25,5 @@ test('switchProjectSafe lädt Liste bei dauerhaft fehlendem Projekt erneut', asy
   await window.switchProjectSafe('p1');
 
   expect(window.reloadProjectList).toHaveBeenCalledTimes(2);
-  expect(window.loadProjectData).toHaveBeenCalledTimes(2);
+  expect(window.loadProjectData).toHaveBeenCalledTimes(3);
 });

--- a/web/src/projectSwitch.js
+++ b/web/src/projectSwitch.js
@@ -113,10 +113,17 @@ function switchProjectSafe(projectId) {
     // Wechsel erneut anstoßen, damit er abgeschlossen wird
     return switchProjectSafe(projectId);
   } else if (/(nicht gefunden|not found)/i.test(msg)) {
-    // Allgemeiner Projektfehler: Warnung ausgeben und Liste auffrischen
-    console.warn('Projektwechsel abgebrochen:', msg);
+    // Projekt fehlt: Liste neu laden und Platzhalter versuchen
+    console.warn('Projekt nicht gefunden, versuche Platzhalter zu laden:', msg);
     try {
+      const adapter = getStorageAdapter('current');
+      try { await repairProjectIntegrity(adapter, projectId, ui); } catch {}
       await reloadProjectList();
+      try {
+        await loadProjectData(projectId, projectAbort ? { signal: projectAbort.signal } : {});
+      } catch (e2) {
+        console.warn('Platzhalter-Projekt konnte nicht geladen werden:', String(e2.message || e2));
+      }
     } catch {}
   } else {
     console.error('switchProjectSafe error', err);


### PR DESCRIPTION
## Zusammenfassung
- Fehlende Projekt-IDs laden nun einen Platzhalter statt den Wechsel abzubrechen
- README und CHANGELOG entsprechend aktualisiert
- Test angepasst, da das Laden jetzt ein drittes Mal versucht wird

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba16bdf6a083279c6a4d37f3de7aaf