### PR TITLE
Synchronisierte Zeilenmarkierung für Nummern-Navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.403
+* `web/src/main.js` synchronisiert beim Scrollen und bei Nummern-Sprüngen die `selectedRow`-Markierung, damit Pfeiltasten, Nummern-Schaltflächen und manuelles Scrollen dieselbe Zeile hervorheben.
+* `README.md` beschreibt die gemeinsame Hervorhebung der Nummern-Navigation ohne Sprünge.
+* `CHANGELOG.md` dokumentiert die vereinheitlichte Zeilenwahl über alle Navigationswege.
 ## 🛠️ Patch in 1.40.402
 * `web/src/main.js` verlässt sich beim DE-Audio-Lookup ausschließlich auf den gepflegten Index und stößt höchstens einmalig eine abgesicherte Reindizierung an, damit fehlende Dateien keine wiederholten Vollscans auslösen.
 * `web/src/calculateProjectStats.js` verwendet den globalen Lookup-Helfer nur noch, wenn er verfügbar ist, und spart so doppelte Schlüssel-Scans bei Negativtreffern.

--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Mausrad:** Markiert beim Scrollen automatisch die Zeile in der Bildschirmmitte, ohne sie neu auszurichten
 * **Kein Zoom in Wellenformen:** Beim Ziehen in EN- und DE-Spuren des DE-Audio-Editors erfolgt kein automatisches Zoom mehr
 * **Zeilenauswahl:** Gewählte Zeilen werden vollständig unter dem Tabellenkopf positioniert
-* **Nummern-Navigation:** Vor-/Zurück-Schaltflächen und manuelles Scrollen markieren die aktive Zeile wieder zuverlässig
+* **Nummern-Navigation:** Pfeiltasten, Nummern-Schaltflächen und manuelles Scrollen teilen sich dieselbe Markierung ohne Sprünge
 * **Doppelklick:** Projekt umbenennen
 
 </details>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -4238,6 +4238,13 @@ function addFiles() {
             if (autoScrollTimeout) clearTimeout(autoScrollTimeout);
             const row = getRowByNumber(num);
             if (row) {
+                if (selectedRow !== row) {
+                    if (selectedRow) {
+                        selectedRow.classList.remove('selected-row');
+                    }
+                    selectedRow = row;
+                    selectedRow.classList.add('selected-row');
+                }
                 const container = document.querySelector('.table-container');
                 if (container) {
                     // Scroll-Snap kurz deaktivieren, damit der Tabellenkopf nichts überdeckt
@@ -4279,6 +4286,13 @@ function addFiles() {
                     const cell = row.querySelector('.row-number');
                     if (cell) {
                         const num = parseInt(cell.textContent, 10);
+                        if (selectedRow !== row) {
+                            if (selectedRow) {
+                                selectedRow.classList.remove('selected-row');
+                            }
+                            selectedRow = row;
+                            selectedRow.classList.add('selected-row');
+                        }
                         setActiveRow(row);
                         currentRowNumber = num;
                         if (currentProject) {


### PR DESCRIPTION
## Summary
- synchronisiere die `selectedRow`-Verwaltung in `scrollToNumber` und `updateNumberFromScroll`, damit alle Navigationspfade dieselbe Zeilenmarkierung teilen
- beschreibe die vereinheitlichte Nummern-Navigation in README und CHANGELOG

## Testing
- not run (nicht erforderlich)


------
https://chatgpt.com/codex/tasks/task_e_68d9322249e88327bb49f5ff94feb356