### PR TITLE
Verhindere Datenverlust bei fehlgeschlagenem Projektladen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.405
+* `web/src/main.js` stellt beim Laden den vorherigen Projekt- und Levelzustand wieder her und verhindert so ein versehentliches Überschreiben mit einer leeren Liste nach Fehlern.
+* `tests/loadProjectsError.test.js` sichert ab, dass Ladefehler keine Projektdaten mehr löschen oder abspeichern.
+* `README.md` erwähnt die unangetastete Projektliste bei Speicherfehlern.
 ## 🛠️ Patch in 1.40.404
 * `translate_text.py` bietet einen `--server`-Modus, der Argos einmal lädt, JSON-Aufträge annimmt und Antworten zeilenweise ausgibt.
 * `electron/main.js` startet beim App-Start einen dauerhaften Übersetzungs-Worker, verwaltet Rückmeldungen pro IPC-Anfrage und setzt Neustarts inklusive Auftrags-Retrys um.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Überarbeitete Lade-Mechanik:** Projekte werden wieder zuverlässig geöffnet und laufende Ladevorgänge blockieren sich nicht mehr gegenseitig.
 * **Bereinigter Textvergleich:** Der Helfer `calculateTextSimilarity` verzichtet auf eine ungenutzte Wortmenge und behält alle Funktionen bei.
 * **Stabiles Projektladen:** Fehler beim Lesen aus dem Speicher werden abgefangen und als Hinweis angezeigt.
+* **Fehlerresistente Projektliste:** Tritt beim Laden ein Speicherfehler auf, bleibt die vorhandene Projektliste unverändert und es erscheint ausschließlich ein Hinweisdialog.
 * **Bugfix:** Nach dem Laden eines Projekts reagierte die Oberfläche nicht mehr auf Klicks.
 * **Bugfix:** Nach einem Projektwechsel funktionieren alle Toolbar‑Schaltflächen wieder zuverlässig.
 * **Automatische Projektreparatur:** Wird ein Projekt nicht gefunden, legt das Tool eine leere Struktur an, ergänzt die Projektliste und lädt alles direkt erneut.

--- a/tests/loadProjectsError.test.js
+++ b/tests/loadProjectsError.test.js
@@ -16,18 +16,36 @@ test('loadProjects zeigt Fehlerdialog bei Speicherproblemen', async () => {
     window.updateGlobalProjectProgress = jest.fn();
     window.selectProject = jest.fn();
     window.saveProjects = jest.fn();
+    global.saveProjects = window.saveProjects;
 
-    window.projects = [{ id: 1 }];
-    window.levelColors = {};
-    window.levelOrders = {};
-    window.levelIcons = {};
-    window.levelColorHistory = [];
+    const originalProjects = [{ id: 1, name: 'Alt' }];
+    const originalLevelColors = { foo: '#fff' };
+    const originalLevelOrders = { foo: ['bar'] };
+    const originalLevelIcons = { foo: '🔧' };
+    const originalLevelHistory = ['#fff'];
+
+    window.projects = originalProjects;
+    global.projects = window.projects;
+    window.levelColors = originalLevelColors;
+    global.levelColors = window.levelColors;
+    window.levelOrders = originalLevelOrders;
+    global.levelOrders = window.levelOrders;
+    window.levelIcons = originalLevelIcons;
+    global.levelIcons = window.levelIcons;
+    window.levelColorHistory = originalLevelHistory;
+    global.levelColorHistory = window.levelColorHistory;
     window.textDatabase = {};
     window.filePathDatabase = {};
 
     await loadProjects();
 
     expect(window.electronAPI.showProjectError).toHaveBeenCalled();
-    expect(window.projects).toEqual([]);
-    expect(window.renderProjects).toHaveBeenCalled();
+    expect(window.projects).toBe(originalProjects);
+    expect(projects).toBe(originalProjects);
+    expect(levelColors).toBe(originalLevelColors);
+    expect(levelOrders).toBe(originalLevelOrders);
+    expect(levelIcons).toBe(originalLevelIcons);
+    expect(levelColorHistory).toBe(originalLevelHistory);
+    expect(window.renderProjects).not.toHaveBeenCalled();
+    expect(window.saveProjects).not.toHaveBeenCalled();
 });

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -2765,6 +2765,14 @@ function handleAccessStatusClick() {
 // Lädt Projekte und zugehörige Einstellungen asynchron aus dem Speicher
 // Parameter "skipSelect" verhindert das automatische Öffnen eines Projekts
 async function loadProjects(skipSelect = false) {
+    // Vorherigen Zustand merken, falls das Laden scheitert
+    const previousState = {
+        projects,
+        levelColors,
+        levelOrders,
+        levelIcons,
+        levelColorHistory
+    };
     // Hilfsfunktion für Fehlerhinweise
     const showError = msg => {
         if (window.electronAPI && window.electronAPI.showProjectError) {
@@ -2940,11 +2948,13 @@ async function loadProjects(skipSelect = false) {
             if (first) selectProject(first.id);
         }
     } catch (err) {
-        // Fehler beim Zugriff auf den Speicher melden und zurücksetzen
+        // Fehler melden und ursprünglichen Zustand wiederherstellen
         showError(`Projekte konnten nicht geladen werden: ${err.message}`);
-        projects = [];
-        saveProjects();
-        renderProjects();
+        projects = previousState.projects || [];
+        levelColors = previousState.levelColors || {};
+        levelOrders = previousState.levelOrders || {};
+        levelIcons = previousState.levelIcons || {};
+        levelColorHistory = previousState.levelColorHistory || [];
     }
     window.projects = projects; // Referenz für andere Module aktualisieren
 }


### PR DESCRIPTION
## Summary
- stelle den vorherigen Projekt- und Levelzustand wieder her, wenn `loadProjects` auf einen Speicherfehler läuft
- entferne das fehlerhafte Speichern leerer Listen und dokumentiere die robustere Fehlerbehandlung
- ergänze einen Jest-Test, der sicherstellt, dass Ladefehler keine Projektdaten überschreiben

## Testing
- npm test -- loadProjectsError

------
https://chatgpt.com/codex/tasks/task_e_68d941cfc6148327b1af0975d51dab5d