### PR TITLE
Stabile Zeitachsen im DE-Editor bei Tempoänderungen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.391
+* `web/src/main.js` trennt Bearbeitungszustand und Vorschaubuffer, rechnet Trim-/Ignore-/Stille-Werte im Originalzeitraster und setzt Markierungen sowie Overlays nach Tempoänderungen korrekt auf den abgespielten Puffer um.
+* `README.md` beschreibt die stabilen Bearbeitungsmarkierungen bei Tempoanpassungen im DE-Audio-Editor.
+* `CHANGELOG.md` dokumentiert die neue Vorschaulogik und die präziseren Laufzeitberechnungen.
 ## 🛠️ Patch in 1.40.390
 * `web/hla_translation_tool.html` verwandelt den Kopfbereich in eine kompakte Werkzeugzeile mit Projekt-, Werkzeug-, Medien-, System- und Suchsegment; Speicher- und Migrationsaktionen sitzen jetzt gemeinsam im Verwaltungs-Dropdown.
 * `web/src/style.css` liefert das verschlankte Flex-Layout samt einheitlichen Dropdown-Stilen, schlankeren Buttons und neuen Breakpoints für <1200 px sowie <900 px.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Waveform-Werkzeugleiste für große Monitore:** Zoom- und Höhenregler, synchronisiertes Scrollen sowie Zeitmarken-Lineale sorgen dafür, dass lange Takes auch auf Ultrawide-Displays komfortabel editierbar bleiben.
 * **Feinjustierte Waveform-Werkzeugleiste:** Ein enges Grid mit kleineren Buttons und geringem Padding hält Zoom-, Höhen- und Sync-Regler auch bei kleiner Breite dicht beieinander.
 * **Dynamische DE-Wellenformbreite:** Die DE-Wellenform übernimmt die echte Laufzeit als Pixelbreite, wodurch Scrollleisten, Lineale und Zoom exakt zur Audiodauer passen und lange Takes nachvollziehbar länger bleiben als die EN-Spur.
+* **Stabile Bearbeitungsmarkierungen bei Tempoänderungen:** Trims, gelbe Markierungen sowie Ignorier- und Stille-Bereiche bleiben im Originalzeitraster gespeichert, während die Vorschau alle Overlays auf den tatsächlich abgespielten, ggf. gedehnten Puffer umrechnet.
 * **Master-Timeline entfernt:** Die frühere Zeitleiste oberhalb der Wellen entfällt; Zoom-Tasten, Positions-Slider und Sprungknöpfe sitzen jetzt direkt in der Wave-Toolbar.
 * **Dichteres Waveform-Raster:** Kleinere Gitterabstände, schmalere Blockabstände und reduziertes Scroll-Padding rücken Original- und DE-Wellenform noch näher zusammen und verkürzen die Wege zu den Buttons.
 * **Schlankere Standard-Wellenform:** Neu geöffnete Sitzungen starten mit 80 px hohen Wellenformen, der Höhen-Slider zeigt denselben Startwert und die kompakten Buttons bleiben voll erreichbar.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -663,7 +663,7 @@ function focusWaveSelection() {
         handled = true;
     }
     const deScroll = document.getElementById('waveEditedScroll');
