### PR TITLE
Fix: vermeide Performanceabbau durch doppelte Listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.361
+* `web/src/main.js` markiert Pfad-Zellen nach dem Binden mit einem Datenattribut und registriert den globalen Klick-Listener nur ein einziges Mal, sodass sich keine stetig wachsende Zahl an Handlern ansammelt und die Oberfläche nach langer Laufzeit flott bleibt.
+* README beschreibt das behobene Performance-Problem und nennt die neue Schutzlogik für den Dokument-Listener.
+
 ## 🛠️ Patch in 1.40.360
 * README strukturiert das komplette Feature-Archiv jetzt mit einklappbaren Kapiteln, ergänzt einen Schnellüberblick und erweitert das Inhaltsverzeichnis für eine schnellere Orientierung.
 

--- a/README.md
+++ b/README.md
@@ -1043,6 +1043,10 @@ Die wichtigsten JavaScript-Dateien sind nun thematisch gegliedert:
 * ▶ **Lösung:** Haupt‑Audio‑Ordner erneut einlesen
 * ▶ **Prüfung:** Debug‑Spalte zeigt Pfad‑Status
 
+**🐢 Oberfläche wird nach langer Laufzeit träge**
+* ▶ **Ursache:** Vor Version 1.40.361 legte jede Aktualisierung der Dateitabelle einen weiteren globalen Klick-Listener auf dem Dokument ab. Mit zunehmender Laufzeit sammelten sich dadurch hunderte Handler an und jeder Klick prüfte alle Pfad-Zellen erneut.
+* ▶ **Fix:** Die Pfad-Spalte markiert gebundene Zellen jetzt mit `data-path-menu-bound` und registriert den Dokument-Listener nur einmal. Damit bleibt die Oberfläche auch nach vielen Stunden responsiv.
+
 **⚠️ Spur manuell generieren oder Beta freischalten**
 * ▶ **Ursache:** Die gewählte Sprachspur konnte nicht automatisch heruntergeladen werden.
 * ▶ **Lösung:** Spur im Studio manuell generieren oder Beta-Zugang für den Auto-Download freischalten.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -5842,18 +5842,29 @@ function addDragAndDropHandlers() {
 }
 
 // Registriert Rechtsklick-Handler für Pfad-Zellen, um Details anzuzeigen
+let pathCellDocumentClickHandler = null;
+
 function addPathCellContextMenus() {
     document.querySelectorAll('.path-cell').forEach(cell => {
+        if (cell.dataset.pathMenuBound === '1') {
+            return;
+        }
+        cell.dataset.pathMenuBound = '1';
         cell.addEventListener('contextmenu', e => {
+            // Kontextmenü anzeigen ohne mehrfachen Listener-Aufbau
             e.preventDefault();
             cell.classList.toggle('show-path');
         });
     });
-    document.addEventListener('click', e => {
-        if (!e.target.closest('.path-cell')) {
-            document.querySelectorAll('.path-cell.show-path').forEach(c => c.classList.remove('show-path'));
-        }
-    });
+    if (!pathCellDocumentClickHandler) {
+        // Nur einen globalen Klick-Handler registrieren, um Speicherlecks zu vermeiden
+        pathCellDocumentClickHandler = e => {
+            if (!e.target.closest('.path-cell')) {
+                document.querySelectorAll('.path-cell.show-path').forEach(c => c.classList.remove('show-path'));
+            }
+        };
+        document.addEventListener('click', pathCellDocumentClickHandler);
+    }
 }
 
 // Prüft bei allen Download-Buttons den Status und aktiviert sie ggf.


### PR DESCRIPTION
## Summary
- verhindere, dass `addPathCellContextMenus` bei jedem Rendern weitere Dokument-Listener registriert
- markiere bereits verdrahtete Pfadzellen und dokumentiere den behobenen Performanceeinbruch

## Testing
- nicht ausgeführt (nicht angefordert)


------
https://chatgpt.com/codex/tasks/task_e_68d4210be6788327b05d66202c6c792a