### PR TITLE
Sorge für persistente Ignorierlisten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.362
+* `web/src/main.js` lädt und speichert ignorierte Ordner-Einträge jetzt asynchron, sodass der Datei-Modus (IndexedDB) die Auswahlen dauerhaft behält.
+* README ergänzt den Hinweis, dass der Ordner-Browser ignorierte Dateien dauerhaft merkt.
+
 ## 🛠️ Patch in 1.40.361
 * `web/src/main.js` markiert Pfad-Zellen nach dem Binden mit einem Datenattribut und registriert den globalen Klick-Listener nur ein einziges Mal, sodass sich keine stetig wachsende Zahl an Handlern ansammelt und die Oberfläche nach langer Laufzeit flott bleibt.
 * README beschreibt das behobene Performance-Problem und nennt die neue Schutzlogik für den Dokument-Listener.

--- a/README.md
+++ b/README.md
@@ -825,6 +825,8 @@ Auch Kapitel und Level bieten dieses Rechtsklick-Menü.
 | **Sortierung ändern**     | Klick auf Spalten‑Header                          |
 | **Datei löschen**         | × am Zeilenende oder Context‑Menu                 |
 
+Ignorierte Einträge merkt sich der Ordner-Browser jetzt dauerhaft – unabhängig davon, ob LocalStorage oder der Datei-Modus aktiv ist.
+
 ### Audio & Text
 
 |  Aktion                    |  Bedienung |


### PR DESCRIPTION
## Zusammenfassung
- Ignorierliste im Ordner-Browser asynchron laden und speichern, damit der Datei-Modus die Auswahl dauerhaft behält
- Ordner-Ansicht wartet beim Öffnen und beim Toggle auf die geladenen Daten, um sofort den korrekten Status anzuzeigen
- README und CHANGELOG um den Hinweis zur nun dauerhaften Ignorierfunktion ergänzt

## Tests
- nicht ausgeführt (manuelle Überprüfung)


------
https://chatgpt.com/codex/tasks/task_e_68d46c3784bc832784ed0be969bad3d6