### PR TITLE
Sichere Referenzen beim globalen Reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.412
+* `web/src/main.js` leert `projects` jetzt in-place, hält `window.projects` synchron und aktualisiert `currentProject`-Spiegel nach dem Reset.
+* `tests/resetGlobalStateProjects.test.js` prüft den referenztreuen Reset und den nachfolgenden Reload von `loadProjectData`.
+* `README.md` erwähnt den referenzsicheren Reset der Projektliste vor dem erneuten Laden.
 ## 🛠️ Patch in 1.40.411
 * `web/src/main.js` akzeptiert bei `updateText` eine Optionsstruktur, mit der Sammelläufe das unmittelbare `saveCurrentProject()` überspringen und trotzdem den Dirty-Timer nutzen.
 * `web/src/main.js` setzt die neue Option in `generateEmotionalText` für vorab berechnete Sammeldurchläufe und stößt nach `Promise.all(workers)` eine einmalige Speicherung an.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Robuster Projektaufruf:** Doppelklicks werden ignoriert, fehlende Listen werden nachgeladen und nicht gefundene Projekte melden einen klaren Fehler
 * **Einziger Click-Listener für Projektkarten:** Ereignisdelegation verhindert doppelte `selectProject`-Aufrufe beim Neurendern
 * **Listener nach Reset neu gesetzt:** `resetGlobalState` setzt den Merker zurück und `renderProjects` bindet den Klick-Listener erneut, damit Projekte weiterhin auswählbar bleiben
+* **Projektliste ohne Referenzbruch:** `resetGlobalState` leert `projects` jetzt in-place, sodass `loadProjectData` direkt einen frischen Reload anstößt und Fenster-Referenzen erhalten bleiben.
 * **Live-Suche nach Projektwechsel funktionsfähig:** `switchProjectSafe` ruft `initializeEventListeners` erneut auf
 * **Fallback ohne `switchProjectSafe`:** Sollte das Skript fehlen, öffnen Klicks Projekte direkt über `selectProject`
 * **Synchronisierte Projektreparatur:** `repairProjectIntegrity` wartet auf alle Speicherzugriffe und aktualisiert den In-Memory-Cache sofort

--- a/tests/resetGlobalStateProjects.test.js
+++ b/tests/resetGlobalStateProjects.test.js
@@ -1,0 +1,49 @@
+/** @jest-environment jsdom */
+// Prüft, dass resetGlobalState die Projektliste in-place leert und Fenster-Referenzen behält
+const fs = require('fs');
+const path = require('path');
+
+describe('resetGlobalState synchronisiert projects', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <div id="totalProgress"></div>
+      <div id="folderProgress"></div>
+      <div id="emoProgress"></div>
+      <div id="folderGrid" style="display: none"></div>
+      <div id="projectLoadingOverlay" class="hidden"></div>
+    `;
+    window.storage = window.localStorage;
+    window.showToast = jest.fn();
+    window.updateStatus = jest.fn();
+
+    const mainCode = fs.readFileSync(path.join(__dirname, '../web/src/main.js'), 'utf8');
+    const runMain = new Function('window', 'module', 'require', mainCode + '\nwindow.resetGlobalState = resetGlobalState; window.__testAccessProjects = () => projects;');
+    runMain(window, { exports: {} }, () => ({}));
+    const helperCode = fs.readFileSync(path.join(__dirname, '../web/src/projectHelpers.js'), 'utf8');
+    eval(helperCode);
+  });
+
+  test('leert projects vor dem erneuten Laden vollständig', async () => {
+    const interneListe = window.__testAccessProjects();
+    interneListe.push({ id: 'alt' });
+    expect(window.projects).toBe(interneListe);
+
+    window.selectProject = jest.fn();
+    window.reloadProjectList = jest.fn(async () => {
+      // Vor dem erneuten Laden muss die Referenz leer sein
+      expect(window.projects).toBe(interneListe);
+      expect(interneListe.length).toBe(0);
+      // Neue Projektdaten simulieren
+      interneListe.push({ id: 'neu' });
+    });
+
+    await window.resetGlobalState();
+    expect(interneListe.length).toBe(0);
+    await window.loadProjectData('neu');
+
+    expect(window.reloadProjectList).toHaveBeenCalledTimes(1);
+    expect(window.selectProject).toHaveBeenCalledWith('neu');
+    expect(window.__testAccessProjects()).toBe(interneListe);
+  });
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -125,7 +125,17 @@ async function switchStorage(targetMode) {
 
 // Setzt alle globalen Zustände zurück, um Reste des alten Backends zu vermeiden
 function resetGlobalState() {
-    if (typeof projects !== 'undefined') projects = [];
+    if (typeof projects !== 'undefined') {
+        // Projektliste in-place leeren, damit Fenster-Referenzen erhalten bleiben
+        if (Array.isArray(projects)) {
+            projects.length = 0;
+        } else {
+            projects = [];
+        }
+        if (typeof window !== 'undefined') {
+            window.projects = projects;
+        }
+    }
     if (typeof levelColors !== 'undefined') levelColors = {};
     if (typeof levelOrders !== 'undefined') levelOrders = {};
     if (typeof levelIcons !== 'undefined') levelIcons = {};
@@ -133,8 +143,18 @@ function resetGlobalState() {
     if (typeof currentProjectLock !== 'undefined' && currentProjectLock && typeof currentProjectLock.release === 'function') {
         currentProjectLock.release();
     }
-    if (typeof currentProject !== 'undefined') currentProject = null;
-    if (typeof currentProjectLock !== 'undefined') currentProjectLock = null;
+    if (typeof currentProject !== 'undefined') {
+        currentProject = null;
+        if (typeof window !== 'undefined') {
+            window.currentProject = currentProject;
+        }
+    }
+    if (typeof currentProjectLock !== 'undefined') {
+        currentProjectLock = null;
+        if (typeof window !== 'undefined') {
+            window.currentProjectLock = currentProjectLock;
+        }
+    }
     if (typeof readOnlyMode !== 'undefined') readOnlyMode = false;
     if (typeof files !== 'undefined') files = [];
     if (typeof textDatabase !== 'undefined') textDatabase = {};


### PR DESCRIPTION
## Zusammenfassung
- leert die globale Projektliste in `resetGlobalState` in-place und synchronisiert die Fenster-Referenzen
- setzt `currentProject`-Spiegel nach dem Reset sauber zurück
- ergänzt einen Jest-Regressionstest und aktualisiert README sowie CHANGELOG

## Tests
- npm test -- resetGlobalStateProjects.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d95cabf8e48327afc12158bf0e0d00