### PR TITLE
Stoppe Übersetzungswarteschlange bei Reset und Projektwechsel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 🛠️ Patch in 1.40.413
+* `web/src/main.js` führt `cancelTranslationQueue()` ein, bricht laufende Übersetzungen inklusive offener Promises sauber ab, setzt den Fortschritt zurück und wird von `resetGlobalState()` vor allen anderen Aufräumarbeiten aufgerufen.
+* `web/src/projectSwitch.js` stoppt beim Projektwechsel die Übersetzungswarteschlange, bevor Speicher und Caches geleert werden, damit keine späten Rückläufer leere Projektdaten speichern.
+* `tests/resetGlobalStateCancelsTranslation.test.js` simuliert eine laufende Übersetzung, prüft den Abbruch durch `resetGlobalState()` und stellt sicher, dass keine leere Projektliste mehr persistiert wird.
+* `README.md` dokumentiert die abbruchfeste Übersetzungswarteschlange.
 ## 🛠️ Patch in 1.40.412
 * `web/src/main.js` leert `projects` jetzt in-place, hält `window.projects` synchron und aktualisiert `currentProject`-Spiegel nach dem Reset.
 * `tests/resetGlobalStateProjects.test.js` prüft den referenztreuen Reset und den nachfolgenden Reload von `loadProjectData`.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Bereinigte Abschluss-Logik:** Die früheren UI-Helfer `toggleFileCompletion`, `toggleCompletionAll`, `toggleFileSelection` und `toggleSelectAll` wurden entfernt, weil der Fertig-Status nun vollständig automatisch aus den Projekt- und Dateidaten berechnet wird.
 * **Live-Speichern:** Änderungen an Dateien oder Texten werden nach kurzer Pause automatisch gesichert.
 * **Hintergrund-Übersetzungswarteschlange:** Automatische Übersetzungen laufen projektübergreifend weiter; beim Wechsel landen neue Projekte hinten in der Warteschlange und starten, sobald die aktuelle Übersetzung abgeschlossen ist.
+* **Abbruchfeste Übersetzungswarteschlange:** Globale Resets und Projektwechsel stoppen laufende Jobs sofort, leeren alle Warteschlangen und blockieren verspätete Rückläufer, damit keine leeren Projektlisten gespeichert werden.
 * **Fehlerfreie Auto-Übersetzungen nach Projektwechsel:** Die Warteschlange schreibt erkannte Ergebnisse jetzt sofort ins passende Projekt, sodass fertige Texte auch nach einem Wechsel oder Neustart zuverlässig in der Tabelle auftauchen.
 * **Sofortspeichern nach GPT- und Emotions-Einträgen:** Übernommene Bewertungen landen weiterhin sofort im Projekt; Sammelläufe der Emotionstexte bündeln ihre Änderungen und lösen danach ein gemeinsames Speichern aus.
 * **Gemeinsame Projektliste:** `window.projects` stellt sicher, dass alle Module auf dieselbe Projektreferenz zugreifen.