-    if (deScroll && originalEditBuffer) {
+    if (deScroll && previewEditBuffer) {
         if (deSelectionActive) {
             const start = editStartTrim;
             const end = editDurationMs - editEndTrim;
@@ -726,8 +726,8 @@ function updateWaveRulers() {
     }
     const deCanvas = document.getElementById('waveEdited');
     const deRuler = document.getElementById('waveEditedRuler');
-    if (deCanvas && deRuler && originalEditBuffer) {
-        drawWaveRuler(deRuler, deCanvas, originalEditBuffer);
+    if (deCanvas && deRuler && previewEditBuffer) {
+        drawWaveRuler(deRuler, deCanvas, previewEditBuffer);
     }
 }
 
@@ -13633,6 +13633,7 @@ function bufferToWav(buffer) {
 
 let currentEditFile = null;
 let originalEditBuffer = null;
+let previewEditBuffer = null; // Vorschaubuffer nach allen Bearbeitungen
 let savedOriginalBuffer = null; // Unverändertes DE-Audio
 let volumeMatchedBuffer = null; // Lautstärke an EN angepasst
 let isVolumeMatched = false;   // Merkt, ob der Lautstärkeabgleich ausgeführt wurde
@@ -13669,6 +13670,7 @@ async function openDeEdit(fileId) {
         originalEditBuffer = await loadAudioBuffer(backupSrc);
     }
     savedOriginalBuffer = originalEditBuffer;
+    previewEditBuffer = null;
     volumeMatchedBuffer = null;
     isVolumeMatched = false;
     radioEffectBuffer = null;
@@ -14663,6 +14665,13 @@ async function applyVolumeMatch() {
 // Wendet alle Effekte und Schnitte in gleicher Reihenfolge wie beim Speichern an
 async function recomputeEditBuffer() {
     let buf = savedOriginalBuffer;
+    if (!buf) {
+        previewEditBuffer = null;
+        originalEditBuffer = null;
+        editDurationMs = 0;
+        updateDeEditWaveforms();
+        return;
+    }
     if (isVolumeMatched) {
         // Lautstärkeangleichung ggf. zwischenspeichern
         if (!volumeMatchedBuffer) {
@@ -14689,17 +14698,30 @@ async function recomputeEditBuffer() {
         buf = await applyInterferenceEffect(buf);
     }
 
-    // Trimmen und Pausen entfernen, damit die Vorschau exakt dem Endergebnis entspricht
-    let trimmed = trimAndPadBuffer(buf, editStartTrim, editEndTrim);
-    const adj = editIgnoreRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim }));
-    trimmed = removeRangesFromBuffer(trimmed, adj);
-    const pads = editSilenceRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim }));
-    trimmed = insertSilenceIntoBuffer(trimmed, pads);
+    // Bearbeitungsgrundlage sichern, damit alle Zeitangaben im ursprünglichen Raster bleiben
+    originalEditBuffer = buf;
+    if (originalEditBuffer) {
+        editDurationMs = originalEditBuffer.length / originalEditBuffer.sampleRate * 1000;
+        // Sicherstellen, dass Trim-Werte innerhalb der neuen Dauer liegen
+        editStartTrim = Math.max(0, Math.min(editStartTrim, editDurationMs));
+        const maxEndTrim = Math.max(0, editDurationMs - editStartTrim);
+        editEndTrim = Math.max(0, Math.min(editEndTrim, maxEndTrim));
+    } else {
+        editDurationMs = 0;
+    }
 
-    // Erst danach das Tempo anpassen
-    const relFactor = tempoFactor / loadedTempoFactor; // nur Differenz anwenden
-    originalEditBuffer = await timeStretchBuffer(trimmed, relFactor);
-    editDurationMs = originalEditBuffer.length / originalEditBuffer.sampleRate * 1000;
+    // Vorschaubuffer inklusive Schnitten, Pausen und Tempo vorbereiten
+    let preview = originalEditBuffer ? trimAndPadBuffer(originalEditBuffer, editStartTrim, editEndTrim) : null;
+    if (preview) {
+        const ignoreRanges = editIgnoreRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim }));
+        preview = removeRangesFromBuffer(preview, ignoreRanges);
+        const silenceRanges = editSilenceRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim }));
+        preview = insertSilenceIntoBuffer(preview, silenceRanges);
+        const relFactor = tempoFactor / loadedTempoFactor; // nur Differenz anwenden
+        previewEditBuffer = await timeStretchBuffer(preview, relFactor);
+    } else {
+        previewEditBuffer = null;
+    }
     updateDeEditWaveforms();
 }
 // =========================== RECOMPUTEEDITBUFFER END =======================
@@ -15232,7 +15254,66 @@ function updateDeEditWaveforms(progressOrig = null, progressDe = null) {
     }
 
     const showOrig = progressOrig !== null ? progressOrig : editOrigCursor;
