### PR TITLE
Refine workspace header into compact toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 🛠️ Patch in 1.40.390
+* `web/hla_translation_tool.html` verwandelt den Kopfbereich in eine kompakte Werkzeugzeile mit Projekt-, Werkzeug-, Medien-, System- und Suchsegment; Speicher- und Migrationsaktionen sitzen jetzt gemeinsam im Verwaltungs-Dropdown.
+* `web/src/style.css` liefert das verschlankte Flex-Layout samt einheitlichen Dropdown-Stilen, schlankeren Buttons und neuen Breakpoints für <1200 px sowie <900 px.
+* `README.md` beschreibt die neue Kopfzeile mit gebündelten Aktionen und verweist auf das Verwaltungs-Dropdown.
+* `CHANGELOG.md` dokumentiert die Überarbeitung des kompakten Headers.
 ## 🛠️ Patch in 1.40.389
 * `web/src/main.js` berechnet die Waveform-Breite direkt aus dem Laufzeitverhältnis und setzt die Pixelbreite inline, damit EN- und DE-Spuren exakt nach Dauer skaliert werden.
 * `web/src/style.css` erlaubt die inline gesetzten Pixelbreiten und sichert mit Mindestmaßen die Bedienbarkeit auch bei sehr kurzen Takes ab.

--- a/README.md
+++ b/README.md
@@ -812,6 +812,18 @@ Fehlt eine Abhängigkeit wie PyTorch oder das VC++‑Laufzeitpaket, bricht das S
 
 ## 🎮 Bedienung
 
+### Arbeitsbereich-Header
+
+Der Kopfbereich der Weboberfläche ist jetzt als kompakte Werkzeugzeile mit klar getrennten Sektionen aufgebaut:
+
+* **Projekt:** Import, Untertitel und Ordner-Browser liegen direkt neben dem Eingabefeld, das nun in einer schmalen Inline-Zeile mit dem „Hinzufügen“-Knopf sitzt.
+* **Werkzeuge:** GPT-Bewertung, Zufallsprojekt, Wörterliste sowie die beiden Emotionstools bleiben dauerhaft sichtbar; selten genutzte Helfer (Kopierhilfen, ZIP-Import, Audio-Zuordnung, Debug-Bericht usw.) wandern in ein gemeinsames Overflow-Menü (⋯).
+* **Medien:** Video-Manager und Half-Life: Alyx-Launcher teilen sich einen schlanken Block, in dem Modus, Sprache, optionales `+map`-Feld und Cheat-Dropdown direkt neben dem Startknopf angeordnet sind.
+* **System:** Alle Speicher-Anzeigen inklusive Wechsel-Schalter, Ordner-Öffner und Aufräumen sitzen im neuen „Verwaltung“-Dropdown – gemeinsam mit den Migrationsbefehlen und dem Statusmonitor.
+* **Suche & Verlauf:** Live-Suche, UT-Suche-Button, Kopieroptionen, Sortierungen, Fortschrittsstatistiken und Projekt-Playback laufen in einem durchgehenden Abschlusssegment zusammen.
+
+Unter 1200 px ziehen sich die Gruppen enger zusammen, unter 900 px stapeln sich die Abschnitte automatisch untereinander. Dropdowns folgen dem vereinheitlichten Designschema und schließen nach jeder Aktion automatisch.
+
 ### Projekt‑Management
 
 |  Aktion                    |  Bedienung                                          |
@@ -827,7 +839,7 @@ Fehlt eine Abhängigkeit wie PyTorch oder das VC++‑Laufzeitpaket, bricht das S
 | **Schnell-Level**         | Rechtsklick auf Kapitel → Schnell-Level |
 | **Level anpassen**        | Rechtsklick auf Level-Titel → Bearbeiten/Löschen |
 | **Level‑Name kopieren**   | ⧉‑Button in Meta‑Leiste                           |
-| **Half-Life: Alyx starten** | Zentrale Start-Leiste mit Modus‑ und Sprachauswahl, optionalem +map‑Parameter und Cheat-Dropdown |
+| **Half-Life: Alyx starten** | Medienblock im Header mit Modus- und Sprachauswahl, optionalem +map-Parameter und Cheat-Dropdown |
 
 Beim Rechtsklick auf eine Projekt‑Kachel erscheint ein kleines Menü zum Bearbeiten (⚙️) oder Löschen (🗑️) des Projekts.
 Auch Kapitel und Level bieten dieses Rechtsklick-Menü.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -44,83 +44,183 @@
 
         <!-- Main Content -->
         <main class="main-content">
