### PR TITLE
Verdichtung des DE-Audio-Dialogkopfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.382
+* `web/src/style.css` reduziert Padding, Abstände und große-Screen-Aufweitungen im Kopfbereich des DE-Audio-Dialogs, damit Toolbar und Wave-Raster kompakter bleiben.
+* `README.md` beschreibt den verschlankten Kopfbereich mit engerer Überschrift und dichterem Wellen-Layout.
+* `CHANGELOG.md` dokumentiert den entschlackten Wave-Header.
 ## 🛠️ Patch in 1.40.381
 * `web/src/style.css` verdichtet Wave-Area, Toolbar, Blöcke, Steuerleisten und Scrollbereich, sodass beide Wellenformen dichter nebeneinander liegen.
 * `README.md` ergänzt den Hinweis auf das kompaktere Waveform-Raster mit geringeren Abständen.

--- a/README.md
+++ b/README.md
@@ -747,6 +747,7 @@ Seit Patch 1.40.242 zeigt der DE-Audio-Editor seine Bedienelemente in zwei Spalt
 Seit Patch 1.40.243 ordnet der DE-Audio-Editor Bereiche und Effekte in drei Spalten an. Lange Listen besitzen eigene Scrollleisten, sodass nichts überlappt.
 Seit Patch 1.40.244 bietet der DE-Audio-Editor eine untere Effekt-Toolbar und eigene Anwenden-Knöpfe in den Effekt-Kästen.
 Seit Patch 1.40.245 bleibt diese Effekt-Toolbar als Sticky-Footer sichtbar, und "Speichern" erscheint als primärer Button. "Zurücksetzen" fragt jetzt nach einer Bestätigung.
+Seit Patch 1.40.382 fällt der Kopfbereich des DE-Audio-Editors kompakter aus: Überschrift, Toolbar und Wave-Raster rücken enger zusammen und verlieren übergroße Abstände auf Ultra-Wide-Monitoren.
 Seit Patch 1.40.250 lassen sich Bereiche in EN- und DE-Wellenformen direkt per Ziehen markieren; Start- und Endfelder synchronisieren sich und ungültige Eingaben werden rot hervorgehoben.
 Seit Patch 1.40.194 durchsucht ein neuer Knopf das gesamte Projekt nach passenden Untertiteln und fügt eindeutige Treffer automatisch ein.
 

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1079,8 +1079,8 @@ th:nth-child(8) {
         #deEditDialog .wave-area {
             display: grid;
             grid-template-columns: repeat(2, minmax(0, 1fr));
-            gap: 8px;
-            margin-bottom: 10px;
+            gap: 6px;
+            margin-bottom: 8px;
             align-items: start;
         }
 
@@ -1094,20 +1094,20 @@ th:nth-child(8) {
         @media (min-width: 1800px) {
             #deEditDialog .wave-area {
                 grid-template-columns: repeat(2, minmax(0, 1fr)); /* Ultra-Wide nutzt weiterhin zwei Spalten */
-                gap: 18px;
+                gap: 8px; /* Deutlich weniger zusätzlicher Abstand auf großen Bildschirmen */
             }
         }
 
         #deEditDialog .wave-toolbar {
             display: flex;
             flex-wrap: wrap;
-            gap: 6px;
+            gap: 4px;
             align-items: center;
             justify-content: flex-start;
             background: #1c1c1c;
             border-radius: 10px;
-            padding: 6px 10px;
-            margin-bottom: 10px;
+            padding: 4px 8px;
+            margin-bottom: 8px;
             box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
         }
 
@@ -1319,22 +1319,22 @@ th:nth-child(8) {
                 width: 220px;
             }
             #deEditDialog .wave-toolbar {
-                gap: 10px;
-                padding: 8px 16px;
+                gap: 4px; /* Keine zusätzliche Aufweitung auf großen Bildschirmen */
+                padding: 4px 8px;
             }
         }
 
         #deEditDialog .wave-block {
             display: flex;
             flex-direction: column;
-            gap: 6px;
+            gap: 4px;
             min-width: 0;
         }
 
         #deEditDialog .wave-controls {
             display: flex;
             align-items: stretch;
-            gap: 10px;
+            gap: 8px;
         }
 
         #deEditDialog .wave-viewport {
@@ -1350,7 +1350,7 @@ th:nth-child(8) {
             overflow-y: hidden;
             background: #111;
             border-radius: 8px;
-            padding: 4px 0 8px;
+            padding: 2px 0 6px;
             position: relative;
             scroll-behavior: smooth;
         }
@@ -2282,6 +2282,11 @@ th:nth-child(8) {
 #deEditDialog .dialog {
     max-width: 1400px; /* Grundbreite für großzügige Arbeitsfläche */
     width: min(96vw, 1400px);
+    padding: 22px 28px; /* Weniger vertikaler Innenabstand für einen kompakteren Kopfbereich */
+}
+
+#deEditDialog .dialog h3 {
+    margin-bottom: 14px; /* Überschrift näher an den Inhalt rücken */
 }
 
 @media (min-width: 1800px) {


### PR DESCRIPTION
## Summary
- reduziertes Padding und geringere Abstände im Kopfbereich des DE-Audio-Dialogs für einen kompakteren Einstieg
- README und CHANGELOG um Hinweise auf das verschlankte Layout ergänzt

## Testing
- python3 -m http.server 8000 (manuelle Sichtprüfung im Browser bei 1920x1080)


------
https://chatgpt.com/codex/tasks/task_e_68d7b6e26770832789d0a937179a3394