### PR TITLE
Remove fullPath argument from extractRelevantFolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.342
+* `extractRelevantFolder` erwartet nur noch das Ordner-Array; der ungenutzte Parameter für vollständige Pfade wurde entfernt und alle Aufrufe angepasst.
+* README und Changelog dokumentieren die verschlankte Signatur für Frontend-Helfer.
 ## 🛠️ Patch in 1.40.341
 * `web/src/main.js` vereinfacht `addFileToProject` auf die Parameter `filename` und `folder`; alle Aufrufe arbeiten ohne das frühere Ergebnisobjekt.
 * README und Changelog dokumentieren die neue Funktionssignatur für Entwicklerinnen und Entwickler.

--- a/README.md
+++ b/README.md
@@ -1137,7 +1137,7 @@ verwendet werden, um optionale Downloads zu überspringen.
 * **`saveDeHistoryBuffer(relPath, data)`** – legt einen Buffer als neue History-Version ab.
 * **`chooseExisting(base, names)`** – liefert den ersten existierenden Ordnernamen und wirft einen Fehler bei leerer Liste.
 * **`copyDubbedFile(originalPath, tempDubPath)`** – verschiebt eine heruntergeladene Dub-Datei in den deutschen Ordnerbaum.
-* **`extractRelevantFolder(parts)`** – gibt den relevanten Abschnitt eines Dateipfades ab "vo" oder ohne führendes "sounds" zurück (siehe `web/src/pathUtils.js`).
+* **`extractRelevantFolder(parts)`** – gibt den relevanten Abschnitt eines Dateipfades ab "vo" oder ohne führendes "sounds" zurück (siehe `web/src/pathUtils.js`). Der frühere zweite Parameter mit dem vollständigen Pfad entfällt; das Array der Ordnerteile reicht aus.
 * **`calculateProjectStats(project)`** – ermittelt pro Projekt den Übersetzungs‑ und Audio‑Fortschritt. Diese Funktion wird auch in den Tests ausführlich geprüft.
 * **`addFileToProject(filename, folder)`** – fügt eine neue Datei anhand von Dateiname und Ordner in das aktuell geladene Projekt ein; weitere Metadaten wie Texte werden direkt aus den globalen Datenbanken abgerufen, daher ist kein dritter Parameter mehr nötig.
 * **`ipcContracts.ts`** – definiert Typen für die IPC-Kommunikation zwischen Preload und Hauptprozess.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -7656,7 +7656,7 @@ function cleanupIncorrectFolderNames() {
                     if (realPath.endsWith('/' + filename)) {
                         // Finde den korrekten Ordner für diese Datei
                         const parts = realPath.split('/');
-                        const correctFolder = extractRelevantFolder(parts.slice(0, -1), realPath);
+                        const correctFolder = extractRelevantFolder(parts.slice(0, -1));
                         
                         // Prüfe ob wir schon einen Eintrag für diesen Ordner haben
                         const alreadyHasCorrectFolder = correctPaths.some(p => p.folder === correctFolder);
@@ -11940,7 +11940,7 @@ async function verarbeiteGescannteDateien(dateien) {
         const relPath  = file.fullPath;
         const parts    = relPath.split('/');
         const filename = parts.pop();
-        const folder   = extractRelevantFolder(parts, relPath);
+        const folder   = extractRelevantFolder(parts);
 
         if (!filePathDatabase[filename]) filePathDatabase[filename] = [];
 

--- a/web/src/pathUtils.js
+++ b/web/src/pathUtils.js
@@ -1,7 +1,8 @@
 // Hilfsfunktionen für Pfadoperationen
 
-function extractRelevantFolder(folderParts, fullPath) {
+function extractRelevantFolder(folderParts) {
     // Gibt den relevanten Ordnerpfad einer Datei zurück.
+    // Wir benötigen nur die Ordnerteile, um die Struktur zu bestimmen.
     // Enthält der Pfad einen "vo"-Ordner, liefern wir alles ab diesem Punkt
     // (inklusive "vo") zurück, um die komplette Struktur zu bewahren.
 


### PR DESCRIPTION
## Summary
- remove the unused `fullPath` parameter from `extractRelevantFolder`
- update callers to pass only folder parts
- document the streamlined signature in the README and changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd87bfba208327b19db009fcffa93f