### PR TITLE
Automatisches Scrollen im EN-Review aktivieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.422
+* `web/src/main.js` scrollt beim Starten der EN-Review-Wiedergabe und bei manuellen Zurück/Weiter-Schritten automatisch zur passenden Tabellenzeile, bevor die Markierung gesetzt wird.
+* `README.md` erwähnt das automatische Mitscrollen der EN-Review sowohl bei Wiedergabe als auch bei manueller Navigation.
 ## 🛠️ Patch in 1.40.421
 * `web/src/main.js` ergänzt eigene Statusvariablen und Wiedergabefunktionen für den EN-Review, aktualisiert den Dialog-Inhalt dynamisch, stoppt Projekt-Wiedergaben beim Start der Review und macht alle neuen Helfer für UI und Tests verfügbar.
 * `web/hla_translation_tool.html` erweitert den EN-Review-Dialog um eine Fortschrittsanzeige sowie einen Button zum direkten Scrollen auf die aktuelle Tabellenzeile.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Kapitelwahl beim Erstellen:** Neue oder bestehende Kapitel direkt auswählen
 * **Intelligenter Ordner‑Scan** mit Duplikat‑Prävention und Auto‑Normalisierung
 * **Eingebettete Audio‑Wiedergabe** (MP3 / WAV / OGG) direkt im Browser
-* **EN-Review-Überblick:** Der 🇬🇧-Dialog bietet jetzt eine eigene Wiedergabe mit Fortschrittsanzeige, zeigt EN/DE-Text der aktuellen Zeile, blendet zwei vergangene und zwei kommende Dateien ein und erlaubt über Zurück/Weiter sowie „Zur Zeile“-Sprung einen direkten Abgleich mit der Tabelle.
+* **EN-Review-Überblick:** Der 🇬🇧-Dialog bietet jetzt eine eigene Wiedergabe mit Fortschrittsanzeige, zeigt EN/DE-Text der aktuellen Zeile, blendet zwei vergangene und zwei kommende Dateien ein und scrollt sowohl bei der automatischen Wiedergabe als auch beim manuellen Zurück/Weiter-Schritt direkt zur passenden Tabellenzeile.
 * **Automatische MP3-Konvertierung** beim Start (Originale in `Backups/mp3`)
 * **Automatische Prüfung geänderter Endungen** passt Datenbank und Projekte an
 * **Live‑Statistiken:** EN‑%, DE‑%, Completion‑%, Globale Textzahlen (EN/DE/BEIDE/∑)

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -8017,6 +8017,7 @@ function playCurrentEnglishReviewFile() {
 
     const position = getFilePosition(file.id);
     if (position > 0) {
+        scrollToNumber(position);
         highlightProjectRow(file.id);
         enReviewHighlightedId = file.id;
     }
@@ -8190,6 +8191,7 @@ function englishReviewPrev() {
         if (file) {
             const position = getFilePosition(file.id);
             if (position > 0) {
+                scrollToNumber(position);
                 highlightProjectRow(file.id);
                 enReviewHighlightedId = file.id;
             }
@@ -8214,6 +8216,7 @@ function englishReviewNext() {
         if (file) {
             const position = getFilePosition(file.id);
             if (position > 0) {
+                scrollToNumber(position);
                 highlightProjectRow(file.id);
                 enReviewHighlightedId = file.id;
             }


### PR DESCRIPTION
## Summary
- ergänze in `web/src/main.js` Scroll-Aufrufe für Wiedergabe sowie Zurück/Weiter, damit die Tabelle vor der Hervorhebung mitscrollt
- dokumentiere das automatische Mitscrollen in README und CHANGELOG

## Testing
- keine automatisierten Tests ausgeführt (EN-Review erfordert Projekt- und Audiodaten)

------
https://chatgpt.com/codex/tasks/task_e_68e382ad216883279d76133a9cbe6710