### PR TITLE
Optimierte Index-Suche für DE-Audios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 🛠️ Patch in 1.40.402
+* `web/src/main.js` verlässt sich beim DE-Audio-Lookup ausschließlich auf den gepflegten Index und stößt höchstens einmalig eine abgesicherte Reindizierung an, damit fehlende Dateien keine wiederholten Vollscans auslösen.
+* `web/src/calculateProjectStats.js` verwendet den globalen Lookup-Helfer nur noch, wenn er verfügbar ist, und spart so doppelte Schlüssel-Scans bei Negativtreffern.
+* `tests/calculateProjectStats.test.js` ergänzt einen Spy-gestützten Test, der sicherstellt, dass Serien fehlender Audios keine wiederholten `Object.keys`-Durchläufe mehr erzeugen.
+* `README.md` und `CHANGELOG.md` dokumentieren die optimierte Index-Nutzung beim Fortschrittsabgleich.
 ## 🛠️ Patch in 1.40.401
 * `web/src/main.js` führt einen case-insensitiven Index für `deAudioCache` ein, stellt Hilfsfunktionen zum Setzen/Löschen bereit und überträgt bestehende Einträge beim Cleanup automatisch in die neue Struktur.
 * `web/src/dubbing.js` und `web/src/projectSwitch.js` verwenden die neuen Helfer, damit alle Schreib- und Löschvorgänge den Index aktuell halten.

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Level‑Statistik‑Panel** (aufklappbar im Ordner‑Browser)
 * **Projekt‑übergreifende Fortschrittsanzeige:** Dateien und Dashboard zeigen Status über alle Projekte
 * **Case-insensitiver Audio-Abgleich:** Fortschrittsbalken erkennen `.WAV`- und `.MP3`-Dateien jetzt unabhängig von der Groß-/Kleinschreibung der Endung.
+* **Optimierter Audio-Index:** Fehlende DE-Audios greifen zuerst auf den gepflegten Index zu; nur bei Bedarf wird einmalig eine geschützte Reindizierung ausgelöst, wodurch große Projekte ohne wiederholte Vollscans flott bleiben.
 * **Visuelle Gesamtbalken** in der Filter-Leiste zeigen den Fortschritt aller Projekte
 * **Emo-Status-Anzeige:** Ein violettes Feld zählt gefüllte, leere und fehlerhafte Emotional-Texte. Ein Klick darauf generiert fehlende oder fehlerhafte Einträge neu.
 * **Grüne Rahmen** für **100 %**‑Projekte & vollständig übersetzte Ordner

--- a/web/src/calculateProjectStats.js
+++ b/web/src/calculateProjectStats.js
@@ -19,11 +19,15 @@ function resolveDeAudioCache(options = {}) {
 function findCacheKeyInsensitive(cache, key) {
     if (!cache || !key) return null;
     if (Object.prototype.hasOwnProperty.call(cache, key)) return key;
-    if (typeof globalScope.findDeAudioCacheKeyInsensitive === 'function') {
-        const mapped = globalScope.findDeAudioCacheKeyInsensitive(key);
+    const helper = typeof globalScope.findDeAudioCacheKeyInsensitive === 'function'
+        ? globalScope.findDeAudioCacheKeyInsensitive
+        : null;
+    if (helper) {
+        const mapped = helper(key);
         if (mapped && Object.prototype.hasOwnProperty.call(cache, mapped)) {
             return mapped;
         }
+        return null;
     }
     const lower = key.toLowerCase();
     for (const existing of Object.keys(cache)) {


### PR DESCRIPTION
## Summary
- nutze im Browser nur noch den gepflegten DE-Audio-Index und löse bei Bedarf höchstens eine abgesicherte Reindizierung aus
- verhindere doppelte Schlüssel-Scans in den Projektstatistiken, wenn der globale Helper verfügbar ist, und sichere dies per neuem Jest-Test ab
- dokumentiere die Optimierung in README und CHANGELOG

## Testing
- node --experimental-vm-modules node_modules/jest/bin/jest.js tests/calculateProjectStats.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d92d330bc8832790d68e1226d5d984