### PR TITLE
Projektleiste nach Wechsel zentrieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.311
+* Projektleiste scrollt nach einem Projektwechsel automatisch zur ausgewählten Karte und bleibt zentriert.
 ## 🛠️ Patch in 1.40.310
 * Navigationsfunktionen sind wieder global verfügbar und der Scroll-Listener wird beim Initialisieren gesetzt, wodurch Vor-/Zurück-Schaltflächen und manuelles Scrollen erneut korrekt arbeiten.
 ## 🛠️ Patch in 1.40.309

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Projektkarten mit Rahmen:** Jede Karte besitzt einen grauen Rand und nutzt nun die volle Breite. Im geöffneten Level wird der Rand grün. Das aktuell gewählte Projekt hebt sich mit einem blauen Balken, leicht transparentem Hintergrund (rgba(33,150,243,0.2)) und weißer Schrift deutlich ab.
 * **Überarbeitete Seitenleiste:** Jede Projektkarte besteht aus zwei Zeilen mit einheitlich breiten Badges für EN, DE und Audio.
 * **Breitere Projektleiste:** Die Sidebar ist jetzt 320 px breit, damit lange Einträge korrekt angezeigt werden.
+* **Projektleiste zentriert nach Wechsel:** Nach dem Projektwechsel scrollt die Leiste automatisch zur gewählten Karte und hält die Position.
 * **Aktiver Level hervorgehoben:** Geöffnete Level-Gruppen besitzen jetzt einen grünen Rahmen und einen leicht abgedunkelten Hintergrund.
 * **Dezente Level-Gruppen:** Geschlossene Level zeigen einen ganz leichten Hintergrund und nur beim Überfahren einen feinen Rahmen.
 * **Abgesetzte Level-Blöcke:** Zwischen den Levels erscheint ein grauer Trennstrich und die Level-ID wird kleiner in Grau angezeigt.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2795,9 +2795,23 @@ function selectProject(id){
 
     expandedLevel = currentProject.levelName;
     expandedChapter = getLevelChapter(currentProject.levelName);
+    // Scrollposition der Projektliste merken
+    const list = document.getElementById('projectList');
+    const alteScrollPos = list ? list.scrollTop : 0;
+
     renderProjects();
     document.querySelectorAll('.project-item')
         .forEach(item=>item.classList.toggle('active',item.dataset.projectId==id));
+
+    // Ausgewählte Projektkarte nach dem Rendern zentrieren
+    if (list) {
+        const aktiveKarte = list.querySelector(`.project-item[data-project-id="${id}"]`);
+        if (aktiveKarte && aktiveKarte.scrollIntoView) {
+            aktiveKarte.scrollIntoView({ block: 'center' });
+        } else {
+            list.scrollTop = alteScrollPos;
+        }
+    }
 
     files = currentProject.files || [];
     segmentInfo = currentProject._segmentInfo || null;


### PR DESCRIPTION
## Zusammenfassung
- Projektliste merkt sich die Scrollposition und zentriert nach dem Projektwechsel automatisch die gewählte Karte
- Dokumentation zur zentrierten Projektleiste ergänzt
- Changelog um den Bugfix der Projektliste erweitert

## Testanweisungen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb0300de5c8327b1f101ed7a1cd0aa