### PR TITLE
Projektliste vor neuem Projekt aktualisieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.305
+* Projektwechsel lädt die Projektliste vor dem Öffnen neu und übergibt `skipSelect=true`, sodass kein Projekt automatisch geladen wird und der Fehler „Projekte konnten nicht geladen werden“ ausbleibt.
 ## 🛠️ Patch in 1.40.304
 * Fehlende Projekt-IDs laden nun einen Platzhalter; der Projektwechsel bricht nicht mehr ab.
 ## 🛠️ Patch in 1.40.303

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Fallback ohne `switchProjectSafe`:** Sollte das Skript fehlen, öffnen Klicks Projekte direkt über `selectProject`
 * **Synchronisierte Projektreparatur:** `repairProjectIntegrity` wartet auf alle Speicherzugriffe und aktualisiert den In-Memory-Cache sofort
 * **Projektliste ohne Auto-Auswahl:** `loadProjects` nimmt optional `skipSelect` entgegen; `reloadProjectList` lädt dadurch nur die Liste und öffnet kein altes Projekt
+* **Fehlerfreier Projektwechsel:** `switchProjectSafe` lädt vor dem Öffnen die Projektliste neu und vermeidet so die Meldung „Projekte konnten nicht geladen werden“
 * **Proaktive Listen-Synchronisierung:** Beim Start und nach einem Speichermodus-Wechsel gleicht `reloadProjectList` alle `project:<id>`-Schlüssel mit `hla_projects` ab und ergänzt fehlende Projekte automatisch
 * **Gesicherte Dateien vor GPT-Reset:** Beim Projektwechsel werden Dateien zuerst gespeichert und erst danach der GPT-Zustand bereinigt
 * **Leere Zeilenreihenfolge beim Projektwechsel:** Neben den GPT-Daten wird auch die Anzeige-Reihenfolge gelöscht

--- a/tests/projectSwitchClearGptState.test.js
+++ b/tests/projectSwitchClearGptState.test.js
@@ -24,6 +24,7 @@ test('switchProjectSafe setzt gptEvaluationResults auf null', async () => {
     window.repairProjectIntegrity = jest.fn(async () => {});
     window.resumeAutosave = jest.fn(async () => {});
     window.cancelGptRequests = jest.fn();
+    window.reloadProjectList = jest.fn(async () => {});
 
     // switchProjectSafe aus projectSwitch.js laden
     const psCode = fs.readFileSync(path.join(__dirname, '../web/src/projectSwitch.js'), 'utf8');

--- a/tests/projectSwitchReloadAfterError.test.js
+++ b/tests/projectSwitchReloadAfterError.test.js
@@ -30,7 +30,7 @@ test('switchProjectSafe lädt nach Fehler die Projektliste neu', async () => {
 
   await window.switchProjectSafe('p1');
 
-  expect(window.reloadProjectList).toHaveBeenCalledTimes(1);
+  expect(window.reloadProjectList).toHaveBeenCalledTimes(2);
   expect(window.loadProjectData).toHaveBeenCalledTimes(2);
   expect(window.repairProjectIntegrity).toHaveBeenCalledTimes(2);
 });

--- a/tests/projectSwitchReloadBeforeLoad.test.js
+++ b/tests/projectSwitchReloadBeforeLoad.test.js
@@ -1,0 +1,51 @@
+/** @jest-environment jsdom */
+// Testet, dass beim Projektwechsel die Liste vor dem Öffnen aktualisiert wird
+const fs = require('fs');
+const path = require('path');
+
+test('switchProjectSafe lädt Liste vor dem Projekt ohne Fehler', async () => {
+  // Overlay für den Ladebalken bereitstellen
+  document.body.innerHTML = '<div id="projectLoadingOverlay" class="hidden"></div>';
+
+  const aufrufReihenfolge = [];
+
+  // Notwendige Helferfunktionen bereitstellen
+  window.pauseAutosave = jest.fn(async () => {});
+  window.flushPendingWrites = jest.fn(async () => {});
+  window.detachAllEventListeners = jest.fn();
+  window.clearInMemoryCachesHard = jest.fn();
+  window.closeProjectData = jest.fn(async () => {});
+  window.getStorageAdapter = jest.fn(() => ({}));
+  window.repairProjectIntegrity = jest.fn(async () => {});
+  window.resumeAutosave = jest.fn(async () => {});
+  window.cancelGptRequests = jest.fn();
+  window.clearGptState = jest.fn();
+  window.loadProjectData = jest.fn(async () => { aufrufReihenfolge.push('loadProjectData'); });
+
+  // loadProjects wirft Fehler, falls skipSelect nicht true ist
+  window.loadProjects = jest.fn(async (skipSelect) => {
+    aufrufReihenfolge.push(`loadProjects:${skipSelect}`);
+    if (!skipSelect) {
+      throw new Error('Projekte konnten nicht geladen werden');
+    }
+  });
+  window.reloadProjectList = jest.fn(async (skipSelect = true) => {
+    await window.loadProjects(skipSelect);
+    aufrufReihenfolge.push('reloadProjectList');
+  });
+
+  // switchProjectSafe laden
+  const psCode = fs.readFileSync(path.join(__dirname, '../web/src/projectSwitch.js'), 'utf8');
+  eval(psCode);
+
+  await window.switchProjectSafe('p1');
+
+  // Sicherstellen, dass loadProjects mit skipSelect=true aufgerufen wurde
+  expect(window.loadProjects).toHaveBeenCalledWith(true);
+  // Kontrolle der Aufrufreihenfolge: reloadProjectList vor loadProjectData
+  const idxReload = aufrufReihenfolge.indexOf('reloadProjectList');
+  const idxLoad = aufrufReihenfolge.indexOf('loadProjectData');
+  expect(idxReload).toBeGreaterThan(-1);
+  expect(idxLoad).toBeGreaterThan(-1);
+  expect(idxReload).toBeLessThan(idxLoad);
+});

--- a/tests/projectSwitchReloadEnglishError.test.js
+++ b/tests/projectSwitchReloadEnglishError.test.js
@@ -31,7 +31,7 @@ test('switchProjectSafe lädt nach englischer Fehlermeldung die Projektliste neu
 
   await window.switchProjectSafe('p1');
 
-  expect(window.reloadProjectList).toHaveBeenCalledTimes(1);
+  expect(window.reloadProjectList).toHaveBeenCalledTimes(2);
   expect(window.loadProjectData).toHaveBeenCalledTimes(2);
   expect(window.repairProjectIntegrity).toHaveBeenCalledTimes(2);
 });

--- a/tests/projectSwitchReloadListPersistent.test.js
+++ b/tests/projectSwitchReloadListPersistent.test.js
@@ -24,6 +24,6 @@ test('switchProjectSafe lädt Liste bei dauerhaft fehlendem Projekt erneut', asy
 
   await window.switchProjectSafe('p1');
 
-  expect(window.reloadProjectList).toHaveBeenCalledTimes(2);
+  expect(window.reloadProjectList).toHaveBeenCalledTimes(3);
   expect(window.loadProjectData).toHaveBeenCalledTimes(3);
 });

