### PR TITLE
Fix: Mono-Zeitdehnung passt SoundTouch-Puffer an

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.440
+* `web/src/main.js` berücksichtigt den zweikanaligen SoundTouch-Puffer beim Extrahieren, damit Mono-Zeitdehnungen keinen stummen Kanal anhängen und wieder korrekt auf ihre ursprüngliche Spurzahl zurückgeführt werden.
+* `README.md` erwähnt den Stereo-Puffer als Fix für Mono-Zeitdehnungen.
+* `CHANGELOG.md` dokumentiert die SoundTouch-Korrektur für Mono-Stretching.
 ## 🛠️ Patch in 1.40.439
 * `web/src/main.js` setzt die Tempo-Berechnung komplett neu auf, analysiert das Ruhepolster segmentiert, überspringt laute Randbereiche automatisch und verteilt fehlende Frames mehrstufig, bevor als letztes Mittel Stille angefügt wird.
 * `README.md` beschreibt die neue Tempo-Engine samt segmentierter Schwellenbestimmung und sanfter Restverteilung.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ### 🎯 Kernfunktionen
 
 * **Pad-Skalierung beim Time-Stretch:** Auto-Tempo entfernt nach dem Strecken exakt das gestauchte Sekundenpolster, sodass weder Anfang noch Ende bei kombinierten Pausen- und Tempo-Automationen verloren gehen.
+* **Mono-Stretch bleibt fehlerfrei:** Beim Zeitdehnen legt das Tool einen Stereo-Puffer an, weil SoundTouch unabhängig vom Eingang immer zwei Kanäle liefert, und übernimmt nur die echten Kanalspuren zurück in die Ausgabe.
 * **Neu aufgesetzte Tempo-Engine:** Die komplett neu geschriebene Time-Stretch-Funktion berechnet den Ruhe-Schwellwert segmentiert, verwirft laute Polsterbereiche automatisch und verteilt fehlende Samples stufenweise zwischen Start- und Endreserve, bevor als letzter Schritt Stille ergänzt wird.
 * **Tempo-Auto ignoriert Randstille:** Die automatische Tempo-Anpassung berücksichtigt erkannte Leerräume an den Rändern nicht mehr in der Berechnung, damit gesprochene Passagen unverändert bleiben und nichts „abgeschnitten“ wirkt.
 * **Limits bewahren das Tempo-Polster:** Beim Begrenzen von Start und Ende hält Tempo Auto jetzt stets mindestens das gestretchte Sekundenpolster ein, damit die Kombination aus Schnellzugriff → Auto → Speichern → Tempo Auto keine Stilleinsprünge mehr hinterlässt.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -9540,8 +9540,10 @@ async function timeStretchBuffer(buffer, factor, options = {}) {
         const filter = new SimpleFilter(source, st);
 
         const channels = padded.numberOfChannels;
+        // SoundTouch gibt auch bei Mono-Eingaben stets zwei Kanäle zurück, daher wird die Quellpuffergröße auf mindestens Stereo gesetzt.
+        const sourceChannels = Math.max(2, padded.numberOfChannels);
         const frameChunk = 4096;
-        const temp = new Float32Array(frameChunk * channels);
+        const temp = new Float32Array(frameChunk * sourceChannels);
         const collected = Array.from({ length: channels }, () => []);
         let producedFrames = 0;
 
@@ -9549,8 +9551,10 @@ async function timeStretchBuffer(buffer, factor, options = {}) {
             const frames = filter.extract(temp, frameChunk);
             if (!frames) break;
             for (let i = 0; i < frames; i++) {
-                for (let ch = 0; ch < channels; ch++) {
-                    collected[ch].push(temp[i * channels + ch]);
+                for (let ch = 0; ch < sourceChannels; ch++) {
+                    if (ch < channels) {
+                        collected[ch].push(temp[i * sourceChannels + ch]);
+                    }
                 }
             }
             producedFrames += frames;


### PR DESCRIPTION
## Summary
- erweitere `timeStretchBuffer`, damit der temporäre Puffer stets mindestens zwei Kanäle für die SoundTouch-Ausgabe bereitstellt
- übernehme beim Einsammeln nur die tatsächlichen Eingangskanäle und dokumentiere das Verhalten im Code
- ergänze README und Changelog um den Hinweis auf den Mono-Zeitdehnungsfix

## Testing
- not run (nicht angefordert)


------
https://chatgpt.com/codex/tasks/task_e_68db7dcab9f08327829e61b22ba45a3f