### PR TITLE
Align scroll detection with table container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.418
+* `web/src/main.js` orientiert die Scroll-Erkennung an der Mitte des Tabellencontainers, damit die Auswahl auch bei kleineren Fenstern nicht verrutscht.
+* `README.md` dokumentiert die containerbasierte Mitte für die Scroll-Erkennung in der Dateitabelle.
+
 ## 🛠️ Patch in 1.40.417
 * `electron/main.js` blockiert Mehrfachstarts über eine Einzelinstanz-Sperre, zeigt bei erneuten Startversuchen einen Fehlerdialog und fokussiert das laufende Fenster.
 * `README.md` dokumentiert, dass die Desktop-App absichtlich nur einmal gleichzeitig ausgeführt werden kann.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Saubere Einheiten:** Prozentwerte nutzen nun ein geschütztes Leerzeichen und deutsches Dezimaltrennzeichen.
 * **Verbessertes Scrollen in der Dateitabelle:** Nach dem Rendern springt die Tabelle nur zur gemerkten Zeile, wenn keine neue Datei markiert wird; andernfalls wird nach der Auswahl gescrollt.
 * **Auto-Scroll blockiert Zeilennummer-Aktualisierung:** Der Fallback in `selectRow` setzt kurzzeitig `isAutoScrolling`, damit `updateNumberFromScroll` nicht dazwischenfunkt.
+* **Tabellenzentrierte Scroll-Erkennung:** `updateNumberFromScroll` richtet sich nach der Mitte des Tabellencontainers statt nach der Fensterhöhe, wodurch Pfeilnavigation, Buttons und manuelles Scrollen dieselbe Zeile zuverlässig halten.
 * **Übersichtliche Auswahlzeile:** Die gewählte Zeile wird mit kleinem Abstand unter dem Tabellenkopf positioniert, bleibt vollständig sichtbar und zeigt noch einen Teil der vorherigen Zeile.
 * **Tabellenkopf mit vollem Sichtfenster:** Das Scroll-Padding der Tabelle entspricht jetzt der Höhe des sticky Kopfbereichs, sodass die erste Zeile nicht mehr teilweise verdeckt wird.
 * **Überarbeitetes Timing-Layout:** Der Abschnitt „Timing & Bereiche“ nutzt ein zweispaltiges Kartenraster, das bei schmaler Breite automatisch auf eine Spalte umbricht.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -4461,7 +4461,8 @@ function addFiles() {
             if (isAutoScrolling) return; // Ignoriere Scroll-Events während automatischem Scrollen
             const container = document.querySelector('.table-container');
             if (!container) return;
-            const viewportCenter = window.innerHeight / 2;
+            const containerRect = container.getBoundingClientRect();
+            const viewportCenter = containerRect.top + containerRect.height / 2;
             const rows = container.querySelectorAll('#fileTableBody tr');
             for (const row of rows) {
                 const rect = row.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- adjust the scroll-Zeilenerkennung in `updateNumberFromScroll` auf die Mitte des Tabellencontainers
- dokumentiere die stabilere Auswahl in README und CHANGELOG

## Testing
- keine automatisierten Tests hinzugefügt

------
https://chatgpt.com/codex/tasks/task_e_68d99eb058e4832791f8ff9ddb08b99f