### PR TITLE
Score-Spalte bereinigt: applySuggestion entfernt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.348
+* `web/src/scoreColumn.js` entfernt den ungenutzten Helfer `applySuggestion`, sodass die Score-Spalte ausschließlich Kommentare präsentiert.
+* README und Changelog dokumentieren die bereinigte Score-Spalte ohne automatische Übernahmevorschläge.
 ## 🛠️ Patch in 1.40.347
 * `electron/preload.cjs` entfernt die ehemalige Capture-Bridge und verlässt sich ausschließlich auf die bestehenden Preload-Schnittstellen.
 * README und Changelog beschreiben nur noch die tatsächlich genutzte `window.videoApi` für Renderer-Aufrufe.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Feineres Bewertungsschema:** Ab 95 % wird der Score grün, zwischen 85 % und 94 % gelb
 * **Score in Prozent:** Die Bewertung wird in der Tabelle mit Prozentzeichen dargestellt
 * **Aktive Score-Events:** Nach jedem Rendern bindet `attachScoreHandlers` Tooltip und Klick
+* **Bereinigte Score-Aktionen:** Die Score-Spalte verzichtet auf den früheren Helfer `applySuggestion` und konzentriert sich auf die Kommentar-Anzeige
 * **Bugfix:** Verwaiste Vorschlagsfelder lösen beim Laden kein Fehlerereignis mehr aus
 * **Validierte Vorschlagsfelder:** Fehlt die zugehörige Datei, wird der Eintrag entfernt und eine Meldung weist darauf hin
 * **Debug-Bericht bei fehlender Vorschlagsdatei:** Nach dem Entfernen öffnet sich ein Fenster zum Speichern einzelner Berichte

--- a/web/src/scoreColumn.js
+++ b/web/src/scoreColumn.js
@@ -75,20 +75,6 @@ export function closeScoreTooltip() {
     if (box) box.remove();
 }
 
-function applySuggestion(id, files) {
-    const file = files.find(f => f.id === id);
-    if (!file || !file.suggestion) return;
-    file.deText = file.suggestion;
-    markDirty();
-    const row = document.querySelector(`tr[data-id='${id}']`);
-    const deCell = row?.querySelectorAll('textarea.text-input')[1];
-    if (deCell) {
-        deCell.value = file.deText;
-        deCell.classList.add('blink-blue');
-        setTimeout(() => deCell.classList.remove('blink-blue'), 600);
-    }
-}
-
 // Export für Node-Tests
 if (typeof module !== 'undefined') {
     module.exports = {


### PR DESCRIPTION
## Zusammenfassung
- entferne die ungenutzte Funktion `applySuggestion` aus `web/src/scoreColumn.js`, damit nur noch die Kommentar-Anzeige der Score-Spalte aktiv bleibt
- dokumentiere die Bereinigung in README und CHANGELOG, inklusive Hinweis auf die fehlende Vorschlagsübernahme

## Tests
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdaaa6d1188327a9f99f1b7da12caf