### PR TITLE
Hall-Effekt beim Speichern ohne Nebenraum-Effekt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.331
+* Hall-Effekt wird beim Speichern angewendet, auch wenn der Nebenraum-Effekt deaktiviert ist.
 ## 🛠️ Patch in 1.40.330
 * Hall-Effekt des Nebenraum-Dialogs funktioniert nun auch ohne aktivierten Nebenraum-Effekt.
 ## 🛠️ Patch in 1.40.329

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Presets für EM-Störgeräusch:** Individuelle Einstellungen lassen sich speichern und später wieder laden.
 * **Nebenraum- und Hall-Effekt getrennt schaltbar:** Beide Effekte besitzen eigene Kontrollkästchen und lassen sich einzeln oder gemeinsam aktivieren.
 * **Hall-Effekt im Nebenraum-Dialog separat nutzbar:** Der Hall des Nebenraums kann nun auch ohne aktivierten Nebenraum-Effekt verwendet werden.
+* **Hall-Effekt wird auch ohne Nebenraum-Effekt gespeichert:** Beim Speichern bleibt der Hall erhalten, selbst wenn der Nebenraum-Effekt deaktiviert ist.
 * **Presets für Funkgeräte-Effekt:** Beliebige Einstellungen lassen sich unter eigenem Namen speichern und später wieder laden.
 * **Neues Dialogfeld beim Speichern eines Funkgeräte-Presets:** Die Namenseingabe erfolgt jetzt in einem eigenen Fenster.
 * **Getrennte Effektbereiche:** Funkgerät-, Hall- und Störgeräusch-Einstellungen liegen nun in eigenen Abschnitten des Dialogs.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -14992,6 +14992,8 @@ async function applyDeEdit() {
         }
         if (isHallEffect) {
             baseBuffer = await applyReverbEffect(baseBuffer);
+        } else if (neighborHall) {
+            baseBuffer = await applyReverbEffect(baseBuffer, { room: 0.2, wet: 0.3, delay: 40 });
         }
         // Nebenraum-Effekt anwenden, falls aktiv
         if (isNeighborEffect) {


### PR DESCRIPTION
## Zusammenfassung
- Hall wird beim Speichern angewendet, wenn `neighborHall` gesetzt ist, auch ohne Nebenraum-Effekt.
- README und CHANGELOG um entsprechende Hinweise ergänzt.

## Test
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5945408288327a37133a17368c92a