### PR TITLE
Improve auto tempo trim recovery before silence padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.424
+* `web/src/main.js` nimmt bei zu kurzer Stretch-Länge zuerst die trimmbedingten Stillebereiche zurück und greift nur bei unvermeidbaren Resten auf Stille-Padding zurück, damit weich eingeblendete Clips ihren linken Rand behalten.
+* `README.md` dokumentiert die neue Trim-Rücknahme vor dem Stille-Padding bei Auto-Tempo.
+
 ## 🛠️ Patch in 1.40.423
 * `web/src/main.js` ermittelt den Stille-Schwellwert jetzt aus dem gestretchten Ruhepolster und entfernt zusätzliche Frames nur noch nach einem 100-ms-Stillefenster, damit Fade-Ins und Fade-Outs unverändert bleiben.
 * `tests/timeStretchBuffer.test.js` prüfen das polsterbasierte Thresholding und den Mindestwert mit übergebenen Polstergrößen.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 * **Pad-Skalierung beim Time-Stretch:** Auto-Tempo entfernt nach dem Strecken exakt das gestauchte Sekundenpolster, sodass weder Anfang noch Ende bei kombinierten Pausen- und Tempo-Automationen verloren gehen.
 * **Dynamische Stilleprüfung für Auto-Tempo:** Der Schwellwert orientiert sich am gestreckten Ruhepolster und entfernt nur dann zusätzliches Material, wenn ein zusammenhängendes 100-ms-Fenster wirklich unterhalb der Schwelle bleibt – Fade-Ins und Fade-Outs bleiben dadurch unangetastet.
+* **Trim-Rücknahme bei Auto-Tempo:** Reicht die gestretchte Länge nicht aus, nimmt das Tool zuerst die stillen Trim-Ränder zurück, bevor nur noch unvermeidbare Rundungsreste mit Stille aufgefüllt werden – weich eingeblendete Clips behalten dadurch ihren linken Rand.
 * **Asynchrones Speichern:** Beim Start werden Level- und Kapitel-Daten jetzt korrekt geladen, auch wenn das neue IndexedDB-System verwendet wird.
 * **Bereinigte Abschluss-Logik:** Die früheren UI-Helfer `toggleFileCompletion`, `toggleCompletionAll`, `toggleFileSelection` und `toggleSelectAll` wurden entfernt, weil der Fertig-Status nun vollständig automatisch aus den Projekt- und Dateidaten berechnet wird.
 * **Live-Speichern:** Änderungen an Dateien oder Texten werden nach kurzer Pause automatisch gesichert.


### PR DESCRIPTION
## Summary
- adjust the auto-tempo time stretch routine to restore trimmed start/end samples before falling back to silence padding
- document the trim rollback behaviour in the README and changelog

## Testing
- not run (manual audio workflow validation required)


------
https://chatgpt.com/codex/tasks/task_e_68da81b85dac8327b5b9de26c824d52c