-            <!-- Projekt-Steuerung & Tools -->
-            <div class="topbar">
-                <div class="project-actions">
-                    <div class="add-files-container">
-                        <textarea class="file-input" placeholder="Dateinamen eingeben (einer pro Zeile)..." id="fileInput" rows="1"></textarea>
-                        <button class="btn" onclick="addFiles()">Hinzufügen</button>
-                    </div>
-                    <button class="btn btn-secondary" onclick="showImportDialog()">📥 Import</button>
-                    <button class="btn btn-secondary" onclick="showCcImportDialog()">📥 Untertitel importieren</button>
-                    <button class="btn btn-secondary" onclick="showFolderBrowser()">📁 Ordner durchsuchen</button>
-                </div>
-                <div class="system-tools">
-                    <button id="randomProjectButton" class="btn btn-secondary">🎲 Zufallsprojekt</button>
-                    <button id="wordListButton" class="btn btn-secondary" onclick="openWordList()">📚 Wörter</button>
-                    <div class="settings-container">
-                        <button id="settingsButton" class="btn btn-secondary" onclick="toggleSettingsMenu()">⚙️ Einstellungen</button>
-                        <div class="settings-menu" id="settingsMenu">
-                            <div class="settings-item" onclick="cleanupDuplicates()">🧹 Duplikate bereinigen</div>
-                            <div class="settings-item" onclick="scanAudioDuplicates()">🎵 Audio-Duplikate</div>
-                            <div class="settings-item" onclick="showBackupDialog()">💾 Backup</div>
-                            <div class="settings-item" onclick="showApiDialog()">🔊 ElevenLabs API</div>
-                            <div class="settings-item" onclick="showGptApiDialog()">💬 ChatGPT API</div>
-                            <div class="settings-item" onclick="resetFileDatabase()">🔄 Reset DB</div>
-                            <div class="settings-item" onclick="updateAllFilePaths()">🔄 Projekte bereinigen</div>
-                            <div class="settings-item" onclick="repairProjectFolders()">🔧 Ordner reparieren</div>
+            <header class="workspace-header">
+                <div class="workspace-toolbar">
+                    <section class="toolbar-group toolbar-group--project" aria-labelledby="toolbarProjectTitle">
+                        <div class="group-main">
+                            <h3 id="toolbarProjectTitle" class="group-title">Projekt</h3>
+                            <div class="group-buttons">
+                                <button class="btn btn-secondary" onclick="showImportDialog()">📥 Import</button>
+                                <button class="btn btn-secondary" onclick="showCcImportDialog()">🎬 Untertitel</button>
+                                <button class="btn btn-secondary" onclick="showFolderBrowser()">📁 Ordner</button>
+                            </div>
                         </div>
-                    </div>
-                    <button id="devToolsButton" class="btn btn-secondary">🐞 DevTools</button>
-                    <button id="debugReportButton" class="btn btn-secondary">📋 Debug-Bericht</button>
-                    <button class="btn btn-secondary" onclick="openDubbingLog()">📝 Protokoll</button>
-                    <button class="btn btn-secondary" onclick="startMigration()">Migration starten</button>
-                    <button class="btn btn-secondary" onclick="loadMigration()">Migration laden</button>
-                    <button class="btn btn-secondary" onclick="migrateData()">Daten migrieren</button>
-                    <span id="storageModeIndicator"></span>
-                    <button id="switchStorageButton" class="btn btn-secondary">...</button>
-                    <button id="openStorageFolderButton" class="btn btn-secondary" onclick="openStorageFolder()">📂 Speicherordner</button>
-                    <div id="storageMonitor" style="min-width:150px;">
-                        <div class="progress-bar"><div class="progress-fill" id="storageUsageFill"></div></div>
-                        <div class="storage-info">
-                            <span id="storageUsageLabel"></span>
-                            <span id="lastCleanupLabel"></span>
-                            <button id="cleanupButton" class="btn btn-secondary">Aufräumen</button>
+                        <div class="group-body">
+                            <label for="fileInput" class="group-label">Dateien hinzufügen</label>
+                            <div class="project-inline">
+                                <textarea class="file-input" placeholder="Dateinamen eingeben (einer pro Zeile)..." id="fileInput" rows="1"></textarea>
+                                <button class="btn btn-primary" onclick="addFiles()">Hinzufügen</button>
+                            </div>
                         </div>
