### PR TITLE
Improve time-stretch silence trimming safeguards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.419
+* `web/src/main.js` berechnet den Stille-Schwellwert dynamisch zum lautesten Sample, setzt einen Mindestwert von 1e‑6 und beschneidet gestretchte Audios nur noch, wenn mindestens 100 ms pro Seite stumm bleiben und höchstens zehn Prozent der Gesamtlänge entfallen.
+* `tests/timeStretchBuffer.test.js` prüft den dynamischen Schwellwert sowie die neue Trim-Absicherung für sehr leise Ausklänge.
+* `README.md` dokumentiert den signalabhängigen Stillefilter und die zusätzliche Begrenzung beim Entfernen gestretchter Ränder.
 ## 🛠️ Patch in 1.40.418
 * `web/src/main.js` orientiert die Scroll-Erkennung an der Mitte des Tabellencontainers, damit die Auswahl auch bei kleineren Fenstern nicht verrutscht.
 * `README.md` dokumentiert die containerbasierte Mitte für die Scroll-Erkennung in der Dateitabelle.

--- a/README.md
+++ b/README.md
@@ -420,6 +420,8 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Texte unter den Wellenformen:** Unter der EN-Welle erscheint der englische Text und unter der DE-Welle der emotionale deutsche Text.
 * **Manuelles Zuschneiden:** Start- und Endzeit lassen sich per Millisekundenfeld oder durch Ziehen eines Bereichs direkt im DE-Wellenbild setzen; die Felder synchronisieren sich bidirektional.
 * **Automatische Pausenkürzung und Time‑Stretching:** Längere Pausen erkennt das Tool auf Wunsch selbst. Mit einem Regler lässt sich das Tempo von 1,00–3,00 anpassen oder automatisch auf die EN-Länge setzen. Kleine ➖/➕‑Knöpfe erlauben präzise Schritte. Ein Button „🎯 Anpassen & Anwenden“ kombiniert beide Schritte und eine farbige Anzeige warnt bei Abweichungen.
+* **Signalabhängiger Stillefilter beim Time‑Stretch:** Der Schwellwert richtet sich jetzt nach dem lautesten Sample und besitzt einen Boden von 1e‑6, damit sehr leise Ausklänge nicht versehentlich entfernt werden.
+* **Trim-Absicherung für gestretchte Audios:** Beim Entfernen der zusätzlichen Ränder prüft das Tool, ob mindestens 100 ms echte Stille pro Seite vorhanden sind und höchstens zehn Prozent der Gesamtlänge verschwinden.
 * **Zwei Tempo‑Auto‑Knöpfe:** Der erste setzt den Wert auf 1,00 und markiert ihn gelb. Der zweite erhöht das Tempo automatisch, bis die DE-Länge ungefähr der EN-Zeit entspricht.
 * **EN-Originalzeit neben DE-Zeit:** Rechts neben der DE-Dauer zeigt der Editor nun die englische Originalzeit an.
 * **Sanftere Pausenkürzung:** Beim Entfernen langer Pausen bleiben jetzt 2 ms an jedem Übergang stehen, damit die Schnitte nicht zu hart wirken.

