### PR TITLE
Show file translation counts per folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.318
+* Ordner-Browser zeigt jetzt Gesamt-, übersetzte und offene Dateien pro Ordner an.
 ## 🛠️ Patch in 1.40.317
 * Projektliste zentriert nach einem Wechsel automatisch das gewählte Projekt.
 ## 🛠️ Patch in 1.40.316

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.317-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.318-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -849,6 +849,7 @@ Ab sofort zeigt diese Auswahl zusätzlich die vorhandenen EN- und DE-Texte des j
 * **📊 Globale Statistiken:** Übersetzungsfortschritt über alle Projekte
 * **📈 Level‑Statistiken:** Aufklappbares Panel mit Details pro Level
 * **🎨 Ordner‑Anpassung:** Icons und Farben individuell einstellbar
+* **📄 Datei‑Zähler:** Zeigt pro Ordner Gesamt‑, fertige und offene Dateien an
 * **🔍 Pfad‑Anzeige:** Status und aufgelöster Pfad für jede Datei
 * **✅ Completion‑Status:** Visuelle Markierung übersetzter Dateien
 * **🔍 Ordner-Textsuche:** Filtert Dateien nach EN- oder DE-Texten

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -7542,7 +7542,9 @@ function showFolderGrid() {
                 <div onclick="showFolderFiles('${folder.name}')" style="cursor: pointer; padding: 15px;">
                     <div class="folder-card-icon">${folderIcon}</div>
                     <div class="folder-card-name">${lastFolderName}</div>
-                    <div class="folder-card-count">${folder.files.length} Dateien</div>
+                    <div class="folder-card-count">${stats.total} Dateien</div>
+                    <!-- Neue Zeile: zeigt übersetzte und offene Dateien an -->
+                    <div class="folder-card-details">${stats.completed} übersetzt · ${stats.total - stats.completed} offen</div>
                     <div class="folder-card-completion ${stats.isComplete ? 'complete' : stats.percentage > 0 ? 'partial' : 'none'}" style="color: ${completionColor};">
                         ${stats.percentage}% übersetzt
                         ${stats.isComplete ? ' ✅' : stats.percentage > 0 ? ' 🔄' : ' ⏳'}

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2099,6 +2099,13 @@ th:nth-child(8) {
             font-size: 12px;
         }
 
+        /* Zusätzliche Statistikzeile im Ordner-Browser */
+        .folder-card-details {
+            color: #bbb;
+            font-size: 12px;
+            margin-top: 4px;
+        }
+
         .folder-files-view {
             display: none;
             max-height: 400px;


### PR DESCRIPTION
## Summary
- display total, translated, and remaining file counts in each folder card
- add styles for new folder statistics row
- document folder file counters in README and changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc38d222a08327a96f2cafb752afaf