-                    </div>
-                    <div id="migration-status"></div>
+                    </section>
+                    <section class="toolbar-group toolbar-group--tools" aria-labelledby="toolbarToolsTitle">
+                        <div class="group-main">
+                            <h3 id="toolbarToolsTitle" class="group-title">Werkzeuge</h3>
+                            <div class="group-buttons">
+                                <button id="gptScoreButton" class="btn btn-secondary">Bewerten (GPT)</button>
+                                <button id="randomProjectButton" class="btn btn-secondary">🎲 Zufall</button>
+                                <button id="wordListButton" class="btn btn-secondary" onclick="openWordList()">📚 Wörter</button>
+                                <button id="generateEmotionsButton" class="btn btn-blue" title="Erzeugt deutsche Emotionstags für alle Zeilen">Emotionen (DE)</button>
+                                <button id="sendTextV2Button" class="btn btn-blue" title="Alle Emotional-Texte an ElevenLabs senden">An ElevenLabs schicken</button>
+                                <div class="menu-wrapper">
+                                    <button id="toolOverflowToggle" class="btn btn-secondary menu-toggle" data-menu-toggle="toolOverflowMenu" aria-haspopup="true" aria-expanded="false">⋯</button>
+                                    <div class="workspace-dropdown" id="toolOverflowMenu" role="menu">
+                                        <button class="dropdown-item" onclick="openSegmentDialog()">🔊 Audio-Datei zuordnen</button>
+                                        <button class="dropdown-item" onclick="showZipImportDialog()">ZIP importieren</button>
+                                        <button class="dropdown-item" id="copyAssistantButton">Kopierhilfe</button>
+                                        <button class="dropdown-item" id="copyAssistant2Button">Kopierhilfe 2</button>
+                                        <button class="dropdown-item" id="copyAllEmosButton">Emotionen kopieren</button>
+                                        <button class="dropdown-item" id="subtitleSearchAllButton" title="Sucht fehlende deutsche Texte im gesamten Projekt">UT-Suche alles</button>
+                                        <button class="dropdown-item" onclick="openDubbingLog()">📝 Protokoll</button>
+                                        <button class="dropdown-item" id="devToolsButton">🐞 DevTools</button>
+                                        <button class="dropdown-item" id="debugReportButton">📋 Debug-Bericht</button>
+                                    </div>
+                                </div>
+                                <div class="menu-wrapper settings-container">
+                                    <button id="settingsButton" class="btn btn-secondary menu-toggle" onclick="toggleSettingsMenu()" aria-haspopup="true" aria-expanded="false">⚙️ Einstellungen</button>
+                                    <div class="settings-menu workspace-dropdown" id="settingsMenu" role="menu">
+                                        <div class="settings-item" onclick="cleanupDuplicates()">🧹 Duplikate bereinigen</div>
+                                        <div class="settings-item" onclick="scanAudioDuplicates()">🎵 Audio-Duplikate</div>
+                                        <div class="settings-item" onclick="showBackupDialog()">💾 Backup</div>
+                                        <div class="settings-item" onclick="showApiDialog()">🔊 ElevenLabs API</div>
+                                        <div class="settings-item" onclick="showGptApiDialog()">💬 ChatGPT API</div>
+                                        <div class="settings-item" onclick="resetFileDatabase()">🔄 Reset DB</div>
+                                        <div class="settings-item" onclick="updateAllFilePaths()">🔄 Projekte bereinigen</div>
+                                        <div class="settings-item" onclick="repairProjectFolders()">🔧 Ordner reparieren</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                    <section class="toolbar-group toolbar-group--media" aria-labelledby="toolbarMediaTitle">
+                        <div class="group-main">
+                            <h3 id="toolbarMediaTitle" class="group-title">Medien</h3>
+                            <div class="group-buttons">
+                                <button id="openVideoManager" class="btn btn-secondary">🎬 Videos</button>
+                            </div>
+                        </div>
+                        <div class="group-body">
+                            <div class="hla-launch">
+                                <select id="modusSelect">
+                                    <option value="normal">Spiel</option>
+                                    <option value="workshop">Workshop</option>
+                                </select>
+                                <select id="spracheSelect">
+                                    <option value="english">english</option>
+                                    <option value="german">german</option>
+                                </select>
+                                <label class="hla-launch__option">
+                                    <input type="checkbox" id="mapCheckbox"> +map
+                                </label>
+                                <input type="text" id="mapSelect" placeholder="Level">
+                                <div class="start-dropdown">
+                                    <button id="startButton" class="btn btn-secondary" onclick="startHla()" title="">Starten</button>
+                                    <button id="startDropdown" class="btn btn-secondary" onclick="toggleStartMenu()">▼</button>
+                                    <div id="startMenu" class="dropdown-menu">
+                                        <label class="dropdown-item"><input type="checkbox" id="optGod"> Godmode</label>
+                                        <label class="dropdown-item"><input type="checkbox" id="optAmmo"> Unendliche Munition</label>
+                                        <label class="dropdown-item"><input type="checkbox" id="optConsole"> Entwicklerkonsole</label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                    <section class="toolbar-group toolbar-group--system" aria-labelledby="toolbarSystemTitle">
+                        <div class="group-main">
+                            <h3 id="toolbarSystemTitle" class="group-title">System</h3>
+                            <div class="group-buttons">
+                                <div class="menu-wrapper">
+                                    <button id="systemMenuToggle" class="btn btn-secondary menu-toggle" data-menu-toggle="systemMenu" aria-haspopup="true" aria-expanded="false">Verwaltung</button>
+                                    <div class="workspace-dropdown workspace-dropdown--wide" id="systemMenu" role="menu">
+                                        <div class="dropdown-section">
+                                            <h4 class="dropdown-title">Migration</h4>
+                                            <button class="dropdown-item" onclick="startMigration()">Migration starten</button>
+                                            <button class="dropdown-item" onclick="loadMigration()">Migration laden</button>
+                                            <button class="dropdown-item" onclick="migrateData()">Daten migrieren</button>
+                                            <div id="migration-status" class="migration-status"></div>
+                                        </div>
+                                        <div class="dropdown-section">
+                                            <h4 class="dropdown-title">Speicher</h4>
+                                            <div class="storage-compact">
+                                                <div class="storage-status">
+                                                    <span id="storageModeIndicator"></span>
+                                                    <button id="switchStorageButton" class="btn btn-secondary btn-tight">Wechseln</button>
+                                                </div>
+                                                <div id="storageMonitor" class="storage-monitor">
+                                                    <div class="progress-bar"><div class="progress-fill" id="storageUsageFill"></div></div>
+                                                    <div class="storage-info">
+                                                        <span id="storageUsageLabel"></span>
+                                                        <span id="lastCleanupLabel"></span>
+                                                    </div>
+                                                </div>
+                                                <div class="storage-actions">
+                                                    <button id="openStorageFolderButton" class="btn btn-secondary btn-tight" onclick="openStorageFolder()">📂 Speicherordner</button>
+                                                    <button id="cleanupButton" class="btn btn-secondary btn-tight">Aufräumen</button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                    <section class="toolbar-group toolbar-group--search" aria-labelledby="toolbarSearchTitle">
+                        <div class="group-main">
+                            <h3 id="toolbarSearchTitle" class="group-title">Suche &amp; Verlauf</h3>
+                            <button id="subtitleSearchAllButtonInline" class="btn btn-secondary" title="Sucht fehlende deutsche Texte im gesamten Projekt">UT-Suche alles</button>
+                        </div>
+                        <div class="group-body">
+                            <div class="search-bar">
+                                <input type="text" class="search-input" placeholder="Live-Suche: Dateiname oder Text... (Groß-/Kleinschreibung, Punkte ignoriert)" id="searchInput">
+                                <div class="search-results" id="searchResults"></div>
+                            </div>
+                            <div class="search-options copy-options">
+                                <label class="copy-option"><input type="checkbox" id="restTranslationCheckbox"> Reste-Modus</label>
+                                <label class="copy-option"><input type="checkbox" id="copyIncludeTime" checked> Zeit voranstellen</label>
+                                <label class="copy-option"><input type="checkbox" id="copyAddDashes"> --- anhängen</label>
+                                <label class="copy-option"><input type="checkbox" id="copyAddExtremeSpeed"> „extrem schnell reden“ ergänzen</label>
+                            </div>
+                            <div class="search-meta">
+                                <div class="sort-controls">
+                                    <span class="sort-label">Sortierung:</span>
+                                    <button class="sort-btn active" onclick="sortTable('position', event)">Position</button>
+                                    <button class="sort-btn" onclick="sortTable('filename', event)">Dateiname</button>
+                                    <button class="sort-btn" onclick="sortTable('folder', event)">Ordner</button>
+                                    <button class="sort-btn" onclick="sortTable('completion', event)">Fertig</button>
+                                </div>
+                                <div class="progress-info">
+                                    <div class="progress-stat" id="totalProgress">0% vollständig</div>
+                                    <div class="progress-stat" id="folderProgress">0 Ordner</div>
+                                    <div class="progress-stat" id="globalProjectProgress">0% gesamt</div>
+                                    <div class="progress-stat clickable" id="emoProgress" title="Leere und fehlerhafte Emo-Texte neu generieren">🟣 0 | 0 | 0</div>
+                                </div>
+                            </div>
+                            <div class="search-progress">
+                                <div class="progress-bar" id="globalProjectBar">
+                                    <div class="progress-fill" id="globalProjectFill"></div>
+                                </div>
+                                <div class="project-playback">
+                                    <button id="projectPlayPauseBtn" onclick="toggleProjectPlayback()">▶</button>
+                                    <button id="projectStopBtn" onclick="stopProjectPlayback()">⏹</button>
+                                    <button id="numberPrevBtn" onclick="goToPreviousNumber()" title="Eine Nummer zurück">▲</button>
+                                    <button id="numberNextBtn" onclick="goToNextNumber()" title="Eine Nummer weiter">▼</button>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
                 </div>
