### PR TITLE
EM-Störgeräusch mit Anstiegsregler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.322
+* EM-Störgeräusch bietet einen Regler für den Anstieg der Störintensität.
 ## 🛠️ Patch in 1.40.321
 * Ordner-Browser besitzt einen neuen „Bericht“-Knopf, der globale Ordnerstatistiken in die Zwischenablage kopiert.
 ## 🛠️ Patch in 1.40.320

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # hla_translation_tool
 # 🎮 Half‑Life: Alyx Translation Tool
 
-![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.318-green?style=for-the-badge)
+![Half‑Life: Alyx Translation Tool](https://img.shields.io/badge/Version-1.40.322-green?style=for-the-badge)
 ![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
 ![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
 ![Offline](https://img.shields.io/badge/Offline-Ready-green?style=for-the-badge)
@@ -314,7 +314,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Automatischer History-Eintrag:** Beim Lautstärkeabgleich wird das Original gespeichert
 * **Funkgeräte-Effekt:** Alle Parameter (Bandpass, Sättigung, Rauschen, Knackser, Wet) lassen sich bequem per Regler einstellen und werden dauerhaft gespeichert.
 * **Hall-Effekt mit Raumgröße, Hallintensität und Verzögerung:** alle Werte lassen sich justieren und bleiben erhalten.
-* **EM-Störgeräusch mit Intensitätsregler:** fügt elektromagnetische Störungen hinzu; die Stärke ist frei wählbar.
+* **EM-Störgeräusch mit Intensitäts- und Anstiegsregler:** fügt elektromagnetische Störungen hinzu; Stärke und Zeitpunkt des stärkeren Anstiegs sind frei wählbar.
 * **Nebenraum-Effekt:** simuliert gedämpfte Sprache aus einem angrenzenden Raum; optionaler Hall kann zugeschaltet werden.
 * **Optionaler Hall im Nebenraum-Effekt:** wird nun in der Vorschau und beim Speichern korrekt übernommen.
 * **Presets für Funkgeräte-Effekt:** Beliebige Einstellungen lassen sich unter eigenem Namen speichern und später wieder laden.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -801,6 +801,10 @@
                     <label title="Stärke der Störung">Stärke: <span id="emiLevelDisplay"></span>
                         <input type="range" id="emiLevel" min="0" max="1" step="0.05">
                     </label>
+                    <!-- Regler für den Anstiegszeitpunkt -->
+                    <label title="Zeitpunkt des starken Anstiegs">Anstieg ab: <span id="emiRampDisplay"></span>
+                        <input type="range" id="emiRamp" min="0" max="1" step="0.05">
+                    </label>
                 </div>
                 <div class="effect-actions">
                     <button id="emiEffectBoxBtn" class="effect-btn" onclick="applyEmiEffect()" title="EM-Störgeräusch anwenden">EM-Störgeräusch anwenden</button>


### PR DESCRIPTION
## Zusammenfassung
- EM-Störgeräusch erhält einen Regler, der den Zeitpunkt des starken Anstiegs bestimmt
- Reset-Funktion berücksichtigt neue Einstellung und HTML-Oberfläche zeigt zusätzlichen Slider
- README und CHANGELOG ergänzen den neuen Anstiegsregler

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bee3137938832780f69a3ae2dd7edb