### PR TITLE
Synchronisierte Projektliste für Reparaturläufe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 🛠️ Patch in 1.40.416
+* `web/src/main.js` ergänzt den Helfer `replaceProjectList`, der Modul- und Fenster-Referenz auf dieselbe kopierte Projektliste setzt.
+* `web/src/projectHelpers.js` nutzt den neuen Helfer nach Reparaturläufen und verhindert dadurch auseinanderlaufende Projekt-Arrays.
+* `tests/repairProjectIntegritySyncsProjects.test.js` prüft, dass Reparaturen sowohl `projects` als auch `window.projects` synchron halten und `selectProject` den Platzhalter laden kann.
+* `README.md` und `CHANGELOG.md` dokumentieren die wieder synchronisierte Projektliste während Reparaturen.
 ## 🛠️ Patch in 1.40.415
 * `web/src/main.js` führt das Flag `projectResetActive` ein, setzt es während `resetGlobalState()`, blockiert `saveProjects()` und verwirft verspätete Übersetzungs-Rückläufer, solange der Reset läuft.
 * `tests/translationCallbackDuringReset.test.js` simuliert einen laufenden Reset und stellt sicher, dass der Übersetzungs-Callback ohne Speicherschreibvorgang endet und das Promise sauber abgeschlossen wird.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Live-Suche nach Projektwechsel funktionsfähig:** `switchProjectSafe` ruft `initializeEventListeners` erneut auf
 * **Fallback ohne `switchProjectSafe`:** Sollte das Skript fehlen, öffnen Klicks Projekte direkt über `selectProject`
 * **Synchronisierte Projektreparatur:** `repairProjectIntegrity` wartet auf alle Speicherzugriffe und aktualisiert den In-Memory-Cache sofort
+* **Gemeinsame Projektlisten-Aktualisierung:** Der neue Helfer `replaceProjectList` hält `projects` und `window.projects` identisch, sodass Reparaturläufe keine Platzhalter verlieren und `selectProject` sofort wieder funktioniert
 * **Projektliste ohne Auto-Auswahl:** `loadProjects` nimmt optional `skipSelect` entgegen; `reloadProjectList` lädt dadurch nur die Liste und öffnet kein altes Projekt
 * **Fehlerfreier Projektwechsel:** `switchProjectSafe` lädt vor dem Öffnen die Projektliste neu und vermeidet so die Meldung „Projekte konnten nicht geladen werden“
 * **Zentrierter Projektfokus:** Nach einem Projektwechsel scrollt die linke Projektleiste automatisch zum aktiven Eintrag und zentriert ihn

