### PR TITLE
Bereinige Textvergleich in fileUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.355
+* `web/src/fileUtils.js` entfernt die ungenutzte Konstante `allWords`, damit der Textvergleich ohne überflüssige Zwischenspeicher auskommt.
+* README und Changelog dokumentieren die bereinigte Textanalyse.
 ## 🛠️ Patch in 1.40.354
 * `web/src/config.js` exportiert nur noch die fertigen Pfade; der ermittelte Download-Ordnername bleibt intern und entfällt aus der Exportliste.
 * README und Changelog vermerken die bereinigte Download-Konfiguration ohne öffentlichen Ordnernamen.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Sofortspeichern nach GPT- und Emotions-Einträgen:** Übernommene Bewertungen und generierte Emotionstexte werden unmittelbar dauerhaft gesichert.
 * **Gemeinsame Projektliste:** `window.projects` stellt sicher, dass alle Module auf dieselbe Projektreferenz zugreifen.
 * **Überarbeitete Lade-Mechanik:** Projekte werden wieder zuverlässig geöffnet und laufende Ladevorgänge blockieren sich nicht mehr gegenseitig.
+* **Bereinigter Textvergleich:** Der Helfer `calculateTextSimilarity` verzichtet auf eine ungenutzte Wortmenge und behält alle Funktionen bei.
 * **Stabiles Projektladen:** Fehler beim Lesen aus dem Speicher werden abgefangen und als Hinweis angezeigt.
 * **Bugfix:** Nach dem Laden eines Projekts reagierte die Oberfläche nicht mehr auf Klicks.
 * **Bugfix:** Nach einem Projektwechsel funktionieren alle Toolbar‑Schaltflächen wieder zuverlässig.

--- a/web/src/fileUtils.js
+++ b/web/src/fileUtils.js
@@ -27,7 +27,6 @@ function calculateTextSimilarity(text1, text2) {
     const words2 = norm2.split(/\s+/);
 
     let commonWords = 0;
-    const allWords = new Set([...words1, ...words2]);
 
     words1.forEach(word1 => {
         if (words2.some(word2 => {


### PR DESCRIPTION
## Zusammenfassung
- entferne die ungenutzte Konstante `allWords` aus `calculateTextSimilarity`
- aktualisiere README und Changelog mit dem Hinweis auf die bereinigte Textanalyse

## Tests
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdd2c14f888327a96ea280970c707d