### PR TITLE
Scrollfunktionen wieder global verfügbar machen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.310
+* Navigationsfunktionen sind wieder global verfügbar und der Scroll-Listener wird beim Initialisieren gesetzt, wodurch Vor-/Zurück-Schaltflächen und manuelles Scrollen erneut korrekt arbeiten.
 ## 🛠️ Patch in 1.40.309
 * Toolbar-Knöpfe werden nach einem Projektwechsel erneut gebunden und bleiben dadurch funktionsfähig.
 ## 🛠️ Patch in 1.40.308

--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Mausrad:** Markiert beim Scrollen automatisch die Zeile in der Bildschirmmitte, ohne sie neu auszurichten
 * **Kein Zoom in Wellenformen:** Beim Ziehen in EN- und DE-Spuren des DE-Audio-Editors erfolgt kein automatisches Zoom mehr
 * **Zeilenauswahl:** Gewählte Zeilen werden vollständig unter dem Tabellenkopf positioniert
+* **Nummern-Navigation:** Vor-/Zurück-Schaltflächen und manuelles Scrollen markieren die aktive Zeile wieder zuverlässig
 * **Doppelklick:** Projekt umbenennen
 
 ---

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1873,11 +1873,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
 });
-// Scroll-Listener zur Aktualisierung der aktuellen Zeilennummer
-document.addEventListener('DOMContentLoaded', () => {
-    const container = document.querySelector('.table-container');
-    if (container) container.addEventListener('scroll', updateNumberFromScroll);
-});
 // =========================== DOM READY INITIALISIERUNG ENDE ===========================
 
 
@@ -3331,6 +3326,18 @@ function addFiles() {
                 hideLevelMenu();
                 hideChapterMenu();
             });
+
+            // Scroll-Listener nach Laden der Funktionen setzen
+            const tableContainer = document.querySelector('.table-container');
+            if (tableContainer) {
+                tableContainer.addEventListener('scroll', updateNumberFromScroll);
+            }
+
+            // Navigationsfunktionen global zur Verfügung stellen
+            window.scrollToNumber = scrollToNumber;
+            window.goToNextNumber = goToNextNumber;
+            window.goToPreviousNumber = goToPreviousNumber;
+            window.updateNumberFromScroll = updateNumberFromScroll;
         }
 
         // Keyboard Navigation


### PR DESCRIPTION
## Zusammenfassung
- Scroll-Listener innerhalb der Initialisierung gesetzt und Navigationsfunktionen an `window` gebunden
- Dokumentation zu zuverlässiger Nummern-Navigation ergänzt
- Changelog um Patch 1.40.310 erweitert

## Testanweisungen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb015998cc83278c7b5ad15bf40d09