### PR TITLE
Leert das Suchfeld im Video-Manager beim Öffnen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 🛠️ Patch in 1.40.340
+* Video-Manager setzt das Suchfeld beim Öffnen zurück, damit keine alten Filter hängen bleiben.
 ## 🛠️ Patch in 1.40.339
 * `utils/videoFrameUtils.js` entfernt sämtliche Storyboard-Helfer; `extractTime` bleibt als einziger Export.
 * README dokumentiert den Wegfall des Storyboard-Fallbacks und die ausschließliche Nutzung von ffmpeg-Vorschaubildern.

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Gethrottleter Video-ResizeObserver:** `adjustVideoPlayerSize` und `positionOverlay` werden pro Frame gebündelt ausgeführt und umgehen so Endlos-Schleifen.
 * **Dynamische Größenberechnung:** `calcLayout()` ermittelt Breite und Höhe des Players aus Dialog- und Panelgröße und wird per `ResizeObserver` automatisch aufgerufen.
 * **Exportfunktion für Video-Bookmarks:** Gespeicherte Links lassen sich als `videoBookmarks.json` herunterladen.
-* **Dauerhafte Video-Suche:** Der Suchbegriff im Video-Manager bleibt zwischen den Sitzungen erhalten.
+* **Leeres Suchfeld beim Öffnen:** Der Filter im Video-Manager wird jedes Mal zurückgesetzt, damit alle gespeicherten Links sofort sichtbar sind.
 * **Responsiver Video-Manager:** Fester Dialog-Abstand, flexible Toolbar mit Min-Buttons und kompaktem ❌-Icon bei schmaler Breite. Tabellenzeilen besitzen gleichmäßiges Padding und einen Hover-Effekt.
 * **Robuster Video-Dialog:** Das Flex-Layout verhindert Überlappungen und lässt jede Sektion dynamisch wachsen.
 * **Stabileres Grid-Layout im Video-Manager:** Die Aufteilung nutzt jetzt CSS-Grid und die Anzeige aller Dialoge wird komplett über die Klasse `.hidden` gesteuert.

--- a/web/renderer.js
+++ b/web/renderer.js
@@ -136,7 +136,6 @@ videoGrid.addEventListener('click', async e=>{
 });
 
 videoFilter.addEventListener('input', ()=>{
-    storage.setItem('hla_videoFilter', videoFilter.value);
     refreshTable();
 });
 
@@ -200,6 +199,8 @@ async function updateBookmark(index, raw, list){
 openMgr.addEventListener('click', async ()=>{
     if (videoDlg.open) return;
     videoDlg.showModal();
+    // Suchfeld beim Öffnen bewusst leeren, damit alle Videos sichtbar sind
+    videoFilter.value = '';
     await refreshTable();
 });
 
@@ -209,8 +210,5 @@ function closeDialog(){
 closeDlg.addEventListener('click', closeDialog);
 if (closeDlgSmall) closeDlgSmall.addEventListener('click', closeDialog);
 videoDlg.addEventListener('cancel', closeDialog);
-
-const savedFilter = storage.getItem('hla_videoFilter') || '';
-if (savedFilter) videoFilter.value = savedFilter;
 
 refreshTable();


### PR DESCRIPTION
## Zusammenfassung
- Entfernt das Zwischenspeichern des Video-Filters und leert das Suchfeld bei jedem Öffnen des Managers.
- Dokumentiert das neue Verhalten im README und ergänzt den Changelog.

## Tests
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cd826ba1a88327bea830cbb3e7bbcc