### PR TITLE
Deckelung der Trim-Felder im DE-Audio-Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.400
+* `web/src/main.js` kapselt die Eingaben für Start- und End-Trim in `setTrimInputValueSafe`, deckelt alle Werte auf `editDurationMs` und sorgt dafür, dass `validateDeSelection()` nach Auto-Trim, Tempoabgleich und Speichern stabile Markierungen sieht.
+* `README.md` beschreibt die gedeckelten Trim-Felder sowie die manuelle Prüfung mit Auto-Trim, Tempo und anschließendem Speichern.
+* `CHANGELOG.md` dokumentiert die neue Absicherung der Trim-Felder gegen Überläufe.
 ## 🛠️ Patch in 1.40.399
 * `web/src/main.js` normalisiert nach dem Speichern Start- und End-Trim per `normalizeDeTrim()`, belässt `deSelectionActive` aktiv und hält damit die vollständige Markierung sichtbar, ohne die Eingabefelder auf `0` zurückzusetzen.
 * `README.md` beschreibt die unverändert aktive Markierung samt korrekt befüllter Trim-Felder nach dem Speichern.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Feinjustierte Waveform-Werkzeugleiste:** Ein enges Grid mit kleineren Buttons und geringem Padding hält Zoom-, Höhen- und Sync-Regler auch bei kleiner Breite dicht beieinander.
 * **Dynamische DE-Wellenformbreite:** Die DE-Wellenform übernimmt die echte Laufzeit als Pixelbreite, wodurch Scrollleisten, Lineale und Zoom exakt zur Audiodauer passen und lange Takes nachvollziehbar länger bleiben als die EN-Spur.
 * **Frische EN- und DE-Vorschau nach dem Speichern:** Nach dem Speichern lädt der Editor beide Spuren komplett neu, wodurch die EN-Originalspur wieder in voller Länge sichtbar bleibt und nicht mehr zur Miniatur zusammenschrumpft. Gleichzeitig steht die frisch gespeicherte DE-Fassung sofort als neue Arbeitsbasis bereit.
+* **Deckelung der Trim-Eingaben:** Die Start- und Endfelder im DE-Audio-Editor begrenzen sich jetzt strikt auf die reale Laufzeit. Auto-Trim, Tempoabgleich und anschließendes Speichern lassen die Markierung sichtbar und gültig, weil `validateDeSelection()` nur noch mit sicheren Werten arbeitet.
 * **Stabile Trim-Markierung trotz Längenänderungen:** Sobald Auto-Tempo, Pausenentfernung oder Speichern die Gesamtdauer verändern, klemmt der Editor Start- und End-Trim jetzt automatisch auf gültige Werte, synchronisiert die Eingabefelder und hält die grüne Auswahlmarkierung dauerhaft sichtbar.
 * **Aktive DE-Markierung nach dem Speichern:** `applyDeEdit()` setzt Start- und End-Trim nach dem Speichern über `normalizeDeTrim()` auf gültige Werte zurück, lässt `deSelectionActive` bestehen und setzt die Eingabefelder auf die echte Laufzeit statt auf `0`, sodass die Markierung den kompletten Clip weiterhin abbildet.
 * **Master-Timeline entfernt:** Die frühere Zeitleiste oberhalb der Wellen entfällt; Zoom-Tasten, Positions-Slider und Sprungknöpfe sitzen jetzt direkt in der Wave-Toolbar.
@@ -1232,6 +1233,12 @@ verwendet werden, um optionale Downloads zu überspringen.
 
 * Ausgabe erfolgt auf Deutsch.
 * Timing der Sprachausgabe passt zum Original.
+
+### Manuelle Prüfung
+
+* **Auto-Trim + Tempo** – Im DE-Audio-Editor zuerst „Auto-Trim“ auslösen, danach „Tempo automatisch anpassen“.
+* **Werte kontrollieren** – Prüfen, dass Start- und Endfelder die Laufzeit nicht überschreiten.
+* **Speichern** – Mit „Speichern“ bestätigen und sicherstellen, dass die grüne Markierung (`deSelectionActive`) sichtbar bleibt.
 
 ## 🧩 Wichtige Funktionen
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -512,6 +512,14 @@ let currentEnSeconds      = 0;     // Länge der EN-Datei in Sekunden
 let currentDeSeconds      = 0;     // Länge der DE-Datei in Sekunden
 let maxWaveSeconds        = 0;     // Maximale Länge zur Skalierung
 
+// Sichert Eingabewerte für Trim-Felder gegen Überläufe oberhalb der Gesamtdauer ab
+function setTrimInputValueSafe(input, valueMs, maxDurationMs = editDurationMs) {
+    if (!input) return;
+    const sichereDauer = Number.isFinite(maxDurationMs) && maxDurationMs > 0 ? Math.floor(maxDurationMs) : 0;
+    const kandidat = Number.isFinite(valueMs) ? Math.floor(valueMs) : 0;
+    input.value = Math.max(0, Math.min(kandidat, sichereDauer));
+}
+
 // Normalisiert die Trim-Werte nach Änderungen der Gesamtdauer und hält die Eingabefelder konsistent
 function normalizeDeTrim() {
     // Unerwartete Dauern abfangen und auf 0 begrenzen
@@ -527,13 +535,9 @@ function normalizeDeTrim() {
 
     // Eingabefelder synchronisieren
     const startInput = document.getElementById('editStart');
-    if (startInput) {
-        startInput.value = Math.round(editStartTrim);
-    }
+    setTrimInputValueSafe(startInput, editStartTrim, maxDuration);
     const endInput = document.getElementById('editEnd');
-    if (endInput) {
-        endInput.value = Math.round(maxDuration - editEndTrim);
-    }
+    setTrimInputValueSafe(endInput, maxDuration - editEndTrim, maxDuration);
 
     validateDeSelection();
 }
@@ -13772,8 +13776,8 @@ async function openDeEdit(fileId) {
             startInput.select();
         }
     };
