### PR TITLE
Vereinfache addFileToProject-Signatur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.341
+* `web/src/main.js` vereinfacht `addFileToProject` auf die Parameter `filename` und `folder`; alle Aufrufe arbeiten ohne das frühere Ergebnisobjekt.
+* README und Changelog dokumentieren die neue Funktionssignatur für Entwicklerinnen und Entwickler.
 ## 🛠️ Patch in 1.40.340
 * Video-Manager setzt das Suchfeld beim Öffnen zurück, damit keine alten Filter hängen bleiben.
 ## 🛠️ Patch in 1.40.339

--- a/README.md
+++ b/README.md
@@ -1139,6 +1139,7 @@ verwendet werden, um optionale Downloads zu überspringen.
 * **`copyDubbedFile(originalPath, tempDubPath)`** – verschiebt eine heruntergeladene Dub-Datei in den deutschen Ordnerbaum.
 * **`extractRelevantFolder(parts)`** – gibt den relevanten Abschnitt eines Dateipfades ab "vo" oder ohne führendes "sounds" zurück (siehe `web/src/pathUtils.js`).
 * **`calculateProjectStats(project)`** – ermittelt pro Projekt den Übersetzungs‑ und Audio‑Fortschritt. Diese Funktion wird auch in den Tests ausführlich geprüft.
+* **`addFileToProject(filename, folder)`** – fügt eine neue Datei anhand von Dateiname und Ordner in das aktuell geladene Projekt ein; weitere Metadaten wie Texte werden direkt aus den globalen Datenbanken abgerufen, daher ist kein dritter Parameter mehr nötig.
 * **`ipcContracts.ts`** – definiert Typen für die IPC-Kommunikation zwischen Preload und Hauptprozess.
 * **`syncProjectData(projects, filePathDatabase, textDatabase)`** – gleicht Projekte mit der Datenbank ab, korrigiert Dateiendungen und überträgt Texte.
 * **`repairFileExtensions(projects, filePathDatabase, textDatabase)`** – aktualisiert veraltete Dateiendungen in Projekten und verschiebt vorhandene Texte.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -15913,17 +15913,17 @@ async function addFromSearch(result) {
 
                 // Nur hinzufügen, wenn Text gleich ist und Datei noch nicht vorhanden
                 if (!already && baseEn && pathEn && pathEn === baseEn) {
-                    addFileToProject(result.filename, p.folder, result);
+                    addFileToProject(result.filename, p.folder);
                 }
             });
         } else {
             // Verwende ausgewählten Pfad
             const selectedPath = paths[selection.selectedIndex];
-            addFileToProject(result.filename, selectedPath.folder, result);
+            addFileToProject(result.filename, selectedPath.folder);
         }
     } else {
         // Nur ein Pfad oder bereits spezifischer Pfad aus Suchergebnis
-        addFileToProject(result.filename, result.folder, result);
+        addFileToProject(result.filename, result.folder);
     }
 }
 
@@ -16122,7 +16122,7 @@ function playPreview(fullPath) {
 
 // Hilfsfunktion zum Hinzufügen einer Datei zum Projekt
 // fullPath wird nicht mehr als Parameter übergeben
-function addFileToProject(filename, folder, originalResult) {
+function addFileToProject(filename, folder) {
     const fileKey = `${folder}/${filename}`;
     const newFile = {
         id: Date.now() + Math.random(),


### PR DESCRIPTION
## Summary
- entferne den dritten Parameter aus addFileToProject und passe alle internen Aufrufe an
- dokumentiere die neue Signatur in README und CHANGELOG

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd86a7b9388327a22fc90a3d3209f8