-            </div>
+            </header>
 
-            <button id="openVideoManager" class="btn btn-secondary">Videos</button>
-
-            <!-- Spielstart-Leiste -->
-            <div class="start-bar">
-                <div class="hla-launch">
-                    <select id="modusSelect">
-                        <option value="normal">Spiel</option>
-                        <option value="workshop">Workshop</option>
-                    </select>
-                    <select id="spracheSelect">
-                        <option value="english">english</option>
-                        <option value="german">german</option>
-                    </select>
-                    <label>
-                        <input type="checkbox" id="mapCheckbox"> +map
-                    </label>
-                    <input type="text" id="mapSelect" placeholder="Level" style="width:140px">
-                    <div class="start-dropdown">
-                        <button id="startButton" class="btn btn-secondary" onclick="startHla()" title="">Starten</button>
-                        <button id="startDropdown" class="btn btn-secondary" onclick="toggleStartMenu()">▼</button>
-                        <div id="startMenu" class="dropdown-menu">
-                            <label class="dropdown-item"><input type="checkbox" id="optGod"> Godmode</label>
-                            <label class="dropdown-item"><input type="checkbox" id="optAmmo"> Unendliche Munition</label>
-                            <label class="dropdown-item"><input type="checkbox" id="optConsole"> Entwicklerkonsole</label>
-                        </div>
-                    </div>
-                </div>
-            </div>
-			
 <!-- =========================== PROJECT META BAR START =========================== -->
 <div class="project-meta-bar" id="projectMetaBar" style="display:none;">
     <span class="meta-project" id="metaProjectName"></span>
