### PR TITLE
feat: erweitere EN-Review um Wiedergabesteuerung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 🛠️ Patch in 1.40.421
+* `web/src/main.js` ergänzt eigene Statusvariablen und Wiedergabefunktionen für den EN-Review, aktualisiert den Dialog-Inhalt dynamisch, stoppt Projekt-Wiedergaben beim Start der Review und macht alle neuen Helfer für UI und Tests verfügbar.
+* `web/hla_translation_tool.html` erweitert den EN-Review-Dialog um eine Fortschrittsanzeige sowie einen Button zum direkten Scrollen auf die aktuelle Tabellenzeile.
+* `web/src/style.css` liefert die passenden Stilregeln für Fortschritt, Dateilinks und responsive Ausrichtung der EN-Review-Steuerung.
+* `README.md` beschreibt die erweiterte EN-Review-Wiedergabe mit Fortschrittsanzeige und direktem Tabellen-Sprung.
 ## 🛠️ Patch in 1.40.420
 * `web/hla_translation_tool.html` ergänzt einen 🇬🇧-Button unterhalb der Projekt-Wiedergabe, der den neuen EN-Review-Dialog mit eigener Handler-Funktion öffnet.
 * `web/hla_translation_tool.html` liefert ein Dialog-Overlay mit aktuellem Dateiüberblick, EN/DE-Textbereichen, Nachbarlisten und Steuerknöpfen inklusive Aria-Attributen.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Kapitelwahl beim Erstellen:** Neue oder bestehende Kapitel direkt auswählen
 * **Intelligenter Ordner‑Scan** mit Duplikat‑Prävention und Auto‑Normalisierung
 * **Eingebettete Audio‑Wiedergabe** (MP3 / WAV / OGG) direkt im Browser
-* **EN-Review-Überblick:** Ein zusätzlicher Dialog zeigt aktuelle Datei samt EN/DE-Text, zwei vorherige und zwei folgende Dateinamen und lässt sich über einen eigenen 🇬🇧-Button im Fortschrittsbereich komfortabel steuern.
+* **EN-Review-Überblick:** Der 🇬🇧-Dialog bietet jetzt eine eigene Wiedergabe mit Fortschrittsanzeige, zeigt EN/DE-Text der aktuellen Zeile, blendet zwei vergangene und zwei kommende Dateien ein und erlaubt über Zurück/Weiter sowie „Zur Zeile“-Sprung einen direkten Abgleich mit der Tabelle.
 * **Automatische MP3-Konvertierung** beim Start (Originale in `Backups/mp3`)
 * **Automatische Prüfung geänderter Endungen** passt Datenbank und Projekte an
 * **Live‑Statistiken:** EN‑%, DE‑%, Completion‑%, Globale Textzahlen (EN/DE/BEIDE/∑)

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -1243,11 +1243,13 @@
                     </section>
                 </div>
             </div>
+            <div class="english-review-progress" id="englishReviewProgress" aria-live="polite">Fortschritt: 0 / 0 (0%)</div>
             <div class="dialog-buttons english-review-controls">
                 <button class="btn btn-secondary" id="englishReviewPrevBtn" type="button" onclick="englishReviewPrev()" title="Vorherige Datei" aria-label="Vorherige Datei">⏮</button>
                 <button class="btn btn-secondary" id="englishReviewPlayBtn" type="button" onclick="englishReviewPlay()" title="Wiedergabe starten" aria-label="Wiedergabe starten">▶</button>
                 <button class="btn btn-secondary" id="englishReviewPauseBtn" type="button" onclick="englishReviewPause()" title="Wiedergabe anhalten" aria-label="Wiedergabe anhalten">⏸</button>
                 <button class="btn btn-secondary" id="englishReviewNextBtn" type="button" onclick="englishReviewNext()" title="Nächste Datei" aria-label="Nächste Datei">⏭</button>
+                <button class="btn btn-secondary" id="englishReviewScrollBtn" type="button" onclick="englishReviewScrollToCurrent()" title="Aktuelle Zeile anzeigen" aria-label="Zur aktuellen Zeile scrollen">⬇ Zeile</button>
                 <button class="btn btn-secondary" id="englishReviewCloseBtn" type="button" onclick="closeEnglishReview()" title="Dialog schließen" aria-label="Dialog schließen">Schließen</button>
             </div>
         </div>

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -4615,12 +4615,18 @@ th:nth-child(8) {
 .english-review-item.review-item--previous { border-color: rgba(255, 255, 255, 0.08); opacity: 0.85; }
 .english-review-item.review-item--active { border-color: #ff6b1a; background: rgba(255, 107, 26, 0.15); color: #fff; }
 .english-review-item.review-item--upcoming { border-style: dashed; }
+.english-review-progress { text-align: right; color: #bbb; font-size: 13px; }
+.english-review-link { background: none; border: none; color: #ffb347; cursor: pointer; text-align: left; padding: 0; font-weight: 600; font-size: 13px; }
+.english-review-link:hover, .english-review-link:focus { text-decoration: underline; color: #ffd08a; }
+.english-review-link:disabled { color: #555; cursor: default; text-decoration: none; }
+.english-review-link--current { font-size: 15px; }
 .english-review-controls { justify-content: flex-end; gap: 10px; flex-wrap: wrap; }
 .english-review-controls .btn { min-width: 44px; text-align: center; }
 @media (max-width: 720px) {
     .english-review-texts { grid-template-columns: 1fr; }
     .english-review-neighbours { flex-direction: column; }
     .english-review-controls { justify-content: center; }
+    .english-review-progress { text-align: center; }
 }
 
 /* Tabelle für den ZIP-Import */


### PR DESCRIPTION
## Zusammenfassung
- ergänzte Statusverwaltung und Wiedergabe-Helfer für den EN-Review inklusive automatischem Wechsel sowie Projekt-Stopps
- erweiterte den EN-Review-Dialog um Fortschrittsanzeige, Scroll-Schaltfläche und klickbare Dateieinträge
- aktualisierte Styles sowie Dokumentation in README und CHANGELOG

## Tests
- nicht ausgeführt (war nicht erforderlich)


------
https://chatgpt.com/codex/tasks/task_e_68e37d9fe2988327b29a0c8a23a86e9d