### PR TITLE
Entferne switchStorageSafe und aktualisiere Dokumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.346
+* `web/src/projectSwitch.js` entfernt `switchStorageSafe`; Speichermodus-Wechsel laufen wieder über den vorhandenen Helfer `switchStorage` in `web/src/main.js`.
+* README und Changelog verweisen auf den Standard-Helfer für den Speichermoduswechsel.
 ## 🛠️ Patch in 1.40.345
 * `web/src/gptService.js` entfernt den Export `getEmotionPrompt`; das Emotion-Prompt bleibt ausschließlich intern verfügbar.
 * README und Changelog vermerken, dass der Helfer nicht mehr öffentlich angeboten wird.

--- a/README.md
+++ b/README.md
@@ -1163,6 +1163,6 @@ verwendet werden, um optionale Downloads zu überspringen.
     Die Browser-Variante kümmert sich weiterhin um Journale; eine Blob-Aufräumroutine existiert derzeit nicht mehr.
   * **`validateProjectManifest(data)`** – prüft `project.json` gegen ein Zod-Schema und stellt sicher, dass `schemaVersion` und Name vorhanden sind.
   * **`switchProjectSafe(id)`** – wechselt Projekte atomar, bricht laufende Vorgänge ab, leert GPT-Zustände und repariert Verweise.
-  * **`switchStorageSafe(mode)`** – wechselt das Speichersystem mit bereinigten Caches und gestopptem Autosave.
+  * **`switchStorage(targetMode)`** – wechselt das Speichersystem ohne Migration, setzt globale Zustände zurück und lädt Projektliste und Wörterbuch neu.
   * **`LocalIndex`** – kleiner invertierter Index für lokale Volltextsuchen innerhalb eines Projekts; bietet `add(id, text)` zum Aufbau sowie `search(term)` für Trefferlisten. Beim Entfernen von Dateien wird der Index derzeit komplett neu aufgebaut, eine separate `remove`-Methode existiert nicht mehr.
   * **Beim Start** wird jetzt `navigator.storage.persist()` ausgeführt; zusammen mit `navigator.storage.estimate()` zeigt die Oberfläche an, wie viel lokaler Speicher verfügbar bleibt.


### PR DESCRIPTION
## Zusammenfassung
- entfernt `switchStorageSafe` aus `web/src/projectSwitch.js` und belässt nur den Projektwechsel-Helfer auf dem Window-Objekt
- aktualisiert die README mit dem Verweis auf `switchStorage(targetMode)`
- ergänzt den Changelog um den Hinweis auf den Standard-Helfer für Speichermodus-Wechsel

## Tests
- npm test -- projectSwitch
- npm test -- switchStorage

------
https://chatgpt.com/codex/tasks/task_e_68cd969378588327a78de8bfeb39f82a