### PR TITLE
Remove setStorageAdapter helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.352
+* `web/src/projectHelpers.js` entfernt den globalen Setter `setStorageAdapter`; Speicherwechsel setzen weiterhin auf `switchStorage` aus `web/src/main.js`.
+* README und Changelog dokumentieren, dass globale Speicherwechsel über die vorhandene Funktion erfolgen und kein separater Setter mehr nötig ist.
 ## 🛠️ Patch in 1.40.351
 * `extensionUtils.js` entfernt die Hilfsfunktion `syncProjectData` samt Export und `window`-Alias; übrig bleibt `repairFileExtensions`.
 * Testsuite und Dokumentation verweisen nicht länger auf `syncProjectData` und beschreiben den Funktionswegfall.

--- a/README.md
+++ b/README.md
@@ -1159,6 +1159,7 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`removeUnknownFileIds(project, ids, logFn)`** – Hilfsfunktion, die alle Dateien mit unbekannter ID entfernt und jede Entfernung protokolliert.
   * **Entfernt:** Die frühere Hilfsfunktion `syncProjectData` steht nicht mehr zur Verfügung, da ihre Aufgaben vollständig von `repairFileExtensions` abgedeckt werden.
   * **`createStorage(type)`** – liefert je nach Typ ein Speicher-Backend; neben `localStorage` steht nun `indexedDB` zur Verfügung, das Daten je Objekt in eigenen Stores ablegt, große Dateien im OPFS oder als Blob auslagert und ohne Benutzerschlüssel auskommt.
+  * **Entfernt:** Der frühere Setter `setStorageAdapter` steht nicht mehr unter `window`; Speichermodus-Wechsel greifen ausschließlich auf `switchStorage` zurück und erzeugen neue Adapter bei Bedarf über `createStorage`.
   * **`storage.capabilities`** – liefert Feature-Flags wie `blobs` (`opfs`, `file` oder `none`) und `atomicWrite`, sodass die Oberfläche fehlende OPFS-Unterstützung erkennen und ausweichen kann.
   * **`storage.runTransaction(async tx => { ... })`** – führt mehrere Schreibvorgänge gebündelt aus und bricht bei Fehlern komplett ab.
   * **`acquireProjectLock(id)`** – verhandelt einen exklusiven Schreibzugriff pro Projekt und schaltet weitere Fenster in den Nur-Lesen-Modus.

--- a/web/src/projectHelpers.js
+++ b/web/src/projectHelpers.js
@@ -132,11 +132,6 @@ function getStorageAdapter(mode) {
   return null;
 }
 
-// Setzt das globale Speicher-Backend
-function setStorageAdapter(adapter) {
-  window.storage = adapter;
-}
-
 // Repariert offensichtliche Inkonsistenzen im Projekt
 // Prüft dabei das neue Namensschema "project:<id>:meta" und "project:<id>:index"
 // Liefert true zurück, wenn das Projekt neu angelegt wurde
@@ -253,6 +248,5 @@ window.getStorageAdapter = getStorageAdapter;
 window.repairProjectIntegrity = repairProjectIntegrity;
 window.syncProjectListWithStorage = syncProjectListWithStorage;
 window.resumeAutosave = resumeAutosave;
-window.setStorageAdapter = setStorageAdapter;
 window.reloadProjectList = reloadProjectList;
 


### PR DESCRIPTION
## Summary
- entferne den globalen Setter `setStorageAdapter` aus `web/src/projectHelpers.js`
- dokumentiere, dass Speichermodus-Wechsel ausschließlich über `switchStorage` laufen

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdc8502d688327bace0271fa417347