### PR TITLE
Refaktorisiert Cheat-Voreinstellungen in launch_hla

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.353
+* `launch_hla.py` bündelt die Cheat-Voreinstellungen als Modulkonstante `CHEAT_ARGS`, damit beide Startpfade dieselben Parameter verwenden.
+* README und Changelog vermerken die zentrale Konstante für konsistente Cheat-Voreinstellungen.
 ## 🛠️ Patch in 1.40.352
 * `web/src/projectHelpers.js` entfernt den globalen Setter `setStorageAdapter`; Speicherwechsel setzen weiterhin auf `switchStorage` aus `web/src/main.js`.
 * README und Changelog dokumentieren, dass globale Speicherwechsel über die vorhandene Funktion erfolgen und kein separater Setter mehr nötig ist.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Notiz-Übersicht pro Level:** 📊‑Symbol zeigt alle Notizen eines Levels und deren Häufigkeit im gesamten Projekt
 * **Vollständig offline** – keine Server, keine externen Abhängigkeiten
 * **Direkter Spielstart:** Über eine zentrale Start-Leiste lässt sich das Spiel oder der Workshop in der gewünschten Sprache starten. Der Steam-Pfad wird automatisch aus der Windows‑Registry ermittelt.
-* **Schnellstart mit Cheats:** Im Dropdown lassen sich Godmode, unendliche Munition und die Entwicklerkonsole einzeln auswählen. Das Spiel startet nach Klick auf **Starten** mit allen markierten Optionen.
+* **Schnellstart mit Cheats:** Im Dropdown lassen sich Godmode, unendliche Munition und die Entwicklerkonsole einzeln auswählen. Das Spiel startet nach Klick auf **Starten** mit allen markierten Optionen. Die Voreinstellungen liegen gebündelt in `launch_hla.py` als Konstante, sodass beide Startpfade identische Argumente nutzen.
 * **Eigene Video-Links:** Über den Video-Manager lassen sich mehrere URLs speichern und per Knopfdruck öffnen. Fehlt die Desktop-App, werden die Links im Browser gespeichert.
 * **Wählbarer Speichermodus:** Beim ersten Start kann zwischen klassischem LocalStorage und einem IndexedDB-System gewählt werden; alle Zugriffe erfolgen über einen Speicher-Adapter.
 * **Daten migrieren:** Ein zusätzlicher Knopf kopiert alle LocalStorage-Einträge in das neue Speicher-System.

--- a/launch_hla.py
+++ b/launch_hla.py
@@ -7,6 +7,14 @@ except ImportError:  # Nicht-Windows-Systeme
     winreg = None
 
 
+CHEAT_ARGS: dict[str, list[str]] = {
+    "god": ["-vconsole", "-console", "+sv_cheats", "1", "+god"],
+    "ammo": ["-vconsole", "-console", "+sv_cheats", "1", "+sv_infinite_ammo", "1"],
+    "both": ["-vconsole", "-console", "+sv_cheats", "1", "+god", "+sv_infinite_ammo", "1"],
+    "console": ["-vconsole", "-console"],
+}
+
+
 def _get_steam_path() -> str | None:
     """Liest den Installationspfad von Steam aus der Registry aus."""
     if winreg is None:
@@ -51,14 +59,8 @@ def start_hla(mode: str = "normal", lang: str = "english", level: str | None = N
         if lang:
             cmd.extend(["-language", lang])
 
-        cheat_args = {
-            "god": ["-vconsole", "-console", "+sv_cheats", "1", "+god"],
-            "ammo": ["-vconsole", "-console", "+sv_cheats", "1", "+sv_infinite_ammo", "1"],
-            "both": ["-vconsole", "-console", "+sv_cheats", "1", "+god", "+sv_infinite_ammo", "1"],
-            "console": ["-vconsole", "-console"],
-        }
-        if preset in cheat_args:
-            cmd.extend(cheat_args[preset])
+        if preset in CHEAT_ARGS:
+            cmd.extend(CHEAT_ARGS[preset])
 
         if level:
             cmd.extend(["+map", level])
@@ -73,14 +75,8 @@ def start_hla(mode: str = "normal", lang: str = "english", level: str | None = N
     if lang:
         args.extend(["-language", lang])
 
-    cheat_args = {
-        "god": ["-vconsole", "-console", "+sv_cheats", "1", "+god"],
-        "ammo": ["-vconsole", "-console", "+sv_cheats", "1", "+sv_infinite_ammo", "1"],
-        "both": ["-vconsole", "-console", "+sv_cheats", "1", "+god", "+sv_infinite_ammo", "1"],
-        "console": ["-vconsole", "-console"],
-    }
-    if preset in cheat_args:
-        args.extend(cheat_args[preset])
+    if preset in CHEAT_ARGS:
+        args.extend(CHEAT_ARGS[preset])
 
     if level:
         args.extend(["+map", level])


### PR DESCRIPTION
## Summary
- extrahiere die Cheat-Voreinstellungen in `launch_hla.py` in die Modulkonstante `CHEAT_ARGS`
- verwende die neue Konstante in beiden Startpfaden für konsistente Argumente
- dokumentiere die gemeinsame Cheat-Konstante in README und CHANGELOG

## Testing
- python -m compileall launch_hla.py

------
https://chatgpt.com/codex/tasks/task_e_68cdcc0bde8c832784f21d157c495b2c