### PR TITLE
Nutze gemeinsamen extractTime-Helfer im Web-Frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.343
+* `web/src/main.js` bindet `extractTime` aus `utils/videoFrameUtils.js` ein, damit Video-Zeitstempel überall identisch berechnet werden.
+* README und Changelog dokumentieren die gemeinsame Nutzung des YouTube-Helfers.
 ## 🛠️ Patch in 1.40.342
 * `extractRelevantFolder` erwartet nur noch das Ordner-Array; der ungenutzte Parameter für vollständige Pfade wurde entfernt und alle Aufrufe angepasst.
 * README und Changelog dokumentieren die verschlankte Signatur für Frontend-Helfer.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Kompakter GPT-Versand:** Doppelte Zeilen werden zusammengefasst. Der Startdialog zeigt an, wie viele Zeilen wirklich übertragen werden.
 * **Schlanker Video-Bereich:** Gespeicherte Links öffnen sich im Browser. Interner Player und OCR wurden entfernt.
 * **Video-Bookmarks:** Speichert Links für einen schnellen Zugriff.
+* **Gemeinsamer Zeitstempel-Helfer:** Hauptoberfläche und Video-Manager nutzen `utils/videoFrameUtils.js` für identische Startzeiten.
 * **Löschen per Desktop-API:** Einzelne Bookmarks lassen sich über einen IPC-Kanal entfernen.
 * **Tests für Video-Bookmarks:** Überprüfen Laden, Sortierung sowie Hinzufügen und Entfernen von Einträgen.
 * **Tests für Segment-Dialog:** Stellt sicher, dass analysierte Segmente gespeichert und wieder geladen werden.


### PR DESCRIPTION
## Zusammenfassung
- `web/src/main.js` lädt `extractTime` aus `utils/videoFrameUtils.js` sowohl im Node- als auch im Browser-Zweig und ersetzt die lokale Implementierung.
- Fehlerfälle fangen den fehlgeschlagenen CommonJS-Import ab und nutzen denselben Helfer asynchron.
- README und CHANGELOG dokumentieren den gemeinsamen Einsatz des Video-Helfers.

## Tests
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cd8979b0408327a99207aca555a998