### PR TITLE
Skaliere DE-Wellenformbreite nach Audiodauer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 🛠️ Patch in 1.40.388
+* `web/src/main.js` setzt die Canvas-Breite jetzt in Pixeln, damit lange DE-Aufnahmen proportional zur Laufzeit dargestellt und korrekt gescrollt werden können.
+* `web/src/style.css` überlässt die Breite der Wave-Canvas dem Inline-Stil, sodass die neue Pixelbreite nicht mehr überschrieben wird.
+* `README.md` erwähnt die proportional skalierte DE-Wellenform.
+* `CHANGELOG.md` dokumentiert die neue Breitenlogik der Wave-Canvas.
 ## 🛠️ Patch in 1.40.387
 * `web/src/dubbing.js` entfernt den Aufbau der Master-Timeline, bindet die Toolbar-Elemente als gemeinsame Regler und synchronisiert nur noch Zoom- und Positionswerte.
 * `web/src/main.js` verzichtet auf die Timeline-Initialisierung, koppelt die neuen Toolbar-Controls an die bestehenden Callback-Pfade und aktualisiert Scroll- und Zoom-Anzeigen ohne zusätzliche Zeitleiste.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Adaptive DE-Audio-Ansicht:** Wellenformen, Kopierbereich und Effektgruppen nutzen jetzt ein konsistentes Zweispalten-Raster, das auf kleinen Displays automatisch auf eine Spalte reduziert wird und dem Einfügebereich Luft nach oben lässt.
 * **Waveform-Werkzeugleiste für große Monitore:** Zoom- und Höhenregler, synchronisiertes Scrollen sowie Zeitmarken-Lineale sorgen dafür, dass lange Takes auch auf Ultrawide-Displays komfortabel editierbar bleiben.
 * **Feinjustierte Waveform-Werkzeugleiste:** Ein enges Grid mit kleineren Buttons und geringem Padding hält Zoom-, Höhen- und Sync-Regler auch bei kleiner Breite dicht beieinander.
+* **Proportionale DE-Wellenformbreite:** Die DE-Wellenform orientiert sich an der tatsächlichen Audiodauer und nutzt eine passende Pixelbreite, sodass lange Aufnahmen sichtbar länger bleiben als die EN-Spur.
 * **Master-Timeline entfernt:** Die frühere Zeitleiste oberhalb der Wellen entfällt; Zoom-Tasten, Positions-Slider und Sprungknöpfe sitzen jetzt direkt in der Wave-Toolbar.
 * **Dichteres Waveform-Raster:** Kleinere Gitterabstände, schmalere Blockabstände und reduziertes Scroll-Padding rücken Original- und DE-Wellenform noch näher zusammen und verkürzen die Wege zu den Buttons.
 * **Schlankere Standard-Wellenform:** Neu geöffnete Sitzungen starten mit 80 px hohen Wellenformen, der Höhen-Slider zeigt denselben Startwert und die kompakten Buttons bleiben voll erreichbar.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -521,7 +521,8 @@ function updateWaveCanvasDimensions() {
         const widthPx = Math.max(minWidth, Math.round(baseWidth * waveZoomLevel * effectiveRatio));
         canvas.width = widthPx;
         canvas.height = waveHeightPx;
-        canvas.style.width = `${Math.max(1, waveZoomLevel * effectiveRatio) * 100}%`;
+        // Breite jetzt in Pixeln setzen, damit lange DE-Spuren proportional dargestellt werden
+        canvas.style.width = `${widthPx}px`;
         canvas.style.height = `${waveHeightPx}px`;
     });
     updateWaveRulers();

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1225,7 +1225,7 @@ th:nth-child(8) {
 
         #deEditDialog .wave-canvas {
             display: block;
-            width: 100%;
+            width: auto;
             background: #111;
             border-radius: 8px;
         }


### PR DESCRIPTION
## Summary
- setze die Canvasbreite im DE-Audio-Editor proportional zur ermittelten Pixelweite, damit lange Takes sichtbar wachsen
- lasse die Wave-Canvas-Styles die Inlinebreite respektieren und dokumentiere die Änderung in README und CHANGELOG

## Testing
- Manuell in der UI geprüft, dass eine längere DE-Spur breiter dargestellt wird

------
https://chatgpt.com/codex/tasks/task_e_68d7c718e47083279d67927c3f99624b