@@ -133,51 +233,6 @@
 <!-- =========================== PROJECT META BAR END =========================== -->
 
 
-
-            <!-- Filter-Leiste -->
-            <div class="filter-bar">
-                <div class="search-container">
-                    <input type="text" class="search-input" placeholder="Live-Suche: Dateiname oder Text... (Groß-/Kleinschreibung, Punkte ignoriert)" id="searchInput">
-                    <div class="search-results" id="searchResults"></div>
-                </div>
-                <div class="search-btns">
-                    <button id="gptScoreButton" class="btn btn-secondary">Bewerten (GPT)</button>
-                    <button id="generateEmotionsButton" class="btn btn-blue" title="Erzeugt deutsche Emotionstags für alle Zeilen">Emotionen (DE) generieren</button>
-                    <button id="sendTextV2Button" class="btn btn-blue" title="Alle Emotional-Texte an ElevenLabs senden">An ElevenLabs schicken</button>
-                    <button class="btn btn-secondary" onclick="openSegmentDialog()">🔊 Audio-Datei zuordnen</button>
-                    <button class="btn btn-secondary" onclick="showZipImportDialog()">ZIP importieren</button>
-                    <button id="copyAssistantButton" class="btn btn-secondary">Kopierhilfe</button>
-                    <button id="copyAssistant2Button" class="btn btn-secondary">Kopierhilfe 2</button>
-                    <button id="copyAllEmosButton" class="btn btn-secondary">Emotionen kopieren</button>
-                    <button id="subtitleSearchAllButton" class="btn btn-secondary" title="Sucht fehlende deutsche Texte im gesamten Projekt">UT-Suche alles</button>
-                    <label class="copy-option"><input type="checkbox" id="restTranslationCheckbox"> Reste-Modus</label>
-                    <label class="copy-option"><input type="checkbox" id="copyIncludeTime" checked> Zeit voranstellen</label>
-                    <label class="copy-option"><input type="checkbox" id="copyAddDashes"> --- anhängen</label>
-                    <label class="copy-option"><input type="checkbox" id="copyAddExtremeSpeed"> „extrem schnell reden“ ergänzen</label>
-                </div>
-                <div class="sort-controls">
-                    <span style="color: #999;">Sortierung:</span>
-                    <button class="sort-btn active" onclick="sortTable('position', event)">Position</button>
-                    <button class="sort-btn" onclick="sortTable('filename', event)">Dateiname</button>
-                    <button class="sort-btn" onclick="sortTable('folder', event)">Ordner</button>
-                    <button class="sort-btn" onclick="sortTable('completion', event)">Fertig</button>
-                </div>
-                <div class="progress-info">
-                    <div class="progress-stat" id="totalProgress">0% vollständig</div>
-                    <div class="progress-stat" id="folderProgress">0 Ordner</div>
-                    <div class="progress-stat" id="globalProjectProgress">0% gesamt</div>
-                    <div class="progress-stat clickable" id="emoProgress" title="Leere und fehlerhafte Emo-Texte neu generieren">🟣 0 | 0 | 0</div>
-                </div>
-                <div class="progress-bar" id="globalProjectBar">
-                    <div class="progress-fill" id="globalProjectFill"></div>
-                </div>
-                <div class="project-playback">
-                    <button id="projectPlayPauseBtn" onclick="toggleProjectPlayback()">▶</button>
-                    <button id="projectStopBtn" onclick="stopProjectPlayback()">⏹</button>
-                    <button id="numberPrevBtn" onclick="goToPreviousNumber()" title="Eine Nummer zurück">▲</button>
-                    <button id="numberNextBtn" onclick="goToNextNumber()" title="Eine Nummer weiter">▼</button>
-                </div>
-            </div>
 
             <!-- Scan Progress -->
             <div class="scan-progress" id="scanProgress">
