### PR TITLE
Fix EN-Review-Handler wird nur einmal ausgeführt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.423
+* `web/src/main.js` entfernt alte Review-Handler vor dem Neusetzen, schützt den EN-Review-Callback vor Mehrfachausführung und erhöht den Index nach jedem Track nur genau einmal, bevor automatisch weitergespielt oder sauber gestoppt wird.
+* `README.md` beschreibt die abgesicherte EN-Review-Wiedergabe mit eindeutigem Index-Fortschritt.
 ## 🛠️ Patch in 1.40.422
 * `web/src/main.js` scrollt beim Starten der EN-Review-Wiedergabe und bei manuellen Zurück/Weiter-Schritten automatisch zur passenden Tabellenzeile, bevor die Markierung gesetzt wird.
 * `README.md` erwähnt das automatische Mitscrollen der EN-Review sowohl bei Wiedergabe als auch bei manueller Navigation.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Intelligenter Ordner‑Scan** mit Duplikat‑Prävention und Auto‑Normalisierung
 * **Eingebettete Audio‑Wiedergabe** (MP3 / WAV / OGG) direkt im Browser
 * **EN-Review-Überblick:** Der 🇬🇧-Dialog bietet jetzt eine eigene Wiedergabe mit Fortschrittsanzeige, zeigt EN/DE-Text der aktuellen Zeile, blendet zwei vergangene und zwei kommende Dateien ein und scrollt sowohl bei der automatischen Wiedergabe als auch beim manuellen Zurück/Weiter-Schritt direkt zur passenden Tabellenzeile.
+* **Stabile EN-Review-Läufe:** Der Audio-Player entfernt alte Review-Handler vor dem nächsten Start, erhöht den Index nach jedem Track nur einmal und setzt danach entweder automatisch zur nächsten Datei über oder stoppt die Wiedergabe sauber am Ende der Liste.
 * **Automatische MP3-Konvertierung** beim Start (Originale in `Backups/mp3`)
 * **Automatische Prüfung geänderter Endungen** passt Datenbank und Projekte an
 * **Live‑Statistiken:** EN‑%, DE‑%, Completion‑%, Globale Textzahlen (EN/DE/BEIDE/∑)


### PR DESCRIPTION
## Summary
- entferne alte EN-Review-Handler vor dem Neusetzen und markiere den neuen Callback eindeutig
- verhindere Mehrfachausführungen des Review-Ende-Handlers und sorge für einen einmaligen Index-Fortschritt
- dokumentiere die stabilisierte EN-Review-Wiedergabe in README und CHANGELOG

## Testing
- not run (manuelles Durchklicken des EN-Review-Dialogs ist im Container nicht möglich)


------
https://chatgpt.com/codex/tasks/task_e_68e386212c8c8327bf1542cca3abab66