### PR TITLE
Schnellprojekt vergibt nächste freie Teil-Nummer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.316
+* Schnellprojekt setzt die Teil-Nummer automatisch auf den nächsten freien Wert.
 ## 🛠️ Patch in 1.40.315
 * Schnellprojekt vergibt nun die nächste freie Projektnummer.
 ## 🛠️ Patch in 1.40.314

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Automatische Markierung:** Neue Zeilen werden nach dem Hinzufügen sofort ausgewählt
 * **Context‑Menu** (Rechtsklick): Audio, Kopieren, Einfügen, Ordner öffnen, Löschen
 * **Projekt-Analyse:** Rechtsklick auf ein Projekt prüft Dateien und bietet eine automatische Reparatur an
-* **Schnell hinzufügen:** Rechtsklick auf Level → Schnellprojekt (vergibt die nächste freie Projektnummer), Rechtsklick auf Kapitel → Schnell‑Level
+* **Schnell hinzufügen:** Rechtsklick auf Level → Schnellprojekt (vergibt die nächste freie Projekt- und Teil-Nummer), Rechtsklick auf Kapitel → Schnell‑Level
 * **Debug-Bericht pro Level:** Rechtsklick auf ein Level exportiert relevante Debug-Daten
 * **Drag & Drop:** Projekte und Dateien sortieren
 * **Klick auf Zeilennummer:** Position über Dialog anpassen

--- a/tests/quickAddProjectPart.test.js
+++ b/tests/quickAddProjectPart.test.js
@@ -1,0 +1,52 @@
+const { expect, test } = require('@jest/globals');
+
+let projects = [
+    { id: 1, name: 'Neu 1', levelName: 'Testlevel', levelPart: 1, files: [], icon: '🗂️', color: '#fff', restTranslation: false },
+    { id: 2, name: 'Neu 2', levelName: 'Testlevel', levelPart: 2, files: [], icon: '🗂️', color: '#fff', restTranslation: false }
+];
+
+function getLevelColor() { return '#fff'; }
+function saveProjects() {}
+function renderProjects() {}
+
+function quickAddProject(levelName) {
+    // Alle vergebenen Nummern der "Neu"-Projekte global sammeln
+    const usedNums = new Set();
+    projects.forEach(p => {
+        const m = p.name.match(/^Neu (\d+)$/);
+        if (m) usedNums.add(parseInt(m[1]));
+    });
+
+    // Kleinste noch freie Projektnummer ermitteln
+    let nextNum = 1;
+    while (usedNums.has(nextNum)) {
+        nextNum++;
+    }
+
+    // Nächste freie Teil-Nummer für dieses Level bestimmen
+    const nextPart = Math.max(0, ...projects
+        .filter(p => p.levelName === levelName)
+        .map(p => p.levelPart)) + 1;
+
+    const prj = {
+        id: Date.now(),
+        name: `Neu ${nextNum}`,
+        levelName,
+        levelPart: nextPart,
+        files: [],
+        icon: '🗂️',
+        color: getLevelColor(levelName),
+        restTranslation: false
+    };
+
+    projects.push(prj);
+    saveProjects();
+    renderProjects();
+}
+
+test('quickAddProject vergibt aufsteigende Teil-Nummern', () => {
+    quickAddProject('Testlevel');
+    expect(projects[projects.length - 1].levelPart).toBe(3);
+    quickAddProject('Testlevel');
+    expect(projects[projects.length - 1].levelPart).toBe(4);
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2733,11 +2733,16 @@ function quickAddProject(levelName) {
         nextNum++;
     }
 
+    // Nächste freie Teil-Nummer für dieses Level bestimmen
+    const nextPart = Math.max(0, ...projects
+        .filter(p => p.levelName === levelName)
+        .map(p => p.levelPart)) + 1;
+
     const prj = {
         id: Date.now(),
         name: `Neu ${nextNum}`,
         levelName: levelName,
-        levelPart: 1,
+        levelPart: nextPart,
         files: [],
         icon: '🗂️',
         color: getLevelColor(levelName),


### PR DESCRIPTION
## Zusammenfassung
- Schnellprojekt bestimmt jetzt die nächste freie Teil-Nummer pro Level
- Dokumentation und Changelog entsprechend erweitert
- Unit-Test stellt die fortlaufende Teil-Nummerierung sicher

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbe8f51d048327ab6c4ac805152f30