### PR TITLE
Fix: Normalisiere alte Tempo-Faktoren im DE-Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.446
+* `web/src/main.js` begrenzt beim Öffnen des DE-Editors alte Tempo-Faktoren sofort auf den Sliderbereich, damit historische Werte unterhalb von 1 keine extremen Beschleunigungen mehr auslösen.
+* `README.md` weist auf die automatische Normalisierung historischer Tempo-Werte hin.
+
 ## 🛠️ Patch in 1.40.445
 * `web/src/main.js` vereinfacht die Tempo-Verarbeitung radikal: Alle Randanalysen, Trim-Kürzungen und Defizitausgleiche entfallen, das gestretchte Signal bleibt vollständig erhalten und es wird nur noch der künstliche Sicherheitsrand entfernt.
 * `README.md` beschreibt, dass Tempo ausschließlich den Schutzpuffer kappt und keine Originalsamples mehr löscht.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ### 🎯 Kernfunktionen
 
 * **Tempo ohne Audiokürzung:** Die Tempo-Funktion dehnt das Signal nur noch auf den gewünschten Faktor und entfernt ausschließlich den zuvor hinzugefügten Sicherheitsrand. Automatische Randanalysen, Trim-Reduktionen, Defizitausgleiche und Stille-Padding innerhalb des gestretchten Materials wurden vollständig entfernt, damit kein Originalaudio mehr verloren geht.
+* **Tempo-Bereich wird automatisch normalisiert:** Beim Öffnen von DE-Audios korrigiert das Tool historische Tempo-Faktoren außerhalb des Sliderbereichs (z. B. Werte kleiner 1) sofort auf das erlaubte Minimum, sodass neue Beschleunigungen nicht versehentlich ein Drittel der Aufnahme wegkappen.
 * **Mono-Stretch bleibt fehlerfrei:** Beim Zeitdehnen legt das Tool einen Stereo-Puffer an, weil SoundTouch unabhängig vom Eingang immer zwei Kanäle liefert, und übernimmt nur die echten Kanalspuren zurück in die Ausgabe.
 * **Tempo-Sicherungen als reine Anzeige:** Die Häkchen im Tempo-Kasten bleiben zur Dokumentation der gewählten Strategie erhalten, beeinflussen das gestretchte Audiosignal jedoch nicht mehr und dienen nur noch dem Debug-Log.
 * **Tempo-Debug-Schritte:** Der Debug-Knopf neben „Zurücksetzen“ protokolliert weiterhin jeden Stretch-Durchlauf, weist jetzt aber ausdrücklich darauf hin, dass ausschließlich der Schutzpuffer entfernt wird und keine weiteren Kürzungen stattfinden.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -14649,10 +14649,34 @@ async function openDeEdit(fileId) {
     };
 
     tempoFactor = file.tempoFactor || 1.0;
-    loadedTempoFactor = tempoFactor; // Faktor merken, um später Differenzen zu ermitteln
     autoIgnoreMs = 400;
     const tempoRange = document.getElementById('tempoRange');
     const tempoDisp  = document.getElementById('tempoDisplay');
+    let tempoMin = 1;
+    let tempoMax = 3;
+    if (tempoRange) {
+        const parsedMin = parseFloat(tempoRange.min);
+        if (!Number.isNaN(parsedMin)) tempoMin = parsedMin;
+        const parsedMax = parseFloat(tempoRange.max);
+        if (!Number.isNaN(parsedMax)) tempoMax = parsedMax;
+    }
+    if (!Number.isFinite(tempoFactor)) {
+        tempoFactor = tempoMin;
+    }
+    let tempoBegrenzt = false;
+    if (tempoFactor < tempoMin) {
+        tempoFactor = tempoMin;
+        tempoBegrenzt = true;
+    } else if (tempoFactor > tempoMax) {
+        tempoFactor = tempoMax;
+        tempoBegrenzt = true;
+    }
+    loadedTempoFactor = tempoFactor; // Faktor merken, um später Differenzen zu ermitteln
+    if (tempoBegrenzt && file.tempoFactor !== tempoFactor) {
+        // Ältere Projekte können Tempo-Werte außerhalb des Slider-Bereichs besitzen – auf den erlaubten Bereich trimmen
+        file.tempoFactor = tempoFactor;
+        markDirty();
+    }
     if (tempoRange && tempoDisp) {
         tempoRange.value = tempoFactor.toFixed(2);
         tempoDisp.textContent = tempoFactor.toFixed(2);


### PR DESCRIPTION
## Summary
- normalisiere beim Öffnen des DE-Editors historische Tempo-Faktoren auf den Sliderbereich, damit relative Berechnungen keine Clips mehr drastisch kürzen
- dokumentiere die automatische Tempo-Normalisierung in README und Changelog

## Testing
- npm test -- timeStretchBuffer

------
https://chatgpt.com/codex/tasks/task_e_68db939d49548327bea1259f91fe0e87