### PR TITLE
Sorge für sichtbare Trim-Markierung nach dem Speichern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.393
+* `web/src/main.js` belässt nach dem Speichern die Trim-Markierung aktiv und ergänzt den Speichern-Hinweis um DE- und EN-Längen.
+* `README.md` erwähnt den dauerhaft markierten Bereich und die kombinierte Längenanzeige im DE-Audio-Editor.
+* `CHANGELOG.md` dokumentiert die sichtbare Markierung und die zusätzliche Infozeile im Speichern-Hinweis.
 ## 🛠️ Patch in 1.40.392
 * `web/hla_translation_tool.html` ergänzt im Kopfbereich des DE-Audio-Dialogs eine zweite Aktionsleiste mit „Zurücksetzen“, „Speichern“ sowie „Speichern & schließen“.
 * `web/src/style.css` richtet die neue Kopfzeile per Flex-Layout aus und sorgt für passende Abstände und Button-Umbruch.

--- a/README.md
+++ b/README.md
@@ -753,6 +753,7 @@ Seit Patch 1.40.127 besitzt der DE-Audio-Editor überarbeitete Buttons mit hilfr
 Seit Patch 1.40.242 zeigt der DE-Audio-Editor seine Bedienelemente in zwei Spalten, sodass kein Scrollen mehr nötig ist.
 Seit Patch 1.40.243 ordnet der DE-Audio-Editor Bereiche und Effekte in drei Spalten an. Lange Listen besitzen eigene Scrollleisten, sodass nichts überlappt.
 Seit Patch 1.40.244 bietet der DE-Audio-Editor eine untere Effekt-Toolbar und eigene Anwenden-Knöpfe in den Effekt-Kästen.
+Neu: Nach dem Speichern bleibt der komplette DE-Bereich markiert und der Infotext zeigt direkt die aktuellen DE- und EN-Längen.
 Seit Patch 1.40.245 bleibt diese Effekt-Toolbar als Sticky-Footer sichtbar, und "Speichern" erscheint als primärer Button. "Zurücksetzen" fragt jetzt nach einer Bestätigung.
 Seit Patch 1.40.386 ersetzt eine kompakte Fußleiste ohne Sticky-Verhalten die separate Effekt-Toolbar; Zurücksetzen und Speichern bleiben weiterhin schnell erreichbar.
 Seit Patch 1.40.391 erlaubt der Speichern-Button mehrere Durchläufe hintereinander: Die Puffer werden sofort aktualisiert und nur „Speichern & schließen“ beendet den Dialog ausdrücklich.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -15885,7 +15885,15 @@ async function applyDeEdit(param = {}) {
         // Zeitstempel setzen und Erfolg melden
         const now = new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
         const info = document.getElementById('deEditSaveInfo');
-        if (info) info.textContent = `Zuletzt gespeichert: ${now}`;
+        if (info) {
+            // Anzeige mit DE- und EN-Länge ergänzen, damit beide Werte nach dem Speichern sichtbar bleiben
+            const teile = [`Zuletzt gespeichert: ${now}`];
+            const deSekunden = finalBuffer ? (finalBuffer.length / finalBuffer.sampleRate) : null;
+            const enSekunden = editEnBuffer ? (editEnBuffer.length / editEnBuffer.sampleRate) : null;
+            if (Number.isFinite(deSekunden)) teile.push(`DE: ${deSekunden.toFixed(2)}s`);
+            if (Number.isFinite(enSekunden)) teile.push(`EN: ${enSekunden.toFixed(2)}s`);
+            info.textContent = teile.join(' • ');
+        }
         if (typeof showToast === 'function') {
             showToast('DE-Audio gespeichert', 'success');
         }
@@ -15897,10 +15905,12 @@ async function applyDeEdit(param = {}) {
         originalEditBuffer = finalBuffer;
         editDurationMs = finalBuffer.length / finalBuffer.sampleRate * 1000;
         loadedTempoFactor = tempoFactor;
-        deSelectionActive = false;
+        // Nach dem Speichern soll die vollständige Datei weiterhin markiert bleiben
+        deSelectionActive = true;
         volumeMatchedBuffer = null;
         refreshSilenceList();
         updateDeEditWaveforms(0, 0);
+        validateDeSelection();
         updateEffectButtons();
         updateStatus('DE-Audio bearbeitet und gespeichert');
         // Sofort speichern, damit die Bearbeitung gesichert ist


### PR DESCRIPTION
## Zusammenfassung
- halte nach dem Speichern der DE-Bearbeitung die komplette Trim-Markierung aktiv und validiere die Eingabefelder erneut
- ergänze den Speichern-Hinweis um eine kombinierte Anzeige der DE- und EN-Laufzeit
- dokumentiere die Änderungen in README und CHANGELOG

## Tests
- npm test *(schlägt in der Testumgebung wegen fehlender DOM-API im JSDOM-Ersatz für document.querySelector fehl)*

------
https://chatgpt.com/codex/tasks/task_e_68d803f5250c8327bc52f2cc38bcb01d