-    document.getElementById('editStart').value = editStartTrim;
-    document.getElementById('editEnd').value = editDurationMs - editEndTrim;
+    setTrimInputValueSafe(document.getElementById('editStart'), editStartTrim);
+    setTrimInputValueSafe(document.getElementById('editEnd'), editDurationMs - editEndTrim);
     document.getElementById('editStart').oninput = e => {
         const val = parseInt(e.target.value) || 0;
         editStartTrim = Math.max(0, Math.min(val, editDurationMs));
@@ -14427,8 +14431,8 @@ async function openDeEdit(fileId) {
         editEndTrim = 0;
         const sField = document.getElementById('editStart');
         const eField = document.getElementById('editEnd');
-        if (sField) sField.value = 0;
-        if (eField) eField.value = Math.round(editDurationMs);
+        setTrimInputValueSafe(sField, 0);
+        setTrimInputValueSafe(eField, editDurationMs);
         resetCanvasZoom(deCanvas);
         validateDeSelection();
         scheduleWaveformUpdate();
@@ -14443,8 +14447,8 @@ async function openDeEdit(fileId) {
             editEndTrim   = editDurationMs - Math.max(deDragStart, time);
             const sField = document.getElementById('editStart');
             const eField = document.getElementById('editEnd');
-            if (sField) sField.value = Math.round(editStartTrim);
-            if (eField) eField.value = Math.round(editDurationMs - editEndTrim);
+            setTrimInputValueSafe(sField, editStartTrim);
+            setTrimInputValueSafe(eField, editDurationMs - editEndTrim);
             validateDeSelection();
             scheduleWaveformUpdate();
             return;
@@ -14479,8 +14483,8 @@ async function openDeEdit(fileId) {
         }
         const sField = document.getElementById('editStart');
         const eField = document.getElementById('editEnd');
-        if (sField) sField.value = Math.round(editStartTrim);
-        if (eField) eField.value = Math.round(editDurationMs - editEndTrim);
+        setTrimInputValueSafe(sField, editStartTrim);
+        setTrimInputValueSafe(eField, editDurationMs - editEndTrim);
         validateDeSelection();
         scheduleWaveformUpdate();
     };
@@ -14524,8 +14528,8 @@ async function openDeEdit(fileId) {
                 editEndTrim   = dePrevEndTrim;
                 const sField = document.getElementById('editStart');
                 const eField = document.getElementById('editEnd');
-                if (sField) sField.value = Math.round(editStartTrim);
-                if (eField) eField.value = Math.round(editDurationMs - editEndTrim);
+                setTrimInputValueSafe(sField, editStartTrim);
+                setTrimInputValueSafe(eField, editDurationMs - editEndTrim);
                 editDeCursor = start;
                 if (editPlaying === 'de') {
                     const audio = document.getElementById('audioPlayer');
@@ -14559,8 +14563,8 @@ async function openDeEdit(fileId) {
                 editEndTrim = 0;
                 const sField = document.getElementById('editStart');
                 const eField = document.getElementById('editEnd');
-                if (sField) sField.value = 0;
-                if (eField) eField.value = Math.round(editDurationMs);
+                setTrimInputValueSafe(sField, 0);
+                setTrimInputValueSafe(eField, editDurationMs);
                 resetCanvasZoom(deCanvas);
                 validateDeSelection();
                 scheduleWaveformUpdate();
@@ -15318,8 +15322,8 @@ function updateDeEditWaveforms(progressOrig = null, progressDe = null) {
     }
     const sInput = document.getElementById('editStart');
     const eInput = document.getElementById('editEnd');
-    if (sInput) sInput.value = deSelectionActive ? Math.round(editStartTrim) : 0;
-    if (eInput) eInput.value = deSelectionActive ? Math.round(editDurationMs - editEndTrim) : 0;
+    setTrimInputValueSafe(sInput, deSelectionActive ? editStartTrim : 0);
+    setTrimInputValueSafe(eInput, deSelectionActive ? (editDurationMs - editEndTrim) : 0);
     updateWaveRulers();
     updateLengthInfo();
     updateMasterTimeline();


### PR DESCRIPTION
## Summary
- klemme Start- und End-Trim-Eingaben über `setTrimInputValueSafe` auf die reale Laufzeit und halte `validateDeSelection()` stabil
- sorge in allen Pfaden von `openDeEdit` und `updateDeEditWaveforms` für identisch gedeckelte Werte
- ergänze README und CHANGELOG um die Beschreibung der neuen Absicherung sowie die manuelle Testempfehlung

## Testing
- npm test *(schlägt im DOM-losen Testlauf erwartungsgemäß fehl)*

------
https://chatgpt.com/codex/tasks/task_e_68d856c4e20c8327910fae0f83a04aba