### PR TITLE
Bericht-Knopf im Ordner-Browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.321
+* Ordner-Browser besitzt einen neuen „Bericht“-Knopf, der globale Ordnerstatistiken in die Zwischenablage kopiert.
 ## 🛠️ Patch in 1.40.320
 * Projekte aus fehlenden Dateien werden automatisch in Pakete zu höchstens 50 Dateien aufgeteilt.
 ## 🛠️ Patch in 1.40.319

--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ Fehlt eine Abhängigkeit wie PyTorch oder das VC++‑Laufzeitpaket, bricht das S
 ### 3. 📄 Dateien hinzufügen
 * **Über Suche:** Live‑Suche nach Dateinamen oder Textinhalten
 * **Über Browser:** „📁 Ordner durchsuchen" für visuelles Browsen mit Live-Suche im aktuellen Ordner – unterstützt jetzt Suchbegriffe mit Leerzeichen
+* **Bericht:** Im Ordner-Browser erstellt der Knopf **„Bericht“** eine Übersicht aller Ordner samt Übersetzungsfortschritt und kopiert sie in die Zwischenablage
 * **Direct‑Input:** Dateinamen direkt ins Eingabefeld
 
 ### 4. ✏️ Übersetzen

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -460,6 +460,7 @@
             <div class="folder-files-view" id="folderFilesView"></div>
             
             <div class="dialog-buttons">
+                <button class="btn btn-secondary" onclick="copyFolderReport()">Bericht</button>
                 <button class="btn btn-secondary" onclick="closeFolderBrowser()">Schließen</button>
             </div>
         </div>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -7248,6 +7248,45 @@ function calculateFolderCompletionStats() {
 // =========================== CALCFOLDERCOMPLETIONSTATS END ===========================
 
 
+/* =========================== FOLDER REPORT START =========================== */
+function copyFolderReport() {
+    // Statistiken pro Ordner ermitteln
+    const folderStats = calculateFolderCompletionStats();
+
+    let totalFiles = 0;
+    let totalCompleted = 0;
+    const lines = [];
+
+    // Ordner alphabetisch sortieren und Zeilen aufbauen
+    Array.from(folderStats.values())
+        .sort((a, b) => a.folderName.localeCompare(b.folderName))
+        .forEach(stats => {
+            totalFiles += stats.total;
+            totalCompleted += stats.completed;
+            const open = stats.total - stats.completed;
+            lines.push(`${stats.folderName}: ${stats.total} Dateien, ${stats.completed} übersetzt, ${open} offen, ${stats.percentage}%`);
+        });
+
+    const openTotal = totalFiles - totalCompleted;
+    const percent = totalFiles > 0 ? Math.round((totalCompleted / totalFiles) * 100) : 0;
+
+    const reportText = [
+        `Gesamt: ${totalFiles} Dateien, ${totalCompleted} übersetzt, ${openTotal} offen, ${percent}%`,
+        '',
+        ...lines
+    ].join('\n');
+
+    // Text in die Zwischenablage kopieren
+    navigator.clipboard.writeText(reportText)
+        .then(() => updateStatus('📋 Bericht kopiert'))
+        .catch(err => {
+            console.error('Clipboard-Fehler', err);
+            alert('Bericht konnte nicht kopiert werden.');
+        });
+}
+/* =========================== FOLDER REPORT END =========================== */
+
+
         // Auto-scan system for missing permissions
         // Versucht fehlende Dateiberechtigungen ohne Rueckfragen automatisch zu beheben
         function checkAndAutoScan(requiredFiles = [], functionName = 'Funktion') {


### PR DESCRIPTION
## Zusammenfassung
- Bericht-Knopf im Ordner-Browser, der globale Ordnerstatistiken in die Zwischenablage schreibt
- Dokumentation um Bericht-Funktion ergänzt
- Changelog um neue Funktion erweitert

## Testanweisungen
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd99460e0c8327a80ee3ad1446c0d3