### PR TITLE
Projektliste zentriert nach Wechsel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.317
+* Projektliste zentriert nach einem Wechsel automatisch das gewählte Projekt.
 ## 🛠️ Patch in 1.40.316
 * Schnellprojekt setzt die Teil-Nummer automatisch auf den nächsten freien Wert.
 ## 🛠️ Patch in 1.40.315

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.300-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.317-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -82,6 +82,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Synchronisierte Projektreparatur:** `repairProjectIntegrity` wartet auf alle Speicherzugriffe und aktualisiert den In-Memory-Cache sofort
 * **Projektliste ohne Auto-Auswahl:** `loadProjects` nimmt optional `skipSelect` entgegen; `reloadProjectList` lädt dadurch nur die Liste und öffnet kein altes Projekt
 * **Fehlerfreier Projektwechsel:** `switchProjectSafe` lädt vor dem Öffnen die Projektliste neu und vermeidet so die Meldung „Projekte konnten nicht geladen werden“
+* **Zentrierter Projektfokus:** Nach einem Projektwechsel scrollt die linke Projektleiste automatisch zum aktiven Eintrag und zentriert ihn
 * **Proaktive Listen-Synchronisierung:** Beim Start und nach einem Speichermodus-Wechsel gleicht `reloadProjectList` alle `project:<id>`-Schlüssel mit `hla_projects` ab und ergänzt fehlende Projekte automatisch
 * **Gesicherte Dateien vor GPT-Reset:** Beim Projektwechsel werden Dateien zuerst gespeichert und erst danach der GPT-Zustand bereinigt
 * **Leere Zeilenreihenfolge beim Projektwechsel:** Neben den GPT-Daten wird auch die Anzeige-Reihenfolge gelöscht

--- a/tests/projectListScrollIntoView.test.js
+++ b/tests/projectListScrollIntoView.test.js
@@ -1,0 +1,47 @@
+/** @jest-environment jsdom */
+// Prüft, ob selectProject die Projektliste nach einem Wechsel zentriert
+const fs = require('fs');
+const path = require('path');
+
+test('selectProject zentriert die Projektliste auf den aktiven Eintrag', () => {
+    // Einfaches DOM mit zwei Projekten vorbereiten
+    document.body.innerHTML = `
+        <ul id="projectList">
+            <li class="project-item" data-project-id="1"></li>
+            <li class="project-item" data-project-id="2"></li>
+        </ul>
+    `;
+    const items = Array.from(document.querySelectorAll('.project-item'));
+    // scrollIntoView mocken, um Aufrufe zu prüfen
+    items.forEach(el => { el.scrollIntoView = jest.fn(); });
+
+    // Benötigte globale Helfer und Daten bereitstellen
+    global.projects = [
+        { id: '1', levelName: 'A', files: [] },
+        { id: '2', levelName: 'B', files: [] }
+    ];
+    global.stopProjectPlayback = jest.fn();
+    global.saveCurrentProject = jest.fn();
+    global.storeSegmentState = jest.fn();
+    global.clearGptState = jest.fn();
+    global.getLevelChapter = () => 'Kapitel';
+    global.renderProjects = jest.fn();
+    global.showToast = jest.fn();
+    global.storage = { setItem: jest.fn(), getItem: jest.fn(() => '1') };
+    global.window = global;
+    global.acquireProjectLock = jest.fn(() => Promise.resolve({ release: jest.fn(), readOnly: false }));
+    global.currentProjectLock = null;
+    global.autoRetryDone = false;
+
+    // selectProject-Funktion aus main.js extrahieren und ausführen
+    const code = fs.readFileSync(path.join(__dirname, '../web/src/main.js'), 'utf8');
+    const start = code.indexOf('function selectProject');
+    const end = code.indexOf('files = currentProject.files', start);
+    const fnCode = code.slice(start, end) + '}';
+    eval(fnCode); // definiert eine verkürzte Version von selectProject
+
+    // Projekt 2 auswählen und Scroll-Aufruf überprüfen
+    selectProject('2');
+    expect(items[1].scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ block: 'center' }));
+});
+

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2823,6 +2823,11 @@ function selectProject(id){
     renderProjects();
     document.querySelectorAll('.project-item')
         .forEach(item=>item.classList.toggle('active',item.dataset.projectId==id));
+    const aktivesProjekt = document.querySelector('.project-item.active');
+    // Nach dem Wechsel die Projektliste auf den gewählten Eintrag zentrieren
+    if (aktivesProjekt && typeof aktivesProjekt.scrollIntoView === 'function') {
+        aktivesProjekt.scrollIntoView({ block: 'center', inline: 'nearest' });
+    }
 
     files = currentProject.files || [];
     segmentInfo = currentProject._segmentInfo || null;


### PR DESCRIPTION
## Zusammenfassung
- Projektleiste scrollt nach einem Wechsel automatisch zum gewählten Projekt
- README und CHANGELOG mit Hinweis auf zentrierten Projektfokus aktualisiert
- Test prüft, dass `selectProject` den aktiven Eintrag in der Projektliste in die Mitte scrollt

## Tests
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf4e32ea48327ab114f1304f1c7ab