### PR TITLE
Reset setzt Projektlisten-Listener zurück

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.306
+* Nach einem globalen Reset wird der Klick-Listener der Projektliste neu gesetzt, sodass Projekte wieder anwählbar sind.
 ## 🛠️ Patch in 1.40.305
 * Projektwechsel lädt die Projektliste vor dem Öffnen neu und übergibt `skipSelect=true`, sodass kein Projekt automatisch geladen wird und der Fehler „Projekte konnten nicht geladen werden“ ausbleibt.
 ## 🛠️ Patch in 1.40.304

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Englische Fehlermeldung erkannt:** Meldungen wie „Project not found“ werden ebenfalls erkannt und die Projektliste neu geladen
 * **Robuster Projektaufruf:** Doppelklicks werden ignoriert, fehlende Listen werden nachgeladen und nicht gefundene Projekte melden einen klaren Fehler
 * **Einziger Click-Listener für Projektkarten:** Ereignisdelegation verhindert doppelte `selectProject`-Aufrufe beim Neurendern
+* **Listener nach Reset neu gesetzt:** `resetGlobalState` setzt den Merker zurück und `renderProjects` bindet den Klick-Listener erneut, damit Projekte weiterhin auswählbar bleiben
 * **Fallback ohne `switchProjectSafe`:** Sollte das Skript fehlen, öffnen Klicks Projekte direkt über `selectProject`
 * **Synchronisierte Projektreparatur:** `repairProjectIntegrity` wartet auf alle Speicherzugriffe und aktualisiert den In-Memory-Cache sofort
 * **Projektliste ohne Auto-Auswahl:** `loadProjects` nimmt optional `skipSelect` entgegen; `reloadProjectList` lädt dadurch nur die Liste und öffnet kein altes Projekt

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -159,6 +159,8 @@ function resetGlobalState() {
     }
     if (typeof ignoredSegments !== 'undefined' && ignoredSegments.clear) ignoredSegments.clear();
     if (typeof projectIndex !== 'undefined') projectIndex = null;
+    // Click-Listener für die Projektliste zurücksetzen, damit er neu gebunden wird
+    if (typeof projectListClickBound !== 'undefined') projectListClickBound = false;
 }
 
 // Prüft, in welchem Speichersystem ein Schlüssel liegt und zeigt den Status an


### PR DESCRIPTION
## Zusammenfassung
- Setzt `projectListClickBound` im globalen Reset zurück, damit `renderProjects` den Klick-Listener erneut bindet.
- Dokumentation in README und CHANGELOG aktualisiert.

## Testplan
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba1d6911a08327afd042abb3c0ddea