-    const showDe   = progressDe !== null ? progressDe + editStartTrim : editDeCursor;
+
+    // Hilfswerte für die Umrechnung auf den Vorschaubuffer ermitteln
+    const tempoScaleRaw = loadedTempoFactor ? tempoFactor / loadedTempoFactor : tempoFactor;
+    const tempoScale = Math.abs(tempoScaleRaw) > 1e-6 ? tempoScaleRaw : 1;
+    const trimmedLength = Math.max(0, editDurationMs - editStartTrim - editEndTrim);
+
+    const toTrimmedRange = (ranges) => normalizeRanges(
+        ranges.map(r => ({
+            start: r.start - editStartTrim,
+            end: r.end - editStartTrim
+        })),
+        trimmedLength
+    );
+
+    const ignoreTrimmed = toTrimmedRange(editIgnoreRanges);
+    const mapTrimmedToAfterIgnore = (ms) => {
+        let adjusted = Math.max(0, Math.min(trimmedLength, ms));
+        for (const r of ignoreTrimmed) {
+            if (ms <= r.start) break;
+            const overlap = Math.min(ms, r.end) - r.start;
+            if (overlap > 0) adjusted -= overlap;
+        }
+        return Math.max(0, adjusted);
+    };
+
+    const trimmedAfterIgnore = mapTrimmedToAfterIgnore(trimmedLength);
+
+    const silenceTrimmed = toTrimmedRange(editSilenceRanges);
+    const silenceAfterIgnore = silenceTrimmed
+        .map(r => ({
+            start: mapTrimmedToAfterIgnore(r.start),
+            end: mapTrimmedToAfterIgnore(r.end)
+        }))
+        .filter(r => r.end > r.start);
+    const silenceNormalized = normalizeRanges(silenceAfterIgnore, trimmedAfterIgnore);
+
+    const silenceOffsetBefore = (ms, includeCurrent = false) => {
+        let offset = 0;
+        for (const r of silenceNormalized) {
+            if (ms < r.start) break;
+            if (!includeCurrent && ms === r.start) break;
+            offset += r.end - r.start;
+        }
+        return offset;
+    };
+
+    const toFinalTimeline = (originalMs, includeCurrentSilence = false) => {
+        const trimmedMs = Math.max(0, Math.min(trimmedLength, originalMs - editStartTrim));
+        const afterIgnore = mapTrimmedToAfterIgnore(trimmedMs);
+        const offset = silenceOffsetBefore(afterIgnore, includeCurrentSilence);
+        return (afterIgnore + offset) / tempoScale;
+    };
+
+    const finalDurationBeforeTempo = trimmedAfterIgnore + silenceOffsetBefore(trimmedAfterIgnore, true);
+    const finalDuration = finalDurationBeforeTempo / tempoScale;
+
+    const showDeOrig = progressDe !== null ? progressDe + editStartTrim : editDeCursor;
+    let showDe = toFinalTimeline(showDeOrig);
+    if (!Number.isFinite(showDe)) showDe = 0;
+    showDe = Math.max(0, Math.min(finalDuration, showDe));
 
     if (editEnBuffer) {
         const opts = { progress: showOrig };
@@ -15243,14 +15324,36 @@ function updateDeEditWaveforms(progressOrig = null, progressDe = null) {
         }
         drawWaveform(document.getElementById('waveOriginal'), editEnBuffer, opts);
     }