--- a/tests/timeStretchBuffer.test.js
+++ b/tests/timeStretchBuffer.test.js
@@ -1,0 +1,140 @@
+/** @jest-environment jsdom */
+// Prüft den dynamischen Stille-Schwellwert und die Trim-Absicherung beim Time-Stretching
+const { beforeEach, describe, expect, test } = require('@jest/globals');
+
+jest.mock('../../elevenlabs', () => ({
+    downloadDubbingAudio: jest.fn(),
+    renderLanguage: jest.fn(),
+    pollRender: jest.fn()
+}), { virtual: true });
+
+jest.mock('../../extensionUtils', () => ({
+    repairFileExtensions: jest.fn()
+}), { virtual: true });
+
+jest.mock('../../closecaptionParser', () => ({
+    loadClosecaptions: jest.fn()
+}), { virtual: true });
+
+jest.mock('../web/src/dubbing.js', () => ({
+    mountWaveTimeline: jest.fn(),
+    renderWaveTimeline: jest.fn(),
+    syncWaveTimelineControls: jest.fn(),
+    initDubbing: jest.fn()
+}), { virtual: true });
+
+jest.mock('../web/src/fileUtils.js', () => ({
+    calculateTextSimilarity: jest.fn(),
+    levenshteinDistance: jest.fn()
+}), { virtual: true });
+
+jest.mock('../web/src/pathUtils.js', () => ({
+    extractRelevantFolder: jest.fn()
+}), { virtual: true });
+
+jest.mock('../web/src/calculateProjectStats.js', () => ({
+    calculateProjectStats: jest.fn()
+}), { virtual: true });
+
+let helpers;
+
+function createElementStub() {
+    return {
+        textContent: '',
+        className: '',
+        classList: { add: jest.fn(), remove: jest.fn() },
+        style: {},
+        title: '',
+        setAttribute: jest.fn(),
+        removeAttribute: jest.fn(),
+        appendChild: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        value: '',
+        checked: false,
+        querySelector: jest.fn(() => null),
+        querySelectorAll: jest.fn(() => [])
+    };
+}
+
+beforeEach(() => {
+    jest.resetModules();
+    document.getElementById = jest.fn(() => createElementStub());
+    document.querySelector = jest.fn(() => null);
+    document.querySelectorAll = jest.fn(() => []);
+    window.addEventListener = jest.fn();
+    window.removeEventListener = jest.fn();
+    window.localStorage = {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+        clear: jest.fn()
+    };
+    window.storage = window.localStorage;
+    window.AudioContext = function () {
+        this.createBuffer = (channels, length, sampleRate) => ({
+            numberOfChannels: channels,
+            length,
+            sampleRate,
+            getChannelData: () => new Float32Array(length),
+            copyToChannel: jest.fn()
+        });
+        this.close = jest.fn();
+    };
+    window.webkitAudioContext = window.AudioContext;
+    global.storage = window.storage;
+    helpers = require('../web/src/main.js');
+});
+
+function createStubBuffer(channels, sampleRate = 48000) {
+    return {
+        numberOfChannels: channels.length,
+        length: channels[0]?.length || 0,
+        sampleRate,
+        getChannelData(index) {
+            return Float32Array.from(channels[index] || []);
+        }
+    };
+}
+
+describe('timeStretchBuffer-Helfer', () => {
+    test('dynamischer Schwellwert folgt dem lautesten Sample', () => {
+        const buffer = createStubBuffer([
+            [0, 0.2, -0.2, 0],
+            [0, 0.05, -0.1, 0]
+        ]);
+        const threshold = helpers.__test_calculateDynamicSilenceThreshold(buffer);
+        expect(threshold).toBeCloseTo(0.0002, 9);
+    });
+
+    test('dynamischer Schwellwert besitzt einen Mindestwert', () => {
+        const buffer = createStubBuffer([[0, 2e-7, -3e-7, 0]]);
+        const threshold = helpers.__test_calculateDynamicSilenceThreshold(buffer);
+        expect(threshold).toBeCloseTo(1e-6, 12);
+    });
+
+    test('Trim-Absicherung lässt nur Stille mit mindestens 100 ms zu', () => {
+        const sampleRate = 48000;
+        const totalFrames = sampleRate * 20; // 20 Sekunden
+        const result = helpers.__test_applyTrimSafety(1000, 6000, totalFrames, sampleRate);
+        expect(result.start).toBe(0);
+        expect(result.end).toBe(6000);
+    });
+
+    test('Trim-Absicherung begrenzt das Abschneiden auf zehn Prozent der Länge', () => {
+        const sampleRate = 48000;
+        const totalFrames = sampleRate * 2; // 2 Sekunden
+        const result = helpers.__test_applyTrimSafety(8000, 9000, totalFrames, sampleRate);
+        const maxTrim = Math.round(totalFrames * 0.1);
+        const minSilence = Math.round(sampleRate * 0.1);
+        expect(result.start + result.end).toBeLessThanOrEqual(maxTrim);
+        expect(result.start).toBe(0);
+        if (maxTrim >= minSilence) {
+            expect(result.end).toBeGreaterThanOrEqual(minSilence);
+        } else {
+            expect(result.end).toBe(0);
+        }
+        expect(result.end).toBeLessThanOrEqual(maxTrim);
+    });
+});


### PR DESCRIPTION
## Summary
- berechne den Stille-Schwellwert beim Time-Stretching dynamisch und exportiere die Helfer für Tests
- begrenze das Entfernen von Rändern auf mindestens 100 ms echter Stille und höchstens zehn Prozent der Gesamtdauer
- dokumentiere die Änderungen in README und CHANGELOG und ergänze Jest-Tests für extrem leise Ausklänge

## Testing
- npx jest tests/timeStretchBuffer.test.js

------
https://chatgpt.com/codex/tasks/task_e_68da626a175c8327b4dbc0fc4ef4ca45