### PR TITLE
Entferne switchStorageDirection aus der Migration-UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.350
+* `web/src/migrationUI.js` entfernt den UI-Helfer `switchStorageDirection`; Speicherwechsel laufen direkt über die bestehende Funktion `switchStorage`.
+* README und Changelog vermerken den Wegfall des Richtungsschalters in der Migration-Oberfläche.
 ## 🛠️ Patch in 1.40.349
 * `web/src/elevenlabs.js` entfernt den ungenutzten Export `isDubReady`; Statusabfragen erfolgen ausschließlich über `web/src/dubbing.js`.
 * README und Changelog dokumentieren die verschobene Statusprüfung und die abgespeckte Exportliste.

--- a/README.md
+++ b/README.md
@@ -1155,6 +1155,7 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`startMigration()`** – startet den Export, zeigt alte und neue Eintragsanzahl sowie den Zielordner in der Oberfläche an.
   * **`importLocalStorageFromOpfs()`** – liest die Datei `hla_daten.json` aus dem OPFS, ersetzt den aktuellen LocalStorage und gibt die Anzahl der geladenen Einträge zurück.
   * **`loadMigration()`** – UI-Helfer, der den Import startet und Statusmeldungen anzeigt.
+  * **Entfernt:** Der frühere UI-Helfer `switchStorageDirection` entfällt; Speichermodus-Wechsel erfolgen direkt über `switchStorage`.
   * **`cleanupProject.js`** – nutzt `removeUnknownFileIds`, um Datei-IDs mit einer Liste aus der Oberfläche abzugleichen und unbekannte Einträge zu entfernen. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.
   * **`removeUnknownFileIds(project, ids, logFn)`** – Hilfsfunktion, die alle Dateien mit unbekannter ID entfernt und jede Entfernung protokolliert.
   * **`createStorage(type)`** – liefert je nach Typ ein Speicher-Backend; neben `localStorage` steht nun `indexedDB` zur Verfügung, das Daten je Objekt in eigenen Stores ablegt, große Dateien im OPFS oder als Blob auslagert und ohne Benutzerschlüssel auskommt.

--- a/web/src/migrationUI.js
+++ b/web/src/migrationUI.js
@@ -44,14 +44,3 @@ window.migrateData = async function() {
     }
 };
 
-// Optionaler Wechsel mit expliziter Richtung zur Verdeutlichung des Zielsystems
-window.switchStorageDirection = async function(von, zu) {
-    const statusEl = document.getElementById('migration-status');
-    statusEl.textContent = `Wechsle von ${von} zu ${zu} ...`;
-    try {
-        await window.switchStorage(zu);
-        statusEl.textContent = `Wechsel zu ${zu} abgeschlossen.`;
-    } catch (err) {
-        statusEl.textContent = `Fehler beim Wechsel: ${err.message}`;
-    }
-};


### PR DESCRIPTION
## Summary
- entferne den nicht mehr benötigten UI-Helfer `switchStorageDirection` aus der Migration-Oberfläche
- aktualisiere README und Changelog, damit der Wegfall des Richtungsschalters dokumentiert ist

## Testing
- npm test -- migrationUI.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cdb6540f4483279e5b0519f13d85b0