### PR TITLE
Zeige alle Werkzeug-Aktionen direkt in der Leiste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.409
+* `web/hla_translation_tool.html` zeigt alle Werkzeug-Aktionen als direkte Buttons in der Hauptleiste und entfernt das separate Overflow-Menü.
+* `README.md` erläutert, dass sämtliche Werkzeuge ohne 3-Punkte-Menü erreichbar sind und lediglich die Einstellungen im Dropdown bleiben.
+* `CHANGELOG.md` hält die Umstellung auf permanente Werkzeug-Schaltflächen fest.
 ## 🛠️ Patch in 1.40.408
 * `web/hla_translation_tool.html` ordnet den GPT-Testdialog neu in drei Segmente und ergänzt eine Fortschrittsspalte mit Schrittanzeige, Log und Balken.
 * `web/src/style.css` liefert passende Layout- und Farbregeln für die neue GPT-Schrittanzeige, das Live-Log und den Zusammenfassungsbereich.

--- a/README.md
+++ b/README.md
@@ -832,7 +832,7 @@ Fehlt eine Abhängigkeit wie PyTorch oder das VC++‑Laufzeitpaket, bricht das S
 Der Kopfbereich der Weboberfläche ist jetzt als kompakte Werkzeugzeile mit klar getrennten Sektionen aufgebaut:
 
 * **Projekt:** Import, Untertitel und Ordner-Browser liegen direkt neben dem Eingabefeld, das nun in einer schmalen Inline-Zeile mit dem „Hinzufügen“-Knopf sitzt.
-* **Werkzeuge:** GPT-Bewertung, Zufallsprojekt, Wörterliste sowie die beiden Emotionstools bleiben dauerhaft sichtbar; selten genutzte Helfer (Kopierhilfen, ZIP-Import, Audio-Zuordnung, Debug-Bericht usw.) wandern in ein gemeinsames Overflow-Menü (⋯).
+* **Werkzeuge:** GPT-Bewertung, Zufallsprojekt, Wörterliste, Emotionstools und sämtliche Spezialhelfer (Kopierhilfen, ZIP-Import, Audio-Zuordnung, Debug-Bericht usw.) stehen als direkte Buttons nebeneinander bereit – nur die Einstellungen liegen weiterhin im Dropdown.
 * **Medien:** Video-Manager und Half-Life: Alyx-Launcher teilen sich einen schlanken Block, in dem Modus, Sprache, optionales `+map`-Feld und Cheat-Dropdown direkt neben dem Startknopf angeordnet sind.
 * **System:** Alle Speicher-Anzeigen inklusive Wechsel-Schalter, Ordner-Öffner und Aufräumen sitzen im neuen „Verwaltung“-Dropdown – gemeinsam mit den Migrationsbefehlen und dem Statusmonitor.
 * **Suche & Verlauf:** Live-Suche, UT-Suche-Button, Kopieroptionen, Sortierungen, Fortschrittsstatistiken und Projekt-Playback laufen in einem durchgehenden Abschlusssegment zusammen.

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -72,20 +72,15 @@
                                 <button id="wordListButton" class="btn btn-secondary" onclick="openWordList()">📚 Wörter</button>
                                 <button id="generateEmotionsButton" class="btn btn-blue" title="Erzeugt deutsche Emotionstags für alle Zeilen">Emotionen (DE)</button>
                                 <button id="sendTextV2Button" class="btn btn-blue" title="Alle Emotional-Texte an ElevenLabs senden">An ElevenLabs schicken</button>
-                                <div class="menu-wrapper">
-                                    <button id="toolOverflowToggle" class="btn btn-secondary menu-toggle" data-menu-toggle="toolOverflowMenu" aria-haspopup="true" aria-expanded="false">⋯</button>
-                                    <div class="workspace-dropdown" id="toolOverflowMenu" role="menu">
-                                        <button class="dropdown-item" onclick="openSegmentDialog()">🔊 Audio-Datei zuordnen</button>
-                                        <button class="dropdown-item" onclick="showZipImportDialog()">ZIP importieren</button>
-                                        <button class="dropdown-item" id="copyAssistantButton">Kopierhilfe</button>
-                                        <button class="dropdown-item" id="copyAssistant2Button">Kopierhilfe 2</button>
-                                        <button class="dropdown-item" id="copyAllEmosButton">Emotionen kopieren</button>
-                                        <button class="dropdown-item" id="subtitleSearchAllButton" title="Sucht fehlende deutsche Texte im gesamten Projekt">UT-Suche alles</button>
-                                        <button class="dropdown-item" onclick="openDubbingLog()">📝 Protokoll</button>
-                                        <button class="dropdown-item" id="devToolsButton">🐞 DevTools</button>
-                                        <button class="dropdown-item" id="debugReportButton">📋 Debug-Bericht</button>
-                                    </div>
-                                </div>
+                                <button class="btn btn-secondary" onclick="openSegmentDialog()">🔊 Audio-Datei zuordnen</button>
+                                <button class="btn btn-secondary" onclick="showZipImportDialog()">ZIP importieren</button>
+                                <button class="btn btn-secondary" id="copyAssistantButton">Kopierhilfe</button>
+                                <button class="btn btn-secondary" id="copyAssistant2Button">Kopierhilfe 2</button>
+                                <button class="btn btn-secondary" id="copyAllEmosButton">Emotionen kopieren</button>
+                                <button class="btn btn-secondary" id="subtitleSearchAllButton" title="Sucht fehlende deutsche Texte im gesamten Projekt">UT-Suche alles</button>
+                                <button class="btn btn-secondary" onclick="openDubbingLog()">📝 Protokoll</button>
+                                <button class="btn btn-secondary" id="devToolsButton">🐞 DevTools</button>
+                                <button class="btn btn-secondary" id="debugReportButton">📋 Debug-Bericht</button>
                                 <div class="menu-wrapper settings-container">
                                     <button id="settingsButton" class="btn btn-secondary menu-toggle" onclick="toggleSettingsMenu()" aria-haspopup="true" aria-expanded="false">⚙️ Einstellungen</button>
                                     <div class="settings-menu workspace-dropdown" id="settingsMenu" role="menu">


### PR DESCRIPTION
## Summary
- make all tool actions visible as dedicated buttons and remove the overflow toggle
- document the permanent tool buttons in the README and changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d94d3bd9208327904eb7f1785761ce