### PR TITLE
LocalIndex-API entschlackt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.337
+* Browser-Modul `web/src/localIndex.js` entfernt die ungenutzte Methode `remove`; der Index wird bei Bedarf vollständig neu aufgebaut.
+* README dokumentiert den abgespeckten `LocalIndex` samt Fokus auf `add` und `search`.
 ## 🛠️ Patch in 1.40.336
 * Ungenutztes Node-Modul `utils/dataLayout.js` entfernt; Browser-Storage bleibt als einzige Quelle für Journaling-Helfer.
 * Dokumentation passt Datenlayout-Beschreibung und Funktionsliste an den Wegfall der Blob-Verwaltung an.

--- a/README.md
+++ b/README.md
@@ -1157,4 +1157,5 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`validateProjectManifest(data)`** – prüft `project.json` gegen ein Zod-Schema und stellt sicher, dass `schemaVersion` und Name vorhanden sind.
   * **`switchProjectSafe(id)`** – wechselt Projekte atomar, bricht laufende Vorgänge ab, leert GPT-Zustände und repariert Verweise.
   * **`switchStorageSafe(mode)`** – wechselt das Speichersystem mit bereinigten Caches und gestopptem Autosave.
+  * **`LocalIndex`** – kleiner invertierter Index für lokale Volltextsuchen innerhalb eines Projekts; bietet `add(id, text)` zum Aufbau sowie `search(term)` für Trefferlisten. Beim Entfernen von Dateien wird der Index derzeit komplett neu aufgebaut, eine separate `remove`-Methode existiert nicht mehr.
   * **Beim Start** wird jetzt `navigator.storage.persist()` ausgeführt; zusammen mit `navigator.storage.estimate()` zeigt die Oberfläche an, wie viel lokaler Speicher verfügbar bleibt.

--- a/web/src/localIndex.js
+++ b/web/src/localIndex.js
@@ -20,20 +20,6 @@ export class LocalIndex {
     }
 
     /**
-     * Entfernt alle Einträge einer ID aus dem Index.
-     * @param {string} id   Kennung
-     * @param {string} text zu entfernender Text
-     */
-    remove(id, text) {
-        for (const token of tokenize(text)) {
-            const set = this.map[token];
-            if (!set) continue;
-            set.delete(id);
-            if (set.size === 0) delete this.map[token];
-        }
-    }
-
-    /**
      * Sucht nach einem Token und liefert die passenden IDs.
      * @param {string} term Suchbegriff
      * @returns {string[]} Liste der passenden IDs


### PR DESCRIPTION
## Zusammenfassung
- entferne die ungenutzte Methode `remove` aus `web/src/localIndex.js`
- aktualisiere README und Changelog, um die neue LocalIndex-API zu dokumentieren

## Tests
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cd763ac2988327be8bbd526e49eaad