### PR TITLE
Ignorierstatus pro Ordnerstruktur speichern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## 🛠️ Patch in 1.40.363
+* `web/src/main.js` legt ignorierte Dateien jetzt pro Ordner unter `hla_folderStates` ab, migriert Altbestände automatisch und lädt die Daten bei Speicherwechseln erneut.
+* Backups enthalten die neue Struktur `folderStates`, Wiederherstellungen schreiben sie in den Speicher und erzeugen daraus weiterhin die Laufzeit-Lookups.
+* README erläutert den neuen Speicherpfad der Ignorierliste und weist auf die eingebaute Migration hin.
+
+## 🛠️ Patch in 1.40.362
+* `web/src/main.js` lädt und speichert ignorierte Ordner-Einträge jetzt asynchron, sodass der Datei-Modus (IndexedDB) die Auswahlen dauerhaft behält.
+* README ergänzt den Hinweis, dass der Ordner-Browser ignorierte Dateien dauerhaft merkt.
+
 ## 🛠️ Patch in 1.40.361
 * `web/src/main.js` markiert Pfad-Zellen nach dem Binden mit einem Datenattribut und registriert den globalen Klick-Listener nur ein einziges Mal, sodass sich keine stetig wachsende Zahl an Handlern ansammelt und die Oberfläche nach langer Laufzeit flott bleibt.
 * README beschreibt das behobene Performance-Problem und nennt die neue Schutzlogik für den Dokument-Listener.

--- a/README.md
+++ b/README.md
@@ -825,6 +825,10 @@ Auch Kapitel und Level bieten dieses Rechtsklick-Menü.
 | **Sortierung ändern**     | Klick auf Spalten‑Header                          |
 | **Datei löschen**         | × am Zeilenende oder Context‑Menu                 |
 
+Ignorierte Einträge merkt sich der Ordner-Browser jetzt dauerhaft – unabhängig davon, ob LocalStorage oder der Datei-Modus aktiv ist.
+Die Auswahl landet dabei pro Ordner im Schlüssel `hla_folderStates` des gewählten Speichers und wird bei jedem Wechsel erneut geladen.
+Bestehende Installationen, die noch den alten Eintrag `ignoredFiles` nutzen, werden beim ersten Öffnen automatisch in die neue Struktur übertragen.
+
 ### Audio & Text
 
 |  Aktion                    |  Bedienung |


### PR DESCRIPTION
## Zusammenfassung
- speichere ignorierte Dateien je Ordner im Schlüssel `hla_folderStates`, migriere Altbestände automatisch und lade den Status bei Speicherwechseln neu
- erweitere Backup-Export und -Import um die neue Ordnerstruktur und dokumentiere den Speicherpfad samt Migration in README sowie CHANGELOG

## Tests
- nicht ausgeführt (manuelle Überprüfung)


------
https://chatgpt.com/codex/tasks/task_e_68d46c3784bc832784ed0be969bad3d6