--- a/tests/resetGlobalStateCancelsTranslation.test.js
+++ b/tests/resetGlobalStateCancelsTranslation.test.js
@@ -1,0 +1,84 @@
+/** @jest-environment jsdom */
+// Stellt sicher, dass resetGlobalState laufende Übersetzungen abbricht und keine leeren Projekte speichert
+const fs = require('fs');
+const path = require('path');
+
+describe('resetGlobalState stoppt Übersetzungswarteschlange zuverlässig', () => {
+  let storageMock;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    const storageData = {};
+    storageMock = {
+      getItem: jest.fn(key => (Object.prototype.hasOwnProperty.call(storageData, key) ? storageData[key] : null)),
+      setItem: jest.fn((key, value) => { storageData[key] = String(value); }),
+      removeItem: jest.fn(key => { delete storageData[key]; }),
+      clear: jest.fn(() => { Object.keys(storageData).forEach(k => delete storageData[k]); }),
+      key: jest.fn(index => Object.keys(storageData)[index] || null)
+    };
+    Object.defineProperty(storageMock, 'length', {
+      get: () => Object.keys(storageData).length
+    });
+
+    Object.defineProperty(window, 'localStorage', {
+      value: storageMock,
+      configurable: true
+    });
+    window.storage = storageMock;
+
+    document.body.innerHTML = `
+      <div id="translateProgress" class="active"></div>
+      <div id="translateStatus"></div>
+      <div id="translateFill"></div>
+      <div id="totalProgress"></div>
+      <div id="folderProgress"></div>
+      <div id="emoProgress"></div>
+    `;
+
+    window.showToast = jest.fn();
+    window.updateStatus = jest.fn();
+
+    window.electronAPI = {
+      translateText: jest.fn(),
+      onTranslateFinished: jest.fn(),
+      onManualFile: jest.fn(),
+      onDubDone: jest.fn(),
+      onDubError: jest.fn(),
+      onDubStatus: jest.fn(),
+      onDubLog: jest.fn(),
+      onSoundBackupProgress: jest.fn()
+    };
+
+    const mainCode = fs.readFileSync(path.join(__dirname, '../web/src/main.js'), 'utf8');
+    const runMain = new Function(
+      'window',
+      'module',
+      'require',
+      `${mainCode}\nwindow.resetGlobalState = resetGlobalState;\nwindow.__testSetProjects = arr => { projects = arr; window.projects = projects; };\nwindow.__testSetCurrentProject = proj => { currentProject = proj; window.currentProject = proj; };\nwindow.__testUpdateAutoTranslation = updateAutoTranslation;\nwindow.__testInvokeTranslateFinished = payload => {\n  if (!payload || typeof payload.id === 'undefined') return false;\n  const entry = pendingTranslations.get(payload.id);\n  if (!entry) return false;\n  pendingTranslations.delete(payload.id);\n  saveProjects();\n  if (typeof entry.resolve === 'function') { entry.resolve(payload.text); }\n  updateTranslationQueueDisplay();\n  return true;\n};`
+    );
+    runMain(window, { exports: {} }, () => ({}));
+  });
+
+  test('späte Übersetzung triggert kein Speichern mit leerer Projektliste', async () => {
+    const projekt = { id: 'p1', files: [] };
+    const datei = { id: 7, enText: 'Hello there' };
+    window.__testSetProjects([projekt]);
+    window.__testSetCurrentProject(projekt);
+
+    const promise = window.__testUpdateAutoTranslation(datei, true, projekt.id);
+    expect(window.electronAPI.translateText).toHaveBeenCalledTimes(1);
+    const [jobId] = window.electronAPI.translateText.mock.calls[0];
+
+    window.resetGlobalState();
+
+    await expect(promise).rejects.toThrow('Globaler Reset');
+
+    const before = storageMock.setItem.mock.calls.filter(([key]) => key === 'hla_projects').length;
+    const handled = window.__testInvokeTranslateFinished({ id: jobId, text: 'Late result', error: null });
+    expect(handled).toBe(false);
+    const after = storageMock.setItem.mock.calls.filter(([key]) => key === 'hla_projects').length;
+
+    expect(after).toBe(before);
+  });
+});

--- a/web/src/projectSwitch.js
+++ b/web/src/projectSwitch.js
@@ -55,6 +55,9 @@ function switchProjectSafe(projectId) {
       projectAbort = new AbortController();
       // Event-Listener und Caches zurücksetzen
       detachAllEventListeners();
+      if (typeof window.cancelTranslationQueue === 'function') {
+        window.cancelTranslationQueue('Projektwechsel');
+      }
       clearInMemoryCachesHard();
       // Offenes Projekt schließen
       try { await closeProjectData(); } catch {}


### PR DESCRIPTION
## Zusammenfassung
- Füge `cancelTranslationQueue()` hinzu, leere dabei alle Übersetzungszustände und binde den Aufruf in `resetGlobalState()` ein
- Stoppe die Warteschlange beim Projektwechsel und dokumentiere das neue Verhalten in README sowie CHANGELOG
- Ergänze einen Jest-Test, der eine laufende Übersetzung simuliert und sicherstellt, dass nach `resetGlobalState()` kein leeres Projekt gespeichert wird

## Tests
- npm test -- resetGlobalStateCancelsTranslation

------
https://chatgpt.com/codex/tasks/task_e_68d9610593c08327a845eeaf57a4c174