### PR TITLE
Skalierte Polsterentfernung im Time-Stretch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.422
+* `web/src/main.js` skaliert das Stillepolster nach dem Zeitfaktor, entfernt exakt die gestreckte Länge an Start und Ende und übergibt die Werte an die Sicherheitsprüfung.
+* `README.md` erwähnt die faktorbasierte Polster-Skalierung für Auto-Tempo kombiniert mit Pausenentfernung.
+
 ## 🛠️ Patch in 1.40.421
 * `web/src/main.js` entfernt beim Time-Stretch mindestens das bekannte Sekundenpolster, bevor die Zehn-Prozent-Grenze greift, und füllt Längendifferenzen nur noch mit Stille auf.
 * `tests/timeStretchBuffer.test.js` prüft die neuen Mindestwerte für den Polstertrimm.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 ### 🎯 Kernfunktionen
 
+* **Pad-Skalierung beim Time-Stretch:** Auto-Tempo entfernt nach dem Strecken exakt das gestauchte Sekundenpolster, sodass weder Anfang noch Ende bei kombinierten Pausen- und Tempo-Automationen verloren gehen.
 * **Asynchrones Speichern:** Beim Start werden Level- und Kapitel-Daten jetzt korrekt geladen, auch wenn das neue IndexedDB-System verwendet wird.
 * **Bereinigte Abschluss-Logik:** Die früheren UI-Helfer `toggleFileCompletion`, `toggleCompletionAll`, `toggleFileSelection` und `toggleSelectAll` wurden entfernt, weil der Fertig-Status nun vollständig automatisch aus den Projekt- und Dateidaten berechnet wird.
 * **Live-Speichern:** Änderungen an Dateien oder Texten werden nach kurzer Pause automatisch gesichert.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -9270,6 +9270,7 @@ async function timeStretchBuffer(buffer, factor) {
     if (buffer.numberOfChannels > 1) {
         out.getChannelData(1).set(Float32Array.from(outR));
     }
+    const padOutFrames = Math.min(out.length, Math.max(0, Math.round(padFrames / factor)));
 
     // Tatsächliche Stille mit dynamischem Schwellwert suchen
     const thr = calculateDynamicSilenceThreshold(out);
@@ -9283,10 +9284,10 @@ async function timeStretchBuffer(buffer, factor) {
         if (Math.abs(chData[chData.length - 1 - end]) > thr) break;
     }
     // Mindestens das vorab angehängte Polster entfernen, bevor weitere Sicherheitsgrenzen greifen
-    start = Math.max(start, padFrames);
-    end = Math.max(end, padFrames);
+    start = Math.max(start, padOutFrames);
+    end = Math.max(end, padOutFrames);
 
-    const limited = applyTrimSafety(start, end, out.length, out.sampleRate, padFrames, padFrames);
+    const limited = applyTrimSafety(start, end, out.length, out.sampleRate, padOutFrames, padOutFrames);
     start = limited.start;
     end = limited.end;
     let len = out.length - start - end;


### PR DESCRIPTION
## Zusammenfassung
- skaliert das Sekundenpolster im Time-Stretching nach dem Tempo-Faktor und trimmt Start/Ende anhand der tatsächlichen Länge
- passt die Sicherheitsgrenzen auf die gestauchten Polsterwerte an
- dokumentiert die Änderung in README und CHANGELOG

## Tests
- keine (manuelle Überprüfung im Web-Workflow vor Ort erforderlich)

------
https://chatgpt.com/codex/tasks/task_e_68da798769d08327bf2159f17e31c1fd