### PR TITLE
Aktiviere Hall-Effekt ohne Nebenraum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.330
+* Hall-Effekt des Nebenraum-Dialogs funktioniert nun auch ohne aktivierten Nebenraum-Effekt.
 ## 🛠️ Patch in 1.40.329
 * Nebenraum- und Hall-Effekt lassen sich über eigene Kontrollkästchen unabhängig aktivieren.
 ## 🛠️ Patch in 1.40.328

--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Sprachdämpfung-Schalter:** Dämpft das Originalsignal synchron zu Aussetzern und Knacksern.
 * **Presets für EM-Störgeräusch:** Individuelle Einstellungen lassen sich speichern und später wieder laden.
 * **Nebenraum- und Hall-Effekt getrennt schaltbar:** Beide Effekte besitzen eigene Kontrollkästchen und lassen sich einzeln oder gemeinsam aktivieren.
+* **Hall-Effekt im Nebenraum-Dialog separat nutzbar:** Der Hall des Nebenraums kann nun auch ohne aktivierten Nebenraum-Effekt verwendet werden.
 * **Presets für Funkgeräte-Effekt:** Beliebige Einstellungen lassen sich unter eigenem Namen speichern und später wieder laden.
 * **Neues Dialogfeld beim Speichern eines Funkgeräte-Presets:** Die Namenseingabe erfolgt jetzt in einem eigenen Fenster.
 * **Getrennte Effektbereiche:** Funkgerät-, Hall- und Störgeräusch-Einstellungen liegen nun in eigenen Abschnitten des Dialogs.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -13987,6 +13987,9 @@ async function recomputeEditBuffer() {
     }
     if (isNeighborEffect) {
         buf = await applyNeighborRoomEffect(buf, { hall: neighborHall });
+    } else if (neighborHall) {
+        // Nur der Nebenraum-Hall ist aktiv: wende den Raumklang separat an
+        buf = await applyReverbEffect(buf, { room: 0.2, wet: 0.3, delay: 40 });
     }
     if (isEmiEffect) {
         buf = await applyInterferenceEffect(buf);
@@ -14075,11 +14078,11 @@ function toggleNeighborEffect(active) {
     }
 }
 
-// Schaltet den optionalen Hall für den Nebenraum-Effekt
+// Schaltet den optionalen Hall für den Nebenraum-Effekt oder als alleinstehenden Raumklang
 function toggleNeighborHall(active) {
     neighborHall = active;
     storage.setItem('hla_neighborHall', active ? '1' : '0');
-    if (isNeighborEffect) recomputeEditBuffer();
+    recomputeEditBuffer();
     updateEffectButtons();
 }
 


### PR DESCRIPTION
## Zusammenfassung
- Erlaube den Hall-Effekt des Nebenraum-Dialogs auch ohne aktivierten Nebenraum
- Stelle sicher, dass das Umschalten des Nebenraum-Halls immer die Vorschau neu berechnet
- Dokumentation und Changelog für die neue Funktion ergänzt

## Testen
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c59246b3d08327b7d13e9f5b638009