--- a/tests/projectSwitchReloadMissingProject.test.js
+++ b/tests/projectSwitchReloadMissingProject.test.js
@@ -25,5 +25,5 @@ test('switchProjectSafe lädt fehlendes Projekt erneut', async () => {
 
   await window.switchProjectSafe('p1');
   expect(window.loadProjectData).toHaveBeenCalledTimes(2);
-  expect(window.reloadProjectList).toHaveBeenCalledTimes(1);
+  expect(window.reloadProjectList).toHaveBeenCalledTimes(2);
 });

--- a/web/src/projectSwitch.js
+++ b/web/src/projectSwitch.js
@@ -58,6 +58,8 @@ function switchProjectSafe(projectId) {
       clearInMemoryCachesHard();
       // Offenes Projekt schließen
       try { await closeProjectData(); } catch {}
+      // Projektliste aktualisieren, ohne automatisch ein Projekt zu öffnen
+      await reloadProjectList(true);
       // GPT-Zustände und UI leeren
       if (window.clearGptState) window.clearGptState();
       // Neues Projekt laden und auf Promise warten
@@ -75,7 +77,7 @@ function switchProjectSafe(projectId) {
             await repairProjectIntegrity(adapter, projectId, ui);
           } catch {}
           // Danach Liste neu laden und erneut versuchen
-          await reloadProjectList();
+          await reloadProjectList(true);
           await loadProjectData(projectId, { signal: projectAbort.signal });
           geladen = true;
         } else {
@@ -88,7 +90,7 @@ function switchProjectSafe(projectId) {
       const neuAngelegt = await repairProjectIntegrity(adapter, projectId, ui);
       if (neuAngelegt) {
         // Projekt wurde angelegt: Liste neu laden und Projekt erneut öffnen
-        await reloadProjectList();
+        await reloadProjectList(true);
         await loadProjectData(projectId, { signal: projectAbort.signal });
         if (currentSession !== mySession) return;
       }
@@ -108,7 +110,7 @@ function switchProjectSafe(projectId) {
     // Fehlendes Ausgangsprojekt nur protokollieren und Liste neu indizieren
     console.warn('Vorheriges Projekt nicht gefunden, versuche es erneut:', msg);
     try {
-      await reloadProjectList();
+      await reloadProjectList(true);
     } catch {}
     // Wechsel erneut anstoßen, damit er abgeschlossen wird
     return switchProjectSafe(projectId);
@@ -118,7 +120,7 @@ function switchProjectSafe(projectId) {
     try {
       const adapter = getStorageAdapter('current');
       try { await repairProjectIntegrity(adapter, projectId, ui); } catch {}
-      await reloadProjectList();
+      await reloadProjectList(true);
       try {
         await loadProjectData(projectId, projectAbort ? { signal: projectAbort.signal } : {});
       } catch (e2) {
@@ -160,7 +162,7 @@ async function switchStorageSafe(mode) {
       if (adapter && typeof adapter.init === 'function') {
         await adapter.init();
       }
-      await reloadProjectList();
+      await reloadProjectList(true);
     } finally {
       if (autosavePaused) {
         await resumeAutosave();


### PR DESCRIPTION
## Zusammenfassung
- Projektwechsel lädt nun die Projektliste mit `skipSelect=true`, bevor ein neues Projekt geöffnet wird.
- Alle Aufrufe von `reloadProjectList` verwenden explizit `skipSelect=true`, auch beim Speichersystemwechsel.
- Neuer Jest-Test prüft, dass die Liste vor dem Projektladen aktualisiert wird und kein Fehler erscheint.

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba1c03bed08327a259238caea0d22d