### PR TITLE
Auto-Tempo ignoriert Randstille

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 🛠️ Patch in 1.40.431
+* `web/src/main.js` lässt Auto-Tempo erkannte Randstille bei der Berechnung außen vor und verhindert so, dass die automatische Anpassung gesprochene Passagen scheinbar wegschneidet.
+* `README.md` erwähnt den randstillefreien Auto-Tempo-Abgleich als zusätzlichen Schutz vor versehentlich gekürzten Clips.
+* `CHANGELOG.md` dokumentiert die stilleignorierende Tempo-Referenz.
+
 ## 🛠️ Patch in 1.40.430
 * `web/src/main.js` berücksichtigt beim Begrenzen der Trim-Limits jetzt immer das gestretchte Tempo-Polster und löst Überläufe bevorzugt innerhalb der Reserven auf, sodass die Kombination aus Schnellzugriff → Auto → Speichern → Tempo Auto keine einseitigen Lücken mehr erzeugt.
 * `README.md` beschreibt die polsterbewahrenden Limits beim Tempo-Stretching.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ### 🎯 Kernfunktionen
 
 * **Pad-Skalierung beim Time-Stretch:** Auto-Tempo entfernt nach dem Strecken exakt das gestauchte Sekundenpolster, sodass weder Anfang noch Ende bei kombinierten Pausen- und Tempo-Automationen verloren gehen.
+* **Tempo-Auto ignoriert Randstille:** Die automatische Tempo-Anpassung berücksichtigt erkannte Leerräume an den Rändern nicht mehr in der Berechnung, damit gesprochene Passagen unverändert bleiben und nichts „abgeschnitten“ wirkt.
 * **Limits bewahren das Tempo-Polster:** Beim Begrenzen von Start und Ende hält Tempo Auto jetzt stets mindestens das gestretchte Sekundenpolster ein, damit die Kombination aus Schnellzugriff → Auto → Speichern → Tempo Auto keine Stilleinsprünge mehr hinterlässt.
 * **Dynamische Stilleprüfung für Auto-Tempo:** Der Schwellwert orientiert sich am gestreckten Ruhepolster und entfernt nur dann zusätzliches Material, wenn ein zusammenhängendes 100-ms-Fenster wirklich unterhalb der Schwelle bleibt – Fade-Ins und Fade-Outs bleiben dadurch unangetastet.
 * **Crossfade-Samples bleiben unangetastet:** Bei der Schwellwertermittlung ignoriert das Tool die letzten 100 ms des Eingangs- und die ersten 100 ms des Ausgangspolsters, damit überblendete Bereiche weder den Schwellenwert anheben noch als Stille gelten.


### PR DESCRIPTION
## Summary
- verhindere, dass Auto-Tempo bei der Berechnung Randstille berücksichtigt und passe die automatische Anpassung auf eine neue Referenzlänge an
- erweitere die Längenanzeige um einen Hinweis auf ignorierte Stille und dokumentiere das Verhalten in README sowie CHANGELOG

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dad0768a0c83278c82ad62a1de4cde