### PR TITLE
Enable auto tempo to match EN timing bidirectionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 🛠️ Patch in 1.40.448
+* `web/src/main.js` berechnet den Tempo-Abgleich jetzt bidirektional, sodass Auto-Tempo DE-Aufnahmen sowohl beschleunigt als auch verlangsamt, um die EN-Zeit zu treffen.
+* `README.md` erwähnt den beidseitigen Auto-Tempo-Abgleich explizit.
+
 ## 🛠️ Patch in 1.40.447
 * `web/hla_translation_tool.html` ersetzt den Tempo-Debug-Dialog durch eine seitliche Debug-Konsole mit Kopier- und Schließen-Button direkt im DE-Editor.
 * `web/src/style.css` gestaltet das andockbare Debug-Fenster samt Animation und aktiver Button-Markierung.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 ### 🎯 Kernfunktionen
 
 * **Tempo ohne Audiokürzung:** Die Tempo-Funktion dehnt das Signal nur noch auf den gewünschten Faktor und entfernt ausschließlich den zuvor hinzugefügten Sicherheitsrand. Automatische Randanalysen, Trim-Reduktionen, Defizitausgleiche und Stille-Padding innerhalb des gestretchten Materials wurden vollständig entfernt, damit kein Originalaudio mehr verloren geht.
+* **Auto-Tempo gleicht beide Richtungen an:** Der automatische EN-Abgleich beschleunigt oder verlangsamt das DE-Audio jetzt je nach Bedarf und orientiert sich an der reinen Referenzlänge ohne das aktuelle Tempo, statt ausschließlich zu beschleunigen.
 * **Tempo-Bereich wird automatisch normalisiert:** Beim Öffnen von DE-Audios korrigiert das Tool historische Tempo-Faktoren außerhalb des Sliderbereichs (z. B. Werte kleiner 1) sofort auf das erlaubte Minimum, sodass neue Beschleunigungen nicht versehentlich ein Drittel der Aufnahme wegkappen.
 * **Mono-Stretch bleibt fehlerfrei:** Beim Zeitdehnen legt das Tool einen Stereo-Puffer an, weil SoundTouch unabhängig vom Eingang immer zwei Kanäle liefert, und übernimmt nur die echten Kanalspuren zurück in die Ausgabe.
 * **Tempo-Sicherungen als reine Anzeige:** Die Häkchen im Tempo-Kasten bleiben zur Dokumentation der gewählten Strategie erhalten, beeinflussen das gestretchte Audiosignal jedoch nicht mehr und dienen nur noch dem Debug-Log.


### PR DESCRIPTION
## Summary
- compute the auto tempo target factor based on the reference length so clips can speed up or slow down to hit the EN duration
- round the computed value to the slider step, clamp it to the allowed range, and update the UI state
- document the bidirectional auto tempo adjustment in the README and changelog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db9daa265483278a60453d3f11e522