-    if (originalEditBuffer) {
-        const selStart = editStartTrim;
-        const selEnd   = editDurationMs - editEndTrim;
-        const opts = { progress: showDe, ignore: editIgnoreRanges, silence: editSilenceRanges };
-        if (deSelectionActive && selStart < selEnd) {
-            opts.selection = { start: selStart, end: selEnd };
+    if (previewEditBuffer) {
+        const selectionStartFinal = toFinalTimeline(editStartTrim);
+        const selectionEndFinal = toFinalTimeline(editDurationMs - editEndTrim, true);
+
+        const ignoreOverlays = ignoreTrimmed
+            .map(r => {
+                const startAfterIgnore = mapTrimmedToAfterIgnore(r.start);
+                const startOffset = silenceOffsetBefore(startAfterIgnore, false);
+                const startFinal = (startAfterIgnore + startOffset) / tempoScale;
+                const span = Math.max(0, r.end - r.start) / tempoScale;
+                return { start: startFinal, end: startFinal + span };
+            })
+            .filter(r => r.end > r.start);
+
+        const silenceOverlays = silenceNormalized
+            .map(r => {
+                const startOffset = silenceOffsetBefore(r.start, false);
+                const startFinal = (r.start + startOffset) / tempoScale;
+                const span = Math.max(0, r.end - r.start) / tempoScale;
+                return { start: startFinal, end: startFinal + span };
+            })
+            .filter(r => r.end > r.start);
+
+        const opts = { progress: showDe };
+        if (ignoreOverlays.length) opts.ignore = ignoreOverlays;
+        if (silenceOverlays.length) opts.silence = silenceOverlays;
+        if (deSelectionActive && selectionEndFinal > selectionStartFinal) {
+            opts.selection = { start: selectionStartFinal, end: selectionEndFinal };
         }
-        drawWaveform(document.getElementById('waveEdited'), originalEditBuffer, opts);
+        drawWaveform(document.getElementById('waveEdited'), previewEditBuffer, opts);
     }
     const sInput = document.getElementById('editStart');
     const eInput = document.getElementById('editEnd');
@@ -15350,16 +15453,43 @@ function adjustSilenceRanges(deltaMs) {
 
 // Berechnet die finale Laenge nach Schnitt, Ignorierbereichen und Tempo
 function calcFinalLength() {
-    let len = editDurationMs - editStartTrim - editEndTrim;
-    for (const r of editIgnoreRanges) {
-        len -= Math.max(0, r.end - r.start);
+    const tempoScaleRaw = loadedTempoFactor ? tempoFactor / loadedTempoFactor : tempoFactor;
+    const tempoScale = Math.abs(tempoScaleRaw) > 1e-6 ? tempoScaleRaw : 1;
+    const trimmedLength = Math.max(0, editDurationMs - editStartTrim - editEndTrim);
+
+    const ignoreTrimmed = normalizeRanges(
+        editIgnoreRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim })),
+        trimmedLength
+    );
+    let afterIgnore = trimmedLength;
+    for (const r of ignoreTrimmed) {
+        afterIgnore -= Math.max(0, r.end - r.start);
     }
-    for (const r of editSilenceRanges) {
-        len += Math.max(0, r.end - r.start);
+
+    const mapTrimmedToAfterIgnore = (ms) => {
+        let adjusted = Math.max(0, Math.min(trimmedLength, ms));
+        for (const r of ignoreTrimmed) {
+            if (ms <= r.start) break;
+            const overlap = Math.min(ms, r.end) - r.start;
+            if (overlap > 0) adjusted -= overlap;
+        }
+        return Math.max(0, adjusted);
+    };
+
+    const silenceTrimmed = normalizeRanges(
+        editSilenceRanges.map(r => ({ start: r.start - editStartTrim, end: r.end - editStartTrim })),
+        trimmedLength
+    );
+    let totalSilence = 0;
+    for (const r of silenceTrimmed) {
+        const start = mapTrimmedToAfterIgnore(r.start);
+        const end = mapTrimmedToAfterIgnore(r.end);
+        if (end > start) {
+            totalSilence += end - start;
+        }
     }
-    // Aktuelle Datei ist bereits mit loadedTempoFactor gestretcht
-    const relFactor = tempoFactor / loadedTempoFactor;
-    return len / relFactor;
+
+    return (afterIgnore + totalSilence) / tempoScale;
 }
 
 // Aktualisiert Anzeige und Farbe je nach Abweichung zur EN-Laenge
@@ -15553,6 +15683,7 @@ function closeDeEdit() {
     currentEditFile = null;
     originalEditBuffer = null;
     savedOriginalBuffer = null;
+    previewEditBuffer = null;
     volumeMatchedBuffer = null;
     isVolumeMatched = false;
     radioEffectBuffer = null;


### PR DESCRIPTION
## Zusammenfassung
- entkoppelt Bearbeitungszustand und Vorschaubuffer, sodass Trims, Ignorier- und Stillebereiche im Originalzeitraster bleiben
- berechnet Markierung, Ignorier- und Stille-Overlays mit Tempo-Umrechnung auf dem tatsächlich angezeigten Puffer
- korrigiert die Laufzeitberechnung und dokumentiert die stabilen Markierungen in README sowie CHANGELOG

## Tests
- nicht ausführbar (manuelle Browserprüfung erforderlich)


------
https://chatgpt.com/codex/tasks/task_e_68d7f78185148327a7dabf24aa30c433