### PR TITLE
feat: automatisches live-speichern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.312
+* Live-Speichern: Änderungen werden nach kurzer Verzögerung automatisch gesichert.
 ## 🛠️ Patch in 1.40.311
 * Live-Suche funktioniert nach Projektwechsel, da `switchProjectSafe` die Event-Listener erneut setzt.
 ## 🛠️ Patch in 1.40.310

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ### 🎯 Kernfunktionen
 
 * **Asynchrones Speichern:** Beim Start werden Level- und Kapitel-Daten jetzt korrekt geladen, auch wenn das neue IndexedDB-System verwendet wird.
+* **Live-Speichern:** Änderungen an Dateien oder Texten werden nach kurzer Pause automatisch gesichert.
 * **Gemeinsame Projektliste:** `window.projects` stellt sicher, dass alle Module auf dieselbe Projektreferenz zugreifen.
 * **Überarbeitete Lade-Mechanik:** Projekte werden wieder zuverlässig geöffnet und laufende Ladevorgänge blockieren sich nicht mehr gegenseitig.
 * **Stabiles Projektladen:** Fehler beim Lesen aus dem Speicher werden abgefangen und als Hinweis angezeigt.

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -79,7 +79,7 @@ function applySuggestion(id, files) {
     const file = files.find(f => f.id === id);
     if (!file || !file.suggestion) return;
     file.deText = file.suggestion;
-    window.isDirty = true;
+    markDirty();
     const row = document.querySelector(`tr[data-id='${id}']`);
     const deCell = row?.querySelectorAll('textarea.text-input')[1];
     if (deCell) {


### PR DESCRIPTION
## Zusammenfassung
- führt `markDirty()` ein und speichert Änderungen nach 500 ms automatisch
- ersetzt direkte `isDirty`-Zuweisungen durch `markDirty()`-Aufrufe
- dokumentiert das neue Live-Speichern in README und CHANGELOG

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb151a86b48327a68e339f87b37020