--- a/tests/repairProjectIntegritySyncsProjects.test.js
+++ b/tests/repairProjectIntegritySyncsProjects.test.js
@@ -1,0 +1,126 @@
+/** @jest-environment jsdom */
+// Prüft, dass Reparaturen beide Projektlisten synchronisieren und die Auswahl funktioniert
+const fs = require('fs');
+const path = require('path');
+
+jest.mock('../../elevenlabs', () => ({
+  downloadDubbingAudio: jest.fn(),
+  renderLanguage: jest.fn(),
+  pollRender: jest.fn()
+}), { virtual: true });
+jest.mock('../../extensionUtils', () => ({
+  repairFileExtensions: jest.fn()
+}), { virtual: true });
+jest.mock('../../closecaptionParser', () => ({
+  loadClosecaptions: jest.fn()
+}), { virtual: true });
+jest.mock('./dubbing.js', () => ({
+  initDubbing: jest.fn(),
+  mountWaveTimeline: jest.fn(),
+  renderWaveTimeline: jest.fn(),
+  syncWaveTimelineControls: jest.fn()
+}), { virtual: true });
+jest.mock('./fileUtils.js', () => ({
+  calculateTextSimilarity: jest.fn(),
+  levenshteinDistance: jest.fn()
+}), { virtual: true });
+jest.mock('./pathUtils.js', () => ({
+  extractRelevantFolder: jest.fn()
+}), { virtual: true });
+jest.mock('./calculateProjectStats.js', () => ({
+  calculateProjectStats: jest.fn()
+}), { virtual: true });
+jest.mock('./actions/projectEvaluate.js', () => ({
+  applyEvaluationResults: jest.fn()
+}), { virtual: true });
+
+test('repairProjectIntegrity synchronisiert Projekte und Auswahl', async () => {
+  const mainCode = fs.readFileSync(path.join(__dirname, '../web/src/main.js'), 'utf8');
+  eval(mainCode);
+  const helperCode = fs.readFileSync(path.join(__dirname, '../web/src/projectHelpers.js'), 'utf8');
+  eval(helperCode);
+  eval('window.__getProjectsForTest = () => projects; window.__getCurrentProjectForTest = () => (typeof currentProject === "undefined" ? undefined : currentProject);');
+
+  document.body.innerHTML = `
+    <input id="restTranslationCheckbox" />
+    <div id="projectMetaBar"></div>
+    <span id="metaProjectName"></span>
+    <span id="metaLevelName"></span>
+    <span id="metaPartNumber"></span>
+    <select id="mapSelect"></select>
+    <div id="levelStatsContent"></div>
+  `;
+
+  // Abhängigkeiten werden durch harmlose Platzhalter ersetzt
+  window.setRestMode = jest.fn();
+  window.stopProjectPlayback = jest.fn();
+  stopProjectPlayback = window.stopProjectPlayback;
+  window.storeSegmentState = jest.fn();
+  storeSegmentState = window.storeSegmentState;
+  window.clearGptState = jest.fn();
+  clearGptState = window.clearGptState;
+  window.renderProjects = jest.fn();
+  renderProjects = window.renderProjects;
+  window.runTranslationQueue = jest.fn();
+  runTranslationQueue = window.runTranslationQueue;
+  window.renderFileTable = jest.fn();
+  renderFileTable = window.renderFileTable;
+  window.resizeTextFields = jest.fn();
+  resizeTextFields = window.resizeTextFields;
+  window.updateDubStatusForFiles = jest.fn();
+  updateDubStatusForFiles = window.updateDubStatusForFiles;
+  window.updateStatus = jest.fn();
+  updateStatus = window.updateStatus;
+  window.updateFileAccessStatus = jest.fn();
+  updateFileAccessStatus = window.updateFileAccessStatus;
+  window.updateProgressStats = jest.fn();
+  updateProgressStats = window.updateProgressStats;
+  window.updateGlobalProjectProgress = jest.fn();
+  updateGlobalProjectProgress = window.updateGlobalProjectProgress;
+  window.updateProjectMetaBar = jest.fn();
+  updateProjectMetaBar = window.updateProjectMetaBar;
+  window.updateTranslationQueueDisplay = jest.fn();
+  updateTranslationQueueDisplay = window.updateTranslationQueueDisplay;
+  window.refreshGlobalStatsAndGrids = jest.fn();
+  refreshGlobalStatsAndGrids = window.refreshGlobalStatsAndGrids;
+  window.showToast = jest.fn();
+  window.getLevelChapter = jest.fn().mockReturnValue(null);
+  window.getLevelOrder = jest.fn().mockReturnValue(0);
+  window.getLevelColor = jest.fn().mockReturnValue('#fff');
+  window.debugLog = jest.fn();
+  window.acquireProjectLock = jest.fn().mockResolvedValue({ readOnly: false, release: jest.fn() });
+  window.cancelTranslationQueue = jest.fn();
+
+  const adapter = {
+    store: {
+      'project:77:meta': JSON.stringify({ id: '77' }),
+      'project:77:index': '[]',
+      hla_projects: JSON.stringify([])
+    },
+    async getItem(key) { return this.store[key]; },
+    async setItem(key, value) { this.store[key] = value; }
+  };
+
+  const ui = { warn: jest.fn(), info: jest.fn() };
+
+  window.replaceProjectList([]);
+  expect(window.projects).toHaveLength(0);
+
+  const changed = await window.repairProjectIntegrity(adapter, '77', ui);
+  expect(changed).toBe(true);
+
+  const internalProjects = window.__getProjectsForTest();
+  expect(window.projects).toBe(internalProjects);
+
+  const placeholder = window.projects.find(p => String(p.id) === '77');
+  expect(placeholder).toBeDefined();
+  expect(JSON.parse(adapter.store.hla_projects).some(p => String(p.id) === '77')).toBe(true);
+
+  placeholder.files = [];
+  selectProject('77');
+  await Promise.resolve();
+
+  expect(window.acquireProjectLock).toHaveBeenCalledWith('77');
+  expect(window.storage.getItem('hla_lastActiveProject')).toBe('77');
+  expect(window.renderProjects).toHaveBeenCalled();
+});

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -378,6 +378,14 @@ window.addEventListener('DOMContentLoaded', () => {
 // =========================== GLOBAL STATE START ===========================
 let projects               = [];
 window.projects            = projects; // Globale Referenz auf die Projektliste
+// Hilfsfunktion, damit Modul- und Fenster-Referenz stets identisch bleiben
+function replaceProjectList(newList) {
+    const kopie = Array.isArray(newList) ? [...newList] : [];
+    projects = kopie;
+    window.projects = projects;
+    return projects;
+}
+window.replaceProjectList = replaceProjectList;
 let projectResetActive     = false; // Merker, ob ein globaler Reset läuft
 if (typeof window !== 'undefined') {
     window.projectResetActive = projectResetActive;

--- a/web/src/projectHelpers.js
+++ b/web/src/projectHelpers.js
@@ -194,7 +194,9 @@ async function repairProjectIntegrity(adapter, projectId, ui = {}) {
     writes.push(adapter.setItem(listKey, JSON.stringify(list)));
     changed = true;
     // In-Memory-Projekte sofort aktualisieren, um Race-Conditions zu vermeiden
-    if (Array.isArray(window.projects)) {
+    if (typeof window.replaceProjectList === 'function') {
+      window.replaceProjectList(list);
+    } else if (Array.isArray(window.projects)) {
       window.projects = list;
     }
   }


### PR DESCRIPTION
## Summary
- ergänze in `web/src/main.js` den Helfer `replaceProjectList`, damit Modul- und Fensterliste dieselbe Kopie erhalten
- passe `repairProjectIntegrity` an, um den neuen Helfer zu verwenden und Race-Conditions bei Reparaturläufen zu vermeiden
- ergänze einen Regressionstest sowie Dokumentationseinträge in README und CHANGELOG

## Testing
- npx jest tests/repairProjectIntegritySyncsProjects.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d973ad395c8327898a11839cd6cd94