### PR TITLE
Scroll-Padding des Tabellenkopfs korrigiert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.358
+* `web/src/style.css` erhöht `scroll-padding-top` der Dateitabelle auf die reale Höhe des sticky Tabellenkopfs, damit die erste Zeile vollständig sichtbar bleibt.
+* README und Changelog dokumentieren das korrigierte Scroll-Padding des Tabellenkopfs.
 ## 🛠️ Patch in 1.40.357
 * `web/src/main.js` verzichtet auf den ungenutzten Helfer `createDubbing` und lädt im Browser nur noch `downloadDubbingAudio`.
 * `web/src/elevenlabs.js` exportiert ausschließlich `downloadDubbingAudio`; das Anlegen neuer Dubbings erfolgt über das Node-Modul `elevenlabs.js`.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Verbessertes Scrollen in der Dateitabelle:** Nach dem Rendern springt die Tabelle nur zur gemerkten Zeile, wenn keine neue Datei markiert wird; andernfalls wird nach der Auswahl gescrollt.
 * **Auto-Scroll blockiert Zeilennummer-Aktualisierung:** Der Fallback in `selectRow` setzt kurzzeitig `isAutoScrolling`, damit `updateNumberFromScroll` nicht dazwischenfunkt.
 * **Übersichtliche Auswahlzeile:** Die gewählte Zeile wird mit kleinem Abstand unter dem Tabellenkopf positioniert, bleibt vollständig sichtbar und zeigt noch einen Teil der vorherigen Zeile.
+* **Tabellenkopf mit vollem Sichtfenster:** Das Scroll-Padding der Tabelle entspricht jetzt der Höhe des sticky Kopfbereichs, sodass die erste Zeile nicht mehr teilweise verdeckt wird.
 * **Überarbeitetes Timing-Layout:** Der Abschnitt „Timing & Bereiche“ nutzt ein zweispaltiges Kartenraster, das bei schmaler Breite automatisch auf eine Spalte umbricht.
 * **Detailliertes Fehlerfenster:** Fehlende oder beschädigte Projekte melden sich mit einer genauen Ursache und einem Reparaturhinweis.
 * **Debug-Bericht bei Fehlern:** Nach jeder Fehlermeldung kann ein Fenster mit auswählbaren Berichten samt Umgebung geöffnet werden.

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -569,7 +569,7 @@ th:nth-child(8) {
             overflow: auto;
             background: #1a1a1a;
             scroll-snap-type: y mandatory; /* Zeilen am Tabellenkopf einrasten lassen */
-            scroll-padding-top: 8px; /* Kleiner Abstand oben für volle Sichtbarkeit */
+            scroll-padding-top: 60px; /* Abstand entspricht der realen Höhe des sticky Tabellenkopfs */
         }
 
         table {


### PR DESCRIPTION
## Zusammenfassung
- erhöhe das scroll-padding der Dateitabelle auf 60px, damit der sticky Tabellenkopf keine Zeilen mehr überdeckt
- dokumentiere die Anpassung in README und CHANGELOG

## Tests
- manuell mit lokalem HTTP-Server und Playwright geprüft, dass Tabellenzeilen nach dem Scrollen komplett sichtbar unter dem Header einrasten

------
https://chatgpt.com/codex/tasks/task_e_68ce579c105883278bf68c07cff1ace0