### PR TITLE
Handle DE audio cache case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 🛠️ Patch in 1.40.401
+* `web/src/main.js` führt einen case-insensitiven Index für `deAudioCache` ein, stellt Hilfsfunktionen zum Setzen/Löschen bereit und überträgt bestehende Einträge beim Cleanup automatisch in die neue Struktur.
+* `web/src/dubbing.js` und `web/src/projectSwitch.js` verwenden die neuen Helfer, damit alle Schreib- und Löschvorgänge den Index aktuell halten.
+* `web/src/calculateProjectStats.js` nutzt eine case-insensitive Suche, sodass `.WAV`- und `.MP3`-Dateien mit Großbuchstaben im Fortschrittsbalken korrekt erscheinen.
+* `tests/calculateProjectStats.test.js` ergänzt eine Prüfung, die die Erkennung von `.WAV`-Dateien mit Großbuchstaben absichert.
+* `README.md` beschreibt den case-insensitiven Audio-Abgleich für die Fortschrittsanzeige.
+* `CHANGELOG.md` dokumentiert die Umstellung auf den case-insensitiven Audio-Cache und die Auswirkungen auf die Statistiken.
 ## 🛠️ Patch in 1.40.400
 * `web/src/main.js` kapselt die Eingaben für Start- und End-Trim in `setTrimInputValueSafe`, deckelt alle Werte auf `editDurationMs` und sorgt dafür, dass `validateDeSelection()` nach Auto-Trim, Tempoabgleich und Speichern stabile Markierungen sieht.
 * `README.md` beschreibt die gedeckelten Trim-Felder sowie die manuelle Prüfung mit Auto-Trim, Tempo und anschließendem Speichern.

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Globale Dashboard‑Kacheln:** Gesamt, Übersetzt, Ordner komplett, **EN/DE/BEIDE/∑**
 * **Level‑Statistik‑Panel** (aufklappbar im Ordner‑Browser)
 * **Projekt‑übergreifende Fortschrittsanzeige:** Dateien und Dashboard zeigen Status über alle Projekte
+* **Case-insensitiver Audio-Abgleich:** Fortschrittsbalken erkennen `.WAV`- und `.MP3`-Dateien jetzt unabhängig von der Groß-/Kleinschreibung der Endung.
 * **Visuelle Gesamtbalken** in der Filter-Leiste zeigen den Fortschritt aller Projekte
 * **Emo-Status-Anzeige:** Ein violettes Feld zählt gefüllte, leere und fehlerhafte Emotional-Texte. Ein Klick darauf generiert fehlende oder fehlerhafte Einträge neu.
 * **Grüne Rahmen** für **100 %**‑Projekte & vollständig übersetzte Ordner

--- a/tests/calculateProjectStats.test.js
+++ b/tests/calculateProjectStats.test.js
@@ -124,6 +124,17 @@ describe('calculateProjectStats', () => {
         });
     });
 
+    test('de audio lookup behandelt Großbuchstaben in Endungen korrekt', () => {
+        global.deAudioCache = { '/game/file1.WAV': true };
+        const result = calculateProjectStats({
+            files: [
+                { enText: 'EN', deText: 'DE', fullPath: '/game/file1.wav' }
+            ]
+        });
+        expect(result.deAudioPercent).toBe(100);
+        expect(result.completedPercent).toBe(100);
+    });
+
     test('average and minimum gpt score are calculated', () => {
         const result = calculateProjectStats({
             files: [

--- a/web/src/calculateProjectStats.js
+++ b/web/src/calculateProjectStats.js
@@ -15,6 +15,25 @@ function resolveDeAudioCache(options = {}) {
     return null;
 }
 
+// Sucht in einem Cache case-insensitiv nach einem Schlüssel
+function findCacheKeyInsensitive(cache, key) {
+    if (!cache || !key) return null;
+    if (Object.prototype.hasOwnProperty.call(cache, key)) return key;
+    if (typeof globalScope.findDeAudioCacheKeyInsensitive === 'function') {
+        const mapped = globalScope.findDeAudioCacheKeyInsensitive(key);
+        if (mapped && Object.prototype.hasOwnProperty.call(cache, mapped)) {
+            return mapped;
+        }
+    }
+    const lower = key.toLowerCase();
+    for (const existing of Object.keys(cache)) {
+        if (typeof existing === 'string' && existing.toLowerCase() === lower) {
+            return existing;
+        }
+    }
+    return null;
+}
+
 // Standardweg, um den Pfad zu einer DE-Audiodatei zu ermitteln
 function defaultGetDeFilePath(file, options = {}) {
     if (!file) return null;
@@ -22,8 +41,11 @@ function defaultGetDeFilePath(file, options = {}) {
     if (file.deAudio) return file.deAudio;
     if (file.hasDeAudio) return true;
     const cache = resolveDeAudioCache(options);
-    if (cache && file.fullPath && cache[file.fullPath]) {
-        return file.fullPath;
+    if (cache && file.fullPath) {
+        const matchedKey = findCacheKeyInsensitive(cache, file.fullPath);
+        if (matchedKey) {
+            return matchedKey;
+        }
     }
     return null;
 }

--- a/web/src/projectSwitch.js
+++ b/web/src/projectSwitch.js
@@ -100,7 +100,11 @@ function switchProjectSafe(projectId) {
         const data = await window.electronAPI.scanFolders();
         await verarbeiteGescannteDateien(data.enFiles);
         data.deFiles.forEach(f => {
-          deAudioCache[f.fullPath] = `sounds/DE/${f.fullPath}`;
+          if (typeof setDeAudioCacheEntry === 'function') {
+            setDeAudioCacheEntry(f.fullPath, `sounds/DE/${f.fullPath}`);
+          } else {
+            deAudioCache[f.fullPath] = `sounds/DE/${f.fullPath}`;
+          }
         });
       } else {
         // Browser-Fallback: lokale Ordner direkt scannen


### PR DESCRIPTION
## Summary
- add a case-insensitive index for the DE audio cache and migrate entries during cleanup
- switch DE audio writers in dubbing and project switching to the indexed helpers and update stats logic to honor upper-case extensions
- document the behaviour change and cover it with a dedicated test

## Testing
- npx jest tests/calculateProjectStats.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d910cf31e0832799e6344bd922ed86