### PR TITLE
Stabilisiere Waveform-Raster auf zweispaltiges Layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.378
+* `web/src/style.css` stellt das Waveform-Raster auf zwei feste Spalten um, bricht auf kleinen Bildschirmen einspaltig um und schafft mehr Abstand für den EN-Einfügebereich.
+* `README.md` beschreibt die neue Zweispalten-Logik im DE-Audio-Editor und den zusätzlichen Freiraum für den Einfügebereich.
+* `CHANGELOG.md` hält das aktualisierte Layout der Wave-Area fest.
 ## 🛠️ Patch in 1.40.377
 * `web/src/dubbing.js` erzeugt eine zentrale Timeline-Leiste samt Zoom- und Scroll-Steuerung und stellt Helfer zum Aktualisieren der Marker bereit.
 * `web/src/main.js` bindet die Timeline in den DE-Audio-Editor ein, synchronisiert Zoom/Scroll mit beiden Wellenformen und visualisiert Trim-, Ignorier-, Stille- sowie Cursor-Markierungen.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Übersichtliche Auswahlzeile:** Die gewählte Zeile wird mit kleinem Abstand unter dem Tabellenkopf positioniert, bleibt vollständig sichtbar und zeigt noch einen Teil der vorherigen Zeile.
 * **Tabellenkopf mit vollem Sichtfenster:** Das Scroll-Padding der Tabelle entspricht jetzt der Höhe des sticky Kopfbereichs, sodass die erste Zeile nicht mehr teilweise verdeckt wird.
 * **Überarbeitetes Timing-Layout:** Der Abschnitt „Timing & Bereiche“ nutzt ein zweispaltiges Kartenraster, das bei schmaler Breite automatisch auf eine Spalte umbricht.
-* **Adaptive DE-Audio-Ansicht:** Wellenformen, Kopierbereich und Effektgruppen reagieren nun auf breite Monitore mit flexiblen Gittern und ordnen sich auf kleineren Displays automatisch übereinander an.
+* **Adaptive DE-Audio-Ansicht:** Wellenformen, Kopierbereich und Effektgruppen nutzen jetzt ein konsistentes Zweispalten-Raster, das auf kleinen Displays automatisch auf eine Spalte reduziert wird und dem Einfügebereich Luft nach oben lässt.
 * **Waveform-Werkzeugleiste für große Monitore:** Zoom- und Höhenregler, synchronisiertes Scrollen sowie Zeitmarken-Lineale sorgen dafür, dass lange Takes auch auf Ultrawide-Displays komfortabel editierbar bleiben.
 * **Tabbasiertes Effekt-Panel:** Die rechte Seitenleiste bündelt Lautstärke- und Funkgerät-Steuerung als „Kernfunktionen“ und verschiebt Hall-, EM-Störungs- sowie Nebenraum-Regler unter „Erweiterte Optionen“ mit klaren Abschnittstiteln.
 * **Detailliertes Fehlerfenster:** Fehlende oder beschädigte Projekte melden sich mit einer genauen Ursache und einem Reparaturhinweis.

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1082,18 +1082,25 @@ th:nth-child(8) {
             margin-top: 2px;
         }
 
-        /* Raster für die Wellenformen – reagiert auf verschiedene Monitorbreiten */
+        /* Raster für die Wellenformen – feste Zweispaltigkeit für mehr Konstanz */
         #deEditDialog .wave-area {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+            grid-template-columns: repeat(2, minmax(0, 1fr));
             gap: 18px;
             margin-bottom: 20px;
             align-items: start;
         }
 
+        /* Auf schmalen Bildschirmen nur eine Spalte, damit nichts überlappt */
+        @media (max-width: 1100px) {
+            #deEditDialog .wave-area {
+                grid-template-columns: 1fr;
+            }
+        }
+
         @media (min-width: 1800px) {
             #deEditDialog .wave-area {
-                grid-template-columns: repeat(auto-fit, minmax(520px, 1fr)); /* Großzügigere Spalten auf Ultra-Wide */
+                grid-template-columns: repeat(2, minmax(0, 1fr)); /* Ultra-Wide nutzt weiterhin zwei Spalten */
                 gap: 24px;
             }
         }
@@ -1720,8 +1727,8 @@ th:nth-child(8) {
     color: #ccc;
 }
 
-/* Bereich zur Übernahme eines EN-Ausschnitts */
-.insert-en-section { margin: 0; }
+/* Bereich zur Übernahme eines EN-Ausschnitts erhält etwas Luft zum Raster */
+.insert-en-section { margin: 12px 0 0; }
 .insert-en-section .insert-controls {
     display: flex;
     gap: 10px;


### PR DESCRIPTION
## Zusammenfassung
- setze das Raster im DE-Waveform-Bereich auf zwei feste Spalten und ergänze einen Einspalten-Fallback für schmale Bildschirme
- belasse die Ultra-Wide-Variante bei zwei Spalten und erhöhe dort nur den Abstand
- dokumentiere die Layoutänderung in README und CHANGELOG

## Tests
- nicht ausgeführt (CSS-Anpassung)


------
https://chatgpt.com/codex/tasks/task_e_68d7aff8bf1c83279d6ab4f8b1a13d2a