### PR TITLE
Projekte global referenzierbar machen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.307
+* `window.projects` bleibt nun synchron, damit alle Module dieselbe Projektreferenz verwenden.
 ## 🛠️ Patch in 1.40.306
 * Nach einem globalen Reset wird der Klick-Listener der Projektliste neu gesetzt, sodass Projekte wieder anwählbar sind.
 ## 🛠️ Patch in 1.40.305

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ### 🎯 Kernfunktionen
 
 * **Asynchrones Speichern:** Beim Start werden Level- und Kapitel-Daten jetzt korrekt geladen, auch wenn das neue IndexedDB-System verwendet wird.
+* **Gemeinsame Projektliste:** `window.projects` stellt sicher, dass alle Module auf dieselbe Projektreferenz zugreifen.
 * **Überarbeitete Lade-Mechanik:** Projekte werden wieder zuverlässig geöffnet und laufende Ladevorgänge blockieren sich nicht mehr gegenseitig.
 * **Stabiles Projektladen:** Fehler beim Lesen aus dem Speicher werden abgefangen und als Hinweis angezeigt.
 * **Bugfix:** Nach dem Laden eines Projekts reagierte die Oberfläche nicht mehr auf Klicks.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -275,6 +275,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
 // =========================== GLOBAL STATE START ===========================
 let projects               = [];
+window.projects            = projects; // Globale Referenz auf die Projektliste
 let levelColors            = {}; // ⬅️ NEU: globale Level-Farben
 let levelOrders            = {}; // ⬅️ NEU: Reihenfolge der Level
 let levelIcons             = {}; // ⬅️ NEU: Icon je Level
@@ -2300,6 +2301,7 @@ async function loadProjects(skipSelect = false) {
         saveProjects();
         renderProjects();
     }
+    window.projects = projects; // Referenz für andere Module aktualisieren
 }
 // =========================== LOAD PROJECTS END ===========================
 
@@ -2307,6 +2309,7 @@ async function loadProjects(skipSelect = false) {
         function saveProjects() {
             storage.setItem('hla_projects', JSON.stringify(projects));
             updateGlobalProjectProgress();
+            window.projects = projects; // Referenz für andere Module aktualisieren
         }
 
         function saveTextDatabase() {


### PR DESCRIPTION
## Zusammenfassung
- Projekte nach Initialisierung sowie beim Laden und Speichern auf `window.projects` referenzieren
- Dokumentation in README und CHANGELOG ergänzt

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba1f59c28c8327aa9cd64eca576b9d