### PR TITLE
Reinitialisiere Such-Listener nach Projektwechsel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.311
+* Live-Suche funktioniert nach Projektwechsel, da `switchProjectSafe` die Event-Listener erneut setzt.
 ## 🛠️ Patch in 1.40.310
 * Navigationsfunktionen sind wieder global verfügbar und der Scroll-Listener wird beim Initialisieren gesetzt, wodurch Vor-/Zurück-Schaltflächen und manuelles Scrollen erneut korrekt arbeiten.
 ## 🛠️ Patch in 1.40.309

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Robuster Projektaufruf:** Doppelklicks werden ignoriert, fehlende Listen werden nachgeladen und nicht gefundene Projekte melden einen klaren Fehler
 * **Einziger Click-Listener für Projektkarten:** Ereignisdelegation verhindert doppelte `selectProject`-Aufrufe beim Neurendern
 * **Listener nach Reset neu gesetzt:** `resetGlobalState` setzt den Merker zurück und `renderProjects` bindet den Klick-Listener erneut, damit Projekte weiterhin auswählbar bleiben
+* **Live-Suche nach Projektwechsel funktionsfähig:** `switchProjectSafe` ruft `initializeEventListeners` erneut auf
 * **Fallback ohne `switchProjectSafe`:** Sollte das Skript fehlen, öffnen Klicks Projekte direkt über `selectProject`
 * **Synchronisierte Projektreparatur:** `repairProjectIntegrity` wartet auf alle Speicherzugriffe und aktualisiert den In-Memory-Cache sofort
 * **Projektliste ohne Auto-Auswahl:** `loadProjects` nimmt optional `skipSelect` entgegen; `reloadProjectList` lädt dadurch nur die Liste und öffnet kein altes Projekt

--- a/tests/projectSwitchReinitializeListeners.test.js
+++ b/tests/projectSwitchReinitializeListeners.test.js
@@ -1,0 +1,37 @@
+/** @jest-environment jsdom */
+// Stellt sicher, dass switchProjectSafe Event-Listener neu setzt
+const fs = require('fs');
+const path = require('path');
+
+test('switchProjectSafe initialisiert Listener neu', async () => {
+  // Platzhalter für Overlay
+  document.body.innerHTML = '<div id="projectLoadingOverlay" class="hidden"></div>';
+
+  // Benötigte Helferfunktionen bereitstellen
+  window.pauseAutosave = jest.fn(async () => {});
+  window.flushPendingWrites = jest.fn(async () => {});
+  window.detachAllEventListeners = jest.fn();
+  window.clearInMemoryCachesHard = jest.fn();
+  window.closeProjectData = jest.fn(async () => {});
+  window.reloadProjectList = jest.fn(async () => {});
+  window.cancelGptRequests = jest.fn();
+  window.clearGptState = jest.fn();
+  window.loadProjectData = jest.fn(async () => {});
+  window.repairProjectIntegrity = jest.fn(async () => false);
+  window.getStorageAdapter = jest.fn(() => ({}));
+  window.updateAllProjectsAfterScan = jest.fn();
+  window.updateFileAccessStatus = jest.fn();
+  window.scanEnOrdner = jest.fn(async () => {});
+  window.initToolbarButtons = jest.fn();
+  window.resumeAutosave = jest.fn(async () => {});
+  window.initializeEventListeners = jest.fn();
+
+  // Code laden und ausführen
+  const psCode = fs.readFileSync(path.join(__dirname, '../web/src/projectSwitch.js'), 'utf8');
+  eval(psCode);
+
+  await window.switchProjectSafe('p1');
+
+  // Sicherstellen, dass initializeEventListeners aufgerufen wurde
+  expect(window.initializeEventListeners).toHaveBeenCalled();
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -3340,6 +3340,9 @@ function addFiles() {
             window.updateNumberFromScroll = updateNumberFromScroll;
         }
 
+        // Globale Bereitstellung für Projektwechsel
+        window.initializeEventListeners = initializeEventListeners;
+
         // Keyboard Navigation
         function handleKeyboardNavigation(e) {
             // Skip if user is typing in an input field

--- a/web/src/projectSwitch.js
+++ b/web/src/projectSwitch.js
@@ -114,6 +114,8 @@ function switchProjectSafe(projectId) {
       updateFileAccessStatus();
       // Nach dem Laden Toolbar-Knöpfe neu verbinden
       window.initToolbarButtons?.();
+      // Event-Listener wie die Live-Suche neu setzen
+      window.initializeEventListeners?.();
     } finally {
       // Autosave wieder aktivieren
       if (autosavePaused) {


### PR DESCRIPTION
## Zusammenfassung
- Exportiere `initializeEventListeners` global, damit Listener nach dem Projektwechsel neu gesetzt werden.
- Setze Event-Listener in `switchProjectSafe` erneut, sodass die Live-Suche weiterhin funktioniert.
- Ergänze README und CHANGELOG um Hinweis auf den Fix und teste die Reinitialisierung.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb10b5d3e0832790a1a76efd3290ee