### PR TITLE
Verbesserte GPT-Bewertung fordert fehlende Zeilen nach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.407
+* `web/src/gptService.js` weist GPT-Antworten gezielt per ID zu, fordert fehlende Zeilen automatisch nach und protokolliert jede Nachforderung im Dialog, bis alle Bewertungen vorliegen oder ein Fehler ausgegeben wird.
+* `tests/gptService.test.js` simuliert Teilantworten und prüft, dass fehlende Zeilen nachgefordert werden und die Anfrage sich auf die offenen IDs konzentriert.
+* `README.md` beschreibt die lückenlose Nachforderung der GPT-Bewertungen samt Dialog-Log.
 ## 🛠️ Patch in 1.40.406
 * `web/src/storage/indexedDbBackend.js` liefert Fallback-Schlüssel unverändert zurück und behält für reguläre `misc:`-Einträge weiterhin das Präfix bei.
 * `tests/indexedDbBackend.test.js` prüft die Schlüsselrekonstruktion sowie das Zusammenspiel mit `syncProjectListWithStorage`.

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Bugfix:** Scores werden korrekt eingefügt, auch wenn ID und Score als Zeichenketten geliefert werden
 * **Robustere Zuordnung:** GPT-Ergebnisse finden jetzt auch dann die richtige Zeile, wenn die ID leicht abweicht
 * **String-Vergleich der IDs:** Datei-IDs werden als Strings abgeglichen, sodass auch Gleitkomma-IDs eindeutig zugeordnet werden
+* **Lückenlose GPT-Bewertung:** Teilantworten werden per ID zugeordnet, fehlende Zeilen automatisch nachgefordert und der Dialog hält den Fortschritt fest, bis alle Zeilen bewertet sind.
 * **Eigenständige Score-Komponente:** Tooltip und Klick sind in `web/src/scoreColumn.js` gekapselt
 * **Einheitliche Score-Klassen:** Die Funktion `scoreClass` vergibt überall die gleichen Farbstufen
 * **Feineres Bewertungsschema:** Ab 95 % wird der Score grün, zwischen 85 % und 94 % gelb


### PR DESCRIPTION
## Summary
- mappt GPT-Bewertungen im Chunk gezielt auf Zeilen-IDs, fordert fehlende Einträge erneut an und dokumentiert jeden Fortschritt im Dialog
- ergänzt einen Jest-Test für Teilantworten, der Nachforderungen und fokussierte Folgerequests prüft
- dokumentiert die lückenlose Bewertungsnachforderung in README und CHANGELOG

## Testing
- node --experimental-vm-modules --unhandled-rejections=warn node_modules/jest/bin/jest.js tests/gptService.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9468cecb88327a5a66348ced72ec6