### PR TITLE
Füge Schnellsprech-Häkchen beim Emo-Kopieren hinzu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 🛠️ Patch in 1.40.368
+* `web/hla_translation_tool.html` ergänzt ein neues Kopier-Häkchen, das bei Bedarf „extrem schnell reden“ in Emotionstags einfügt.
+* `web/src/main.js` erweitert das Kopieren einzelner und aller Emotional-Texte um die optionale Schnellsprech-Anweisung.
+* README und Changelog dokumentieren die neue Kopieroption für extrem schnelles Sprechen.
+
 ## 🛠️ Patch in 1.40.367
 * `web/src/main.js` merkt sich die Projekt-ID jeder Übersetzungsanfrage, synchronisiert das Ergebnis mit dem richtigen Projektobjekt und speichert sofort, damit automatische Vorschläge auch nach einem Projektwechsel sichtbar bleiben.
 * README beschreibt die zuverlässige Übernahme der Auto-Übersetzungen trotz laufender Warteschlange.

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Verbessern:** Ein zusätzlicher Button bewertet die gesamte Übersetzung, zeigt drei verbesserte Fassungen des Emotional-Texts samt Begründung und blendet während der Analyse eine Lade-Animation ein.
 * **Eigenheiten bewahren:** Abgebrochene Sätze oder Fülllaute wie "äh" oder "mh" bleiben auch in gekürzten Emotional-Texten sinngemäß erhalten.
 * **Laufzeit vor Emotional-Text:** Der 📋-Knopf schreibt beim Kopieren jetzt die Dauer der EN-Datei im Format `[8,57sec]` vor den Text.
+* **Schnellsprech-Häkchen:** Beim Button „Emotionen kopieren“ ergänzt ein optionales Häkchen in der ersten Klammer „extrem schnell reden“ direkt nach dem ersten Emotionstag.
 * **Kontextvolle Emotionstags:** Beim Generieren eines Emotional-Texts wird nun der komplette Dialog des Levels an ChatGPT gesendet, damit der Tonfall korrekt erkannt wird.
 * **Tags mitten im Satz:** Die erzeugten Emotionstags stehen jetzt direkt vor der jeweiligen Textstelle und nicht mehr am Ende der Zeile.
 * **Tags auf Deutsch:** In den eckigen Klammern sind die Emotionstags nun auf Deutsch, der eigentliche Dialog bleibt weiterhin Deutsch.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -153,6 +153,7 @@
                     <label class="copy-option"><input type="checkbox" id="restTranslationCheckbox"> Reste-Modus</label>
                     <label class="copy-option"><input type="checkbox" id="copyIncludeTime" checked> Zeit voranstellen</label>
                     <label class="copy-option"><input type="checkbox" id="copyAddDashes"> --- anhängen</label>
+                    <label class="copy-option"><input type="checkbox" id="copyAddExtremeSpeed"> „extrem schnell reden“ ergänzen</label>
                 </div>
                 <div class="sort-controls">
                     <span style="color: #999;">Sortierung:</span>


### PR DESCRIPTION
## Summary
- add a new checkbox next to the "Emotionen kopieren" button to optionally append "extrem schnell reden" inside the first emotion tag when copying
- extend the copy helpers so both bulk and single emotional copies inject the extra instruction without touching stored data
- document the new option in the README and changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4fd3650d88327824e1aa968e425c0