### PR TITLE
Speichern nach GPT- und Emotionsänderungen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.314
+* GPT-Bewertungen und Emotionstexte werden nach dem Einfügen sofort gespeichert.
 ## 🛠️ Patch in 1.40.313
 * Toolbar-Schaltflächen werden nach einem Projektwechsel zuverlässig neu initialisiert.
 ## 🛠️ Patch in 1.40.312

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 * **Asynchrones Speichern:** Beim Start werden Level- und Kapitel-Daten jetzt korrekt geladen, auch wenn das neue IndexedDB-System verwendet wird.
 * **Live-Speichern:** Änderungen an Dateien oder Texten werden nach kurzer Pause automatisch gesichert.
+* **Sofortspeichern nach GPT- und Emotions-Einträgen:** Übernommene Bewertungen und generierte Emotionstexte werden unmittelbar dauerhaft gesichert.
 * **Gemeinsame Projektliste:** `window.projects` stellt sicher, dass alle Module auf dieselbe Projektreferenz zugreifen.
 * **Überarbeitete Lade-Mechanik:** Projekte werden wieder zuverlässig geöffnet und laufende Ladevorgänge blockieren sich nicht mehr gegenseitig.
 * **Stabiles Projektladen:** Fehler beim Lesen aus dem Speicher werden abgefangen und als Hinweis angezeigt.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2882,24 +2882,34 @@ let needTrans = files.filter(f => f.enText && (!f.autoTranslation || f.autoSourc
 
         function saveCurrentProject() {
             if (!currentProject || !isDirty) return;
-            
+
             currentProject.files = files;
             saveProjects();
             saveTextDatabase();
             saveFilePathDatabase();
             isDirty = false;
-			updateProjectMetaBar();
+            updateProjectMetaBar();
+        }
+
+        // Globale Referenz, damit andere Module speichern können
+        if (typeof window !== 'undefined') {
+            window.saveCurrentProject = saveCurrentProject;
         }
 		
 		
 // =========================== PROJECT META FUNCTIONS START ===========================
 function updateProjectMetaBar(){
     const bar=document.getElementById('projectMetaBar');
+    const nameEl=document.getElementById('metaProjectName');
+    const levelEl=document.getElementById('metaLevelName');
+    const partEl=document.getElementById('metaPartNumber');
+    // Ohne passende Elemente abbrechen
+    if(!bar||!nameEl||!levelEl||!partEl) return;
     if(!currentProject){bar.style.display='none';return;}
 
-    document.getElementById('metaProjectName').textContent=currentProject.name||'–';
-    document.getElementById('metaLevelName').textContent  =currentProject.levelName||'–';
-    document.getElementById('metaPartNumber').textContent =currentProject.levelPart ||1;
+    nameEl.textContent=currentProject.name||'–';
+    levelEl.textContent=currentProject.levelName||'–';
+    partEl.textContent=currentProject.levelPart||1;
     bar.style.display='flex';
 
     // Level-Name auch im Map-Feld anzeigen
@@ -5940,7 +5950,11 @@ function updateText(fileId, lang, value, skipUndo) {
     }
     
     markDirty();
-    
+    // Geänderte Texte sofort sichern
+    if (typeof saveCurrentProject === 'function') {
+        saveCurrentProject();
+    }
+
     updateProgressStats();
     renderProjects(); // HINZUFÜGEN für live Update
 }
@@ -16683,6 +16697,8 @@ if (typeof module !== "undefined" && module.exports) {
         __setFilePathDatabase: db => { filePathDatabase = db; },
         __setTextDatabase: db => { textDatabase = db; },
         __setGetAudioDuration: fn => { getAudioDurationFn = fn; },
+        markDirty,
+        saveCurrentProject,
         autoApplySuggestion,
         insertGptResults,
         updateGptSummary,


### PR DESCRIPTION
## Zusammenfassung
- Speichert übernommene GPT-Bewertungen sofort und markiert Projekte als geändert.
- Sicherung von Textänderungen in allen Spalten erfolgt nun unmittelbar.
- Metaleiste wird nur aktualisiert, wenn passende DOM-Elemente vorhanden sind.

## Testverfahren
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb2dd2eb0883278dbac8d519196288