@@ -435,12 +490,12 @@
 <!-- =========================== DIALOG CLOSE BTN START =========================== -->
 <button class="dialog-close-btn" onclick="closeFolderBrowser()">×</button>
 <!-- =========================== DIALOG CLOSE BTN END =========================== -->
-	
+    
             <h3 id="folderBrowserTitle">📁 Ordner durchsuchen</h3>
             <p style="margin-bottom: 15px; color: #999;" id="folderBrowserDescription">
                 Durchsuchen Sie alle verfügbaren Ordner aus der Datenbank und fügen Sie Dateien zu Ihrem Projekt hinzu.
             </p>
-			
+            
 <!-- =========================== LEVEL STATS PANEL START =========================== -->
 <details class="level-stats" id="levelStatsPanel">
     <summary>📊 Übersetzungs-Statistiken pro Level</summary>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -151,58 +151,420 @@ th:nth-child(8) {
             overflow: hidden;
         }
 
-        .topbar,
-        .start-bar,
-        .filter-bar {
-            background: #2a2a2a;
-            padding: 15px 20px;
+        .workspace-header {
+            background: #242424;
             border-bottom: 1px solid #333;
+            padding: 16px 24px 18px;
             display: flex;
-            gap: 15px;
-            align-items: center;
-            flex-wrap: wrap;
+            flex-direction: column;
+            gap: 16px;
         }
 
-        .topbar {
+        .workspace-toolbar {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            align-items: stretch;
+        }
+
+        .toolbar-group {
+            background: #1f1f1f;
+            border: 1px solid #2d2d2d;
+            border-radius: 10px;
+            padding: 12px 14px;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            flex: 1 1 260px;
+            min-width: 0;
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+        }
+
+        .toolbar-group--project { flex: 1 1 320px; }
+        .toolbar-group--tools { flex: 2 1 380px; }
+        .toolbar-group--media { flex: 1 1 280px; }
+        .toolbar-group--system { flex: 1 1 260px; }
+        .toolbar-group--search { flex: 1 1 100%; }
+
+        .group-main {
+            display: flex;
+            align-items: center;
             justify-content: space-between;
-        }
-
-        /* Alte Toolbar-Klasse bleibt für Kompatibilität */
-        .toolbar {
-            background: #2a2a2a;
-            padding: 15px 20px;
-            border-bottom: 1px solid #333;
-            display: flex;
-            gap: 15px;
-            align-items: center;
+            gap: 12px;
             flex-wrap: wrap;
         }
 
-        .search-container {
-            flex: 1;
-            min-width: 250px;
-            position: relative;
-            display: flex; /* Input und Knopf nebeneinander */
-            align-items: center;
+        .group-title {
+            margin: 0;
+            font-size: 12px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: #ff7a33;
+            font-weight: 600;
         }
 
-        .search-input {
+        .group-buttons {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-items: center;
+            justify-content: flex-end;
+        }
+
+        .group-body {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .group-label {
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: #a8a8a8;
+        }
+
+        .project-inline {
+            display: flex;
+            gap: 8px;
+            align-items: stretch;
+        }
+
+        .project-inline .file-input {
             flex: 1;
-            width: auto;
-            padding: 10px 15px;
-            background: #1a1a1a;
-            border: 1px solid #444;
-            border-radius: 6px;
+            min-height: 36px;
+        }
+
+        .project-inline .btn {
+            align-self: stretch;
+        }
+
+        .workspace-header .btn {
+            padding: 8px 12px;
+            border-radius: 8px;
+            font-size: 13px;
+            white-space: nowrap;
+        }
+
+        .workspace-header .btn-secondary {
+            background: #2e2e2e;
+            border: 1px solid #3a3a3a;
+            color: #f1f1f1;
+        }
+
+        .workspace-header .btn-secondary:hover {
+            background: #3a3a3a;
+            border-color: #ff6b1a;
+        }
+
+        .workspace-header .btn-blue {
+            background: #1a73e8;
+            border: none;
+        }
+
+        .btn-tight {
+            padding: 6px 10px;
+            font-size: 12px;
+        }
+
+        .menu-wrapper {
+            position: relative;
+        }
+
+        .menu-toggle {
+            min-width: 42px;
+        }
+
+        .menu-toggle.menu-toggle-active {
+            background: #ff6b1a;
+            border-color: #ff6b1a;
+            color: #fff;
+        }
+
+        .workspace-dropdown {
+            position: absolute;
+            top: calc(100% + 6px);
+            right: 0;
+            background: #1e1e1e;
+            border: 1px solid #333;
+            border-radius: 10px;
+            padding: 8px 0;
+            box-shadow: 0 16px 32px rgba(0, 0, 0, 0.55);
+            min-width: 220px;
+            display: none;
+            z-index: 1200;
+        }
+
+        .workspace-dropdown.menu-open {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .workspace-dropdown--wide {
+            min-width: 340px;
+            padding: 10px 0;
+        }
+
+        .workspace-dropdown .dropdown-section {
+            padding: 6px 16px 12px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+        }
+
+        .workspace-dropdown .dropdown-section:last-child {
+            border-bottom: none;
+            padding-bottom: 14px;
+        }
+
+        .workspace-dropdown .dropdown-title {
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: #ff7a33;
+        }
+
+        .workspace-dropdown .dropdown-item,
+        .workspace-dropdown button:not(.btn) {
+            width: 100%;
+            background: none;
+            border: none;
             color: #e0e0e0;
+            text-align: left;
+            padding: 8px 0;
+            font-size: 13px;
+            cursor: pointer;
+            transition: background 0.2s;
+            display: block;
+        }
+
+        .workspace-dropdown .dropdown-item:hover,
+        .workspace-dropdown button:not(.btn):hover {
+            background: rgba(255, 107, 26, 0.15);
+        }
+
+        .workspace-header select,
+        .workspace-header input[type="text"],
+        .workspace-header textarea {
+            background: #121212;
+            border: 1px solid #333;
+            border-radius: 8px;
+            color: #e0e0e0;
+            padding: 8px 10px;
             font-size: 14px;
             transition: border-color 0.2s;
         }
 
-        .search-input:focus {
+        .workspace-header textarea {
+            resize: vertical;
+            min-height: 36px;
+        }
+
+        .workspace-header select:focus,
+        .workspace-header input[type="text"]:focus,
+        .workspace-header textarea:focus {
             outline: none;
             border-color: #ff6b1a;
+            box-shadow: 0 0 0 1px rgba(255, 107, 26, 0.3);
         }
-			
+
+        .workspace-header label {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 13px;
+            color: #d5d5d5;
+        }
+
+        .workspace-header input[type="checkbox"] {
+            width: 16px;
+            height: 16px;
+        }
+
+        .hla-launch {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-items: center;
+        }
+
+        .hla-launch__option {
+            white-space: nowrap;
+        }
+
+        .hla-launch select,
+        .hla-launch input[type="text"] {
+            min-width: 100px;
+        }
+
+        .hla-launch input[type="text"] {
+            width: 140px;
+        }
+
+        .hla-launch .start-dropdown {
+            display: flex;
+            align-items: stretch;
+        }
+
+        .storage-compact {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .storage-status {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .storage-monitor {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .storage-info {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            font-size: 12px;
+            color: #bdbdbd;
+        }
+
+        .storage-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        .migration-status {
+            min-height: 18px;
+            font-size: 12px;
+            color: #9e9e9e;
+        }
+
+        .toolbar-group--search .search-bar {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            position: relative;
+        }
+
+        .toolbar-group--search .search-input {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .search-options {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 14px;
+            font-size: 13px;
+        }
+
+        .copy-option {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .copy-option input {
+            transform: scale(1.1);
+        }
+
+        .search-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 18px;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .sort-label {
+            color: #999;
+            margin-right: 6px;
+        }
+
+        .search-progress {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+            flex-wrap: wrap;
+        }
+
+        .search-progress .progress-bar {
+            flex: 1;
+            min-width: 220px;
+            background: #111;
+        }
+
+        .workspace-header .progress-fill {
+            background: linear-gradient(90deg, #ff6b1a, #ff9c4a);
+        }
+
+        @media (max-width: 1200px) {
+            .toolbar-group {
+                flex: 1 1 220px;
+            }
+
+            .project-inline {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .project-inline .btn {
+                width: 100%;
+            }
+
+            .group-main {
+                gap: 10px;
+            }
+        }
+
+        @media (max-width: 900px) {
+            .workspace-header {
+                padding: 14px 16px 18px;
+            }
+
+            .toolbar-group {
+                flex: 1 1 100%;
+            }
+
+            .group-main {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 8px;
+            }
+
+            .group-buttons {
+                justify-content: flex-start;
+            }
+
+            .search-meta {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 12px;
+            }
+
+            .search-options {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 10px;
+            }
+
+            .search-progress {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .search-progress .progress-bar {
+                min-width: 0;
+            }
+        }
 
         .search-results {
             position: absolute;
@@ -229,7 +591,7 @@ th:nth-child(8) {
         .copy-option {
             display: flex;
             align-items: center;
-            gap: 4px;
+            gap: 6px;
         }
 		
 		
@@ -1732,26 +2094,19 @@ th:nth-child(8) {
 
         /* Einstellungen-Menü */
         .settings-container {
-            margin-left: auto;
             position: relative;
         }
 
         .settings-menu {
-            position: absolute;
-            top: 100%;
-            right: 0;
-            background: #2a2a2a;
-            border: 1px solid #444;
-            border-radius: 6px;
-            padding: 5px 0;
-            box-shadow: 0 4px 12px rgba(0,0,0,0.5);
-            min-width: 180px;
-            display: none;
-            z-index: 2000;
+            min-width: 220px;
+            border: none;
+            background: #1e1e1e;
+            box-shadow: none;
+            padding: 0;
         }
 
         .settings-item {
-            padding: 10px 15px;
+            padding: 10px 18px;
             cursor: pointer;
             color: #e0e0e0;
             font-size: 14px;
@@ -1759,7 +2114,7 @@ th:nth-child(8) {
         }
 
         .settings-item:hover {
-            background: #333;
+            background: rgba(255, 107, 26, 0.15);
         }
 
         /* Import/Export Dialog */


### PR DESCRIPTION
## Summary
- replace the card grid header with a compact segmented toolbar that keeps core actions visible while moving storage and migration tools into a shared dropdown
- update the CSS with a flex-based layout, unified dropdown styling, and responsive tweaks for the slimmer header
- refresh the README and changelog to describe the streamlined workspace header

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d7d82498d88327b7850a8e6d7a9974