### PR TITLE
Verdichte Abstände im DE-Audio-Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.381
+* `web/src/style.css` verdichtet Wave-Area, Toolbar, Blöcke, Steuerleisten und Scrollbereich, sodass beide Wellenformen dichter nebeneinander liegen.
+* `README.md` ergänzt den Hinweis auf das kompaktere Waveform-Raster mit geringeren Abständen.
+* `CHANGELOG.md` hält die neue Verdichtung der Wave-Layouts fest.
 ## 🛠️ Patch in 1.40.380
 * `web/src/style.css` reduziert Abstände in Wave-Area und Toolbar, damit der obere Editorbereich kompakter erscheint und Buttons weiterhin gut erreichbar bleiben.
 * `README.md` beschreibt die verschlankte Waveform-Werkzeugleiste mit den neuen Abständen.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Adaptive DE-Audio-Ansicht:** Wellenformen, Kopierbereich und Effektgruppen nutzen jetzt ein konsistentes Zweispalten-Raster, das auf kleinen Displays automatisch auf eine Spalte reduziert wird und dem Einfügebereich Luft nach oben lässt.
 * **Waveform-Werkzeugleiste für große Monitore:** Zoom- und Höhenregler, synchronisiertes Scrollen sowie Zeitmarken-Lineale sorgen dafür, dass lange Takes auch auf Ultrawide-Displays komfortabel editierbar bleiben.
 * **Kompaktere Waveform-Werkzeugleiste:** Reduzierte Abstände in Toolbar und Raster lassen den oberen Bereich schlanker wirken, ohne die Bedienflächen zu verkleinern.
+* **Dichteres Waveform-Raster:** Kleinere Gitterabstände, schmalere Blockabstände und weniger Scroll-Padding rücken Original- und DE-Wellenform näher zusammen, behalten dabei aber gut greifbare Steuerelemente.
 * **Tabbasiertes Effekt-Panel:** Die rechte Seitenleiste bündelt Lautstärke- und Funkgerät-Steuerung als „Kernfunktionen“ und verschiebt Hall-, EM-Störungs- sowie Nebenraum-Regler unter „Erweiterte Optionen“ mit klaren Abschnittstiteln.
 * **Detailliertes Fehlerfenster:** Fehlende oder beschädigte Projekte melden sich mit einer genauen Ursache und einem Reparaturhinweis.
 * **Debug-Bericht bei Fehlern:** Nach jeder Fehlermeldung kann ein Fenster mit auswählbaren Berichten samt Umgebung geöffnet werden.

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1079,8 +1079,8 @@ th:nth-child(8) {
         #deEditDialog .wave-area {
             display: grid;
             grid-template-columns: repeat(2, minmax(0, 1fr));
-            gap: 12px;
-            margin-bottom: 14px;
+            gap: 8px;
+            margin-bottom: 10px;
             align-items: start;
         }
 
@@ -1101,12 +1101,12 @@ th:nth-child(8) {
         #deEditDialog .wave-toolbar {
             display: flex;
             flex-wrap: wrap;
-            gap: 10px;
+            gap: 6px;
             align-items: center;
             justify-content: flex-start;
             background: #1c1c1c;
             border-radius: 10px;
-            padding: 8px 12px;
+            padding: 6px 10px;
             margin-bottom: 10px;
             box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
         }
@@ -1319,22 +1319,22 @@ th:nth-child(8) {
                 width: 220px;
             }
             #deEditDialog .wave-toolbar {
-                gap: 14px;
-                padding: 10px 18px;
+                gap: 10px;
+                padding: 8px 16px;
             }
         }
 
         #deEditDialog .wave-block {
             display: flex;
             flex-direction: column;
-            gap: 10px;
+            gap: 6px;
             min-width: 0;
         }
 
         #deEditDialog .wave-controls {
             display: flex;
             align-items: stretch;
-            gap: 14px;
+            gap: 10px;
         }
 
         #deEditDialog .wave-viewport {
@@ -1350,7 +1350,7 @@ th:nth-child(8) {
             overflow-y: hidden;
             background: #111;
             border-radius: 8px;
-            padding: 8px 0 18px;
+            padding: 4px 0 8px;
             position: relative;
             scroll-behavior: smooth;
         }


### PR DESCRIPTION
## Summary
- reduziere Abstände in Wave-Area, Toolbar, Steuerblöcken und Scrollbereich des DE-Audio-Editors, damit die Wellenformen kompakter erscheinen
- passe README und CHANGELOG an, um das verdichtete Waveform-Raster zu dokumentieren

## Testing
- Manuell: Lokalen HTTP-Server gestartet und DE-Audio-Editor im Browser geprüft

------
https://chatgpt.com/codex/tasks/task_e_68d7b617e3108327802add9be842f00b