### PR TITLE
Synchronisiere EN-Wellenform nach Speichern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.394
+* `web/src/main.js` gleicht nach jedem Speichern die EN-Wellenform mit Trims, Pausenentfernungen und Tempoanpassungen ab und aktualisiert zugleich die Laufzeitlabels.
+* `README.md` erwähnt die sofort synchronisierte EN-Vorschau nach gespeicherten Änderungen.
+* `CHANGELOG.md` dokumentiert die neue Anpassung der EN-Anzeige.
 ## 🛠️ Patch in 1.40.393
 * `web/src/main.js` belässt nach dem Speichern die Trim-Markierung aktiv und ergänzt den Speichern-Hinweis um DE- und EN-Längen.
 * `README.md` erwähnt den dauerhaft markierten Bereich und die kombinierte Längenanzeige im DE-Audio-Editor.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Waveform-Werkzeugleiste für große Monitore:** Zoom- und Höhenregler, synchronisiertes Scrollen sowie Zeitmarken-Lineale sorgen dafür, dass lange Takes auch auf Ultrawide-Displays komfortabel editierbar bleiben.
 * **Feinjustierte Waveform-Werkzeugleiste:** Ein enges Grid mit kleineren Buttons und geringem Padding hält Zoom-, Höhen- und Sync-Regler auch bei kleiner Breite dicht beieinander.
 * **Dynamische DE-Wellenformbreite:** Die DE-Wellenform übernimmt die echte Laufzeit als Pixelbreite, wodurch Scrollleisten, Lineale und Zoom exakt zur Audiodauer passen und lange Takes nachvollziehbar länger bleiben als die EN-Spur.
+* **Synchronisierte EN-Vorschau nach dem Speichern:** Sobald du Trims, Pausen oder Tempo-Anpassungen übernimmst, spiegelt die EN-Wellenform die Änderungen und zeigt sofort die neue Laufzeit an.
 * **Master-Timeline entfernt:** Die frühere Zeitleiste oberhalb der Wellen entfällt; Zoom-Tasten, Positions-Slider und Sprungknöpfe sitzen jetzt direkt in der Wave-Toolbar.
 * **Dichteres Waveform-Raster:** Kleinere Gitterabstände, schmalere Blockabstände und reduziertes Scroll-Padding rücken Original- und DE-Wellenform noch näher zusammen und verkürzen die Wege zu den Buttons.
 * **Schlankere Standard-Wellenform:** Neu geöffnete Sitzungen starten mit 80 px hohen Wellenformen, der Höhen-Slider zeigt denselben Startwert und die kompakten Buttons bleiben voll erreichbar.


### PR DESCRIPTION
## Zusammenfassung
- synchronisiere die EN-Vorschau nach jedem Speichern mit Trims, Pausen- und Tempoanpassungen
- aktualisiere Laufzeitlabels sowie Canvas-Skalierung für beide Wellenformen unmittelbar nach dem Speichern
- beschreibe die Änderung in README und CHANGELOG

## Tests
- nicht ausgeführt (UI-Anpassung ohne automatisierte Tests)


------
https://chatgpt.com/codex/tasks/task_e_68d8285d13d0832796835266dd75e70b