### PR TITLE
Fix fallback key handling in IndexedDB backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 🛠️ Patch in 1.40.406
+* `web/src/storage/indexedDbBackend.js` liefert Fallback-Schlüssel unverändert zurück und behält für reguläre `misc:`-Einträge weiterhin das Präfix bei.
+* `tests/indexedDbBackend.test.js` prüft die Schlüsselrekonstruktion sowie das Zusammenspiel mit `syncProjectListWithStorage`.
+* `README.md` dokumentiert die unveränderte Rückgabe von Projekt-Schlüsseln aus dem IndexedDB-Fallback.
+* `CHANGELOG.md` hält die Anpassung an den Schlüssel-Iterator fest.
 ## 🛠️ Patch in 1.40.405
 * `web/src/main.js` stellt beim Laden den vorherigen Projekt- und Levelzustand wieder her und verhindert so ein versehentliches Überschreiben mit einer leeren Liste nach Fehlern.
 * `tests/loadProjectsError.test.js` sichert ab, dass Ladefehler keine Projektdaten mehr löschen oder abspeichern.

--- a/README.md
+++ b/README.md
@@ -1021,6 +1021,10 @@ Startet das Werkzeug bereits im Datei-Modus, wird der LocalStorage auf alte Proj
 
 Wird der Zugriff auf das Origin Private File System blockiert – etwa im `file://`-Kontext mit strengen `worker-src`-Richtlinien –, speichert das IndexedDB-Backend große Dateien automatisch als Base64-Datenblöcke direkt in der Datenbank. Der Indikator zeigt dann **„Datei-Modus (Base64)“** an. Alle Inhalte bleiben damit trotz fehlender OPFS-Rechte zwischen Sitzungen erhalten und der lästige Konsolenfehler verschwindet.
 
+### Schlüssel-Kompatibilität
+
+Das IndexedDB-Backend rekonstruiert Schlüssel aus dem Fallback-Store unverändert und liefert z. B. `project:7:meta` wieder exakt so zurück. Reguläre `misc:`-Einträge behalten weiterhin ihr Präfix, sodass bestehende Aufrufer keine Änderungen benötigen. Die Startprüfung `syncProjectListWithStorage` erkennt dadurch auch nach einer Migration alle Projekt-IDs zuverlässig und ergänzt fehlende Listenplätze.
+
 ### Kontrolle
 
 Über `visualizeFileStorage('schlüssel')` lässt sich prüfen, ob ein bestimmter Eintrag ausschließlich im neuen Speichersystem liegt. Das Ergebnis wird im Statusbereich angezeigt.

--- a/tests/indexedDbBackend.test.js
+++ b/tests/indexedDbBackend.test.js
@@ -9,6 +9,7 @@ const path = require('path');
 const { TextEncoder, TextDecoder } = require('util');
 
 let createIndexedDbBackend;
+const projectHelpersCode = fs.readFileSync(path.join(__dirname, '../web/src/projectHelpers.js'), 'utf8');
 
 beforeAll(() => {
     // Benötigte APIs im Testumfeld bereitstellen
@@ -21,6 +22,7 @@ beforeAll(() => {
     let code = fs.readFileSync(path.join(__dirname, '../web/src/storage/indexedDbBackend.js'), 'utf8');
     code = code.replace(/export\s+/g, '');
     createIndexedDbBackend = new Function(code + '; return createIndexedDbBackend;')();
+    eval(projectHelpersCode);
 });
 
 beforeEach(() => {
@@ -43,6 +45,14 @@ test('keys listet alle Schlüssel', async () => {
     expect(schluessel).toEqual(expect.arrayContaining(['projects:p1', 'textDB:t1']));
 });
 
+test('keys gibt Fallback-Schlüssel unverändert zurück', async () => {
+    const backend = createIndexedDbBackend();
+    await backend.setItem('misc:lokal', 'x');
+    await backend.setItem('project:42:meta', '{}');
+    const schluessel = await backend.keys();
+    expect(schluessel).toEqual(expect.arrayContaining(['misc:lokal', 'project:42:meta']));
+});
+
 test('removeItem und clear löschen Einträge', async () => {
     const backend = createIndexedDbBackend();
     await backend.setItem('misc:a', '1');
@@ -52,5 +62,16 @@ test('removeItem und clear löschen Einträge', async () => {
     await backend.clear();
     const schluessel = await backend.keys();
     expect(schluessel.length).toBe(0);
+});
+
+test('syncProjectListWithStorage nutzt rekonstruierte Projekt-Schlüssel', async () => {
+    const backend = createIndexedDbBackend();
+    await backend.setItem('project:7:meta', '{}');
+    await backend.setItem('project:7:index', '[]');
+    window.projects = [];
+    await window.syncProjectListWithStorage(backend);
+    const listeRoh = await backend.getItem('hla_projects');
+    const liste = listeRoh ? JSON.parse(listeRoh) : [];
+    expect(liste.some(p => String(p.id) === '7')).toBe(true);
 });
 

--- a/web/src/storage/indexedDbBackend.js
+++ b/web/src/storage/indexedDbBackend.js
@@ -175,7 +175,13 @@ async function keysInternal() {
             request.onerror = () => reject(request.error);
         });
         for (const k of keys) {
-            allKeys.push(`${name}:${k}`);
+            if (name === 'misc' && typeof k === 'string' && k.includes(':')) {
+                // Schlüssel aus dem Fallback-Store bereits mit Präfix zurückgeben
+                allKeys.push(k);
+            } else {
+                // Reguläre Einträge weiterhin mit Store-Präfix versehen
+                allKeys.push(`${name}:${k}`);
+            }
         }
     }
     return allKeys;


### PR DESCRIPTION
## Summary
- return fallback-store keys unchanged from the IndexedDB backend while keeping regular misc entries prefixed
- extend the IndexedDB backend tests to cover reconstructed keys and the syncProjectListWithStorage integration
- document the updated key handling in the README and CHANGELOG

## Testing
- `npm test -- indexedDbBackend.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d94320a180832785ddc3c36f212ec9