### PR TITLE
Entferne createDubbing aus dem Browsermodul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.357
+* `web/src/main.js` verzichtet auf den ungenutzten Helfer `createDubbing` und lädt im Browser nur noch `downloadDubbingAudio`.
+* `web/src/elevenlabs.js` exportiert ausschließlich `downloadDubbingAudio`; das Anlegen neuer Dubbings erfolgt über das Node-Modul `elevenlabs.js`.
+* README und Changelog dokumentieren die verschlankte Exportliste ohne Browser-Variante von `createDubbing`.
 ## 🛠️ Patch in 1.40.356
 * `web/renderer.js` fasst das Ermitteln der DOM-Elemente samt Listenern im neuen Helfer `initVideoManager` zusammen, exportiert ihn global und stellt die aktuellen Referenzen über `window.videoManager` bereit.
 * `web/src/main.js` öffnet den Video-Manager stets über die gemeinsam genutzten Referenzen, leert das Suchfeld, prüft `dialog.open` und triggert danach direkt `refreshTable()`.

--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ if (await isDubReady(job.dubbing_id, 'de', apiKey)) {
     // blob speichern ...
 }
 ```
-Die Browser-Datei `web/src/elevenlabs.js` stellt aktuell `createDubbing` und `downloadDubbingAudio` bereit. Statusprüfungen laufen vollständig über `web/src/dubbing.js`, wo `isDubReady` im Rahmen des Frontend-Workflows gekapselt ist. `waitForDubbing` wurde entfernt, da die Browser-Oberfläche ausschließlich auf Statusprüfungen setzt. Auskommentierte Alt-Funktionen wie `dubSegments`, `renderDubbingResource` oder `getDubbingResource` sind entfernt worden.
+Die Browser-Datei `web/src/elevenlabs.js` stellt im Browser nur noch `downloadDubbingAudio` bereit. Statusprüfungen laufen vollständig über `web/src/dubbing.js`, wo `isDubReady` im Rahmen des Frontend-Workflows gekapselt ist. `waitForDubbing` wurde entfernt, da die Browser-Oberfläche ausschließlich auf Statusprüfungen setzt. Auskommentierte Alt-Funktionen wie `dubSegments`, `renderDubbingResource` oder `getDubbingResource` sind entfernt worden. Das Anlegen neuer Dubbings geschieht ausschließlich über die Node-Variante `elevenlabs.js`.
 
 Das Node-Modul `elevenlabs.js` exportiert derzeit `createDubbing`, `downloadDubbingAudio`, `waitForDubbing`, `isDubReady`, `renderLanguage`, `pollRender` und `sendTextV2`. Die Hilfsfunktionen `getDubbingStatus` und `getDefaultVoiceSettings` sind entfallen, weil Statusabfragen und Standardeinstellungen inzwischen direkt in den jeweiligen Workflows gekapselt werden.
 Das komplette Workflow-Skript für den Upload, die Statusabfrage und das erneute

--- a/web/src/elevenlabs.js
+++ b/web/src/elevenlabs.js
@@ -1,44 +1,5 @@
 const API = 'https://api.elevenlabs.io/v1';
 
-// Erstellt ein Dubbing-Projekt bei ElevenLabs
-// target_lang und target_languages sind fest auf "de" gesetzt
-export async function createDubbing({
-    audioFile,
-    csvContent,
-    voiceId = '',
-    apiKey
-}, logger = () => {}) {
-    const form = new FormData();
-
-    form.append('file', audioFile);
-    form.append('csv_file', new Blob([csvContent], { type: 'text/csv' }), 'script.csv');
-    const lang = 'de';
-    form.append('target_lang', lang);
-    form.append('target_languages', JSON.stringify([lang]));
-    form.append('mode', 'manual');
-    form.append('dubbing_studio', 'true');
-
-    if (voiceId) {
-        form.append('voice_id', voiceId);
-    } else {
-        // Ohne Voice-ID wird Voice Cloning abgeschaltet
-        form.append('disable_voice_cloning', 'true');
-    }
-
-    logger(`POST ${API}/dubbing`);
-    const res = await fetch(`${API}/dubbing`, {
-        method: 'POST',
-        headers: { 'xi-api-key': apiKey },
-        body: form
-    });
-    const text = await res.text();
-    logger(`Antwort (${res.status}): ${text}`);
-    if (!res.ok) {
-        throw new Error(`Create dubbing failed: ${res.status} ${text}`);
-    }
-    return JSON.parse(text);
-}
-
 // Lädt die gerenderte Audiodatei einer Sprache herunter
 export async function downloadDubbingAudio(apiKey, id, targetLang = 'de', logger = () => {}) {
     logger(`GET ${API}/dubbing/${id}/audio/${targetLang}`);

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -702,7 +702,7 @@ const moduleStatus = {
 };
 
 // Gemeinsame Funktionen aus elevenlabs.js laden
-let createDubbing, downloadDubbingAudio, renderLanguage, pollRender;
+let downloadDubbingAudio, renderLanguage, pollRender;
 let repairFileExtensions;
 let loadClosecaptions;
 let calculateTextSimilarity, levenshteinDistance;
@@ -723,7 +723,7 @@ let showDubbingSettings, showEmoDubbingSettings,
     openStudioAndWait, dubStatusClicked, downloadDe;
 let sharedProjectStatsCalculator;
 if (typeof module !== 'undefined' && module.exports) {
-    ({ createDubbing, downloadDubbingAudio, renderLanguage, pollRender } = require('../../elevenlabs'));
+    ({ downloadDubbingAudio, renderLanguage, pollRender } = require('../../elevenlabs'));
     moduleStatus.elevenlabs = { loaded: true, source: 'Main' };
 
     ({ showDubbingSettings, createDubbingCSV, validateCsv, msToSeconds, isDubReady,
@@ -788,7 +788,6 @@ if (typeof module !== 'undefined' && module.exports) {
         moduleStatus.projectStats = { loaded: false, source: 'Ausgelagert' };
     }
     import('./elevenlabs.js').then(mod => {
-        createDubbing = mod.createDubbing;
         downloadDubbingAudio = mod.downloadDubbingAudio;
         moduleStatus.elevenlabs = { loaded: true, source: 'Ausgelagert' };
     }).catch(() => { moduleStatus.elevenlabs = { loaded: false, source: 'Ausgelagert' }; });


### PR DESCRIPTION
## Zusammenfassung
- entferne den ungenutzten Browser-Import `createDubbing` aus `web/src/main.js`
- reduziere `web/src/elevenlabs.js` auf den einzigen Export `downloadDubbingAudio`
- aktualisiere README und Changelog, damit die Dokumentation nur noch den verbleibenden Browser-Helfer aufführt

## Tests
- npx jest tests/elevenlabs.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cdd91cae648327a541a101f856f816