### PR TITLE
Nebenraum-Effekt getrennt schaltbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.329
+* Nebenraum- und Hall-Effekt lassen sich über eigene Kontrollkästchen unabhängig aktivieren.
 ## 🛠️ Patch in 1.40.328
 * EM-Störgeräusch-Presets können gespeichert und geladen werden.
 ## 🛠️ Patch in 1.40.327

--- a/README.md
+++ b/README.md
@@ -318,8 +318,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Visualisierung der Störgeräusch-Hüllkurve:** Ein Canvas stellt die berechnete Hüllkurve dar und aktualisiert sich bei jeder Regleränderung.
 * **Sprachdämpfung-Schalter:** Dämpft das Originalsignal synchron zu Aussetzern und Knacksern.
 * **Presets für EM-Störgeräusch:** Individuelle Einstellungen lassen sich speichern und später wieder laden.
-* **Nebenraum-Effekt:** simuliert gedämpfte Sprache aus einem angrenzenden Raum; optionaler Hall kann zugeschaltet werden.
-* **Optionaler Hall im Nebenraum-Effekt:** wird nun in der Vorschau und beim Speichern korrekt übernommen.
+* **Nebenraum- und Hall-Effekt getrennt schaltbar:** Beide Effekte besitzen eigene Kontrollkästchen und lassen sich einzeln oder gemeinsam aktivieren.
 * **Presets für Funkgeräte-Effekt:** Beliebige Einstellungen lassen sich unter eigenem Namen speichern und später wieder laden.
 * **Neues Dialogfeld beim Speichern eines Funkgeräte-Presets:** Die Namenseingabe erfolgt jetzt in einem eigenen Fenster.
 * **Getrennte Effektbereiche:** Funkgerät-, Hall- und Störgeräusch-Einstellungen liegen nun in eigenen Abschnitten des Dialogs.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -848,10 +848,8 @@
             </fieldset>
             <fieldset class="effect-group">
                 <legend>🚪 Nebenraum-Effekt</legend>
-                <label id="neighborHallToggleLabel" class="effect-toggle" title="Hall zum Nebenraum-Effekt hinzufügen"><input type="checkbox" id="neighborHallToggle" onchange="toggleNeighborHall(this.checked)"> Hall hinzufügen</label>
-                <div class="effect-actions">
-                    <button id="neighborEffectBoxBtn" class="effect-btn" onclick="applyNeighborEffect()" title="Nebenraum-Effekt anwenden">Nebenraum-Effekt anwenden</button>
-                </div>
+                <label id="neighborToggleLabel" class="effect-toggle" title="Nebenraum-Effekt ein- oder ausschalten"><input type="checkbox" id="neighborToggle" onchange="toggleNeighborEffect(this.checked)"> Nebenraum-Effekt</label>
+                <label id="neighborHallToggleLabel" class="effect-toggle" title="Hall-Effekt ein- oder ausschalten"><input type="checkbox" id="neighborHallToggle" onchange="toggleNeighborHall(this.checked)"> Hall-Effekt</label>
             </fieldset>
             </div> <!-- edit-right Ende -->
         </div> <!-- edit-flex Ende -->

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -13422,6 +13422,11 @@ async function openDeEdit(fileId) {
         nHall.checked = neighborHall;
         nHall.onchange = e => toggleNeighborHall(e.target.checked);
     }
+    const nToggle = document.getElementById('neighborToggle');
+    if (nToggle) {
+        nToggle.checked = isNeighborEffect;
+        nToggle.onchange = e => toggleNeighborEffect(e.target.checked);
+    }
     const emiVoice = document.getElementById('emiVoiceDampToggle');
     if (emiVoice) {
         emiVoice.checked = emiVoiceDamp;
@@ -13862,12 +13867,16 @@ function updateEffectButtons() {
         emiBoxBtn.classList.toggle('active', isEmiEffect);
     }
     const neighborBtn = document.getElementById('neighborEffectBtn');
-    const neighborBoxBtn = document.getElementById('neighborEffectBoxBtn');
+    const neighborLabel = document.getElementById('neighborToggleLabel');
+    const neighborToggle = document.getElementById('neighborToggle');
     if (neighborBtn) {
         neighborBtn.classList.toggle('active', isNeighborEffect);
     }
-    if (neighborBoxBtn) {
-        neighborBoxBtn.classList.toggle('active', isNeighborEffect);
+    if (neighborLabel) {
+        neighborLabel.classList.toggle('active', isNeighborEffect);
+    }
+    if (neighborToggle) {
+        neighborToggle.checked = isNeighborEffect;
     }
 }
 
@@ -14054,6 +14063,17 @@ async function applyNeighborEffect() {
     updateEffectButtons();
 }
 // =========================== APPLYNEIGHBOREFFECT END ========================
+
+// Schaltet den Nebenraum-Effekt abhängig vom Kontrollkästchen ein oder aus
+function toggleNeighborEffect(active) {
+    if (active) {
+        applyNeighborEffect();
+    } else {
+        isNeighborEffect = false;
+        recomputeEditBuffer();
+        updateEffectButtons();
+    }
+}
 
 // Schaltet den optionalen Hall für den Nebenraum-Effekt
 function toggleNeighborHall(active) {


### PR DESCRIPTION
## Zusammenfassung
- Nebenraum-Effekt besitzt nun ein eigenes Kontrollkästchen und kann unabhängig vom Hall-Effekt aktiviert werden.
- Neuer Toggle für den Nebenraum-Effekt im JavaScript sorgt für sauberes Ein- und Ausschalten.
- Dokumentation und Changelog aktualisiert.

## Test
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c58e8ab6c88327b3e0debb7225a09c