### PR TITLE
Filter Crossfade-Ränder bei der Stilleanalyse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.425
+* `web/src/main.js` überspringt bei der Stilleanalyse die letzten 100 ms des vorderen und die ersten 100 ms des hinteren Polsters, damit Crossfade-Samples weder in die Stichprobe noch in die Schwellenwertberechnung einfließen.
+* `README.md` dokumentiert die ausgesparte Crossfade-Zone während der Schwellwertermittlung.
+
 ## 🛠️ Patch in 1.40.424
 * `web/src/main.js` nimmt bei zu kurzer Stretch-Länge zuerst die trimmbedingten Stillebereiche zurück und greift nur bei unvermeidbaren Resten auf Stille-Padding zurück, damit weich eingeblendete Clips ihren linken Rand behalten.
 * `README.md` dokumentiert die neue Trim-Rücknahme vor dem Stille-Padding bei Auto-Tempo.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 
 * **Pad-Skalierung beim Time-Stretch:** Auto-Tempo entfernt nach dem Strecken exakt das gestauchte Sekundenpolster, sodass weder Anfang noch Ende bei kombinierten Pausen- und Tempo-Automationen verloren gehen.
 * **Dynamische Stilleprüfung für Auto-Tempo:** Der Schwellwert orientiert sich am gestreckten Ruhepolster und entfernt nur dann zusätzliches Material, wenn ein zusammenhängendes 100-ms-Fenster wirklich unterhalb der Schwelle bleibt – Fade-Ins und Fade-Outs bleiben dadurch unangetastet.
+* **Crossfade-Samples bleiben unangetastet:** Bei der Schwellwertermittlung ignoriert das Tool die letzten 100 ms des Eingangs- und die ersten 100 ms des Ausgangspolsters, damit überblendete Bereiche weder den Schwellenwert anheben noch als Stille gelten.
 * **Trim-Rücknahme bei Auto-Tempo:** Reicht die gestretchte Länge nicht aus, nimmt das Tool zuerst die stillen Trim-Ränder zurück, bevor nur noch unvermeidbare Rundungsreste mit Stille aufgefüllt werden – weich eingeblendete Clips behalten dadurch ihren linken Rand.
 * **Asynchrones Speichern:** Beim Start werden Level- und Kapitel-Daten jetzt korrekt geladen, auch wenn das neue IndexedDB-System verwendet wird.
 * **Bereinigte Abschluss-Logik:** Die früheren UI-Helfer `toggleFileCompletion`, `toggleCompletionAll`, `toggleFileSelection` und `toggleSelectAll` wurden entfernt, weil der Fertig-Status nun vollständig automatisch aus den Projekt- und Dateidaten berechnet wird.


### PR DESCRIPTION
## Summary
- blende bei der dynamischen Schwellwertberechnung die letzten 100 ms des Start- und die ersten 100 ms des Endpolsters aus, damit Crossfade-Samples nicht in die Statistik fallen
- dokumentiere die neue Schutzlogik in README und CHANGELOG

## Testing
- not run (nicht angefordert)


------
https://chatgpt.com/codex/tasks/task_e_68da84ce938883279f297103c6febbad