### PR TITLE
Add audio language toggle to EN review dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 🛠️ Patch in 1.40.425
+* `web/hla_translation_tool.html` ergänzt im EN-Review-Dialog eine Radiogruppe für EN- und DE-Audio, die EN standardmäßig aktiviert.
+* `web/src/main.js` verwaltet die neue Review-Sprache, reagiert auf Umschalter, lädt DE-Audios über Cache und Dateisystem nach und meldet fehlende Dateien pro Sprache.
+* `README.md` beschreibt den Sprachumschalter im 🇬🇧-Dialog und erklärt den Wechsel zwischen EN- und DE-Audio.
+* `CHANGELOG.md` dokumentiert den neuen Umschalter für die EN-Review.
+
 ## 🛠️ Patch in 1.40.424
 * `web/hla_translation_tool.html` entfernt die Projekt-Wiedergabe-Schaltflächen, führt Nummern-Navigation und 🇬🇧-Review-Button in einem flexiblen Block zusammen und vermeidet dadurch Leerräume.
 * `web/src/main.js` streicht alle Projekt-Player-Variablen samt Hilfsfunktionen, vereinfacht `playDeAudio()` und belässt den Fokus auf der EN-Review ohne gegenseitige Stopps.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Intelligenter Ordner‑Scan** mit Duplikat‑Prävention und Auto‑Normalisierung
 * **Eingebettete Audio‑Wiedergabe** (MP3 / WAV / OGG) direkt im Browser
 * **EN-Review-Überblick:** Der 🇬🇧-Dialog bietet jetzt eine eigene Wiedergabe mit Fortschrittsanzeige, zeigt EN/DE-Text der aktuellen Zeile, blendet zwei vergangene und zwei kommende Dateien ein und scrollt sowohl bei der automatischen Wiedergabe als auch beim manuellen Zurück/Weiter-Schritt direkt zur passenden Tabellenzeile.
+* **EN/DE-Audio-Umschalter im Review:** Im 🇬🇧-Dialog wählst du per Radiogruppe zwischen EN- und DE-Audio; EN ist voreingestellt und DE wird automatisch deaktiviert, wenn für die Datei kein deutsches Audio existiert.
 * **Projekt-Player entfernt:** Die frühere Projekt-Wiedergabeliste samt Play/Pause/Stop-Schaltflächen ist gestrichen; die Nummern-Navigation sitzt nun direkt neben dem 🇬🇧-Review-Knopf, der als zentrale Kontrollstelle dient.
 * **Stabile EN-Review-Läufe:** Der Audio-Player entfernt alte Review-Handler vor dem nächsten Start, erhöht den Index nach jedem Track nur einmal und setzt danach entweder automatisch zur nächsten Datei über oder stoppt die Wiedergabe sauber am Ende der Liste.
 * **Automatische MP3-Konvertierung** beim Start (Originale in `Backups/mp3`)
@@ -891,6 +892,7 @@ Ignorierte Einträge merkt sich der Ordner-Browser jetzt dauerhaft – unabhäng
 | -------------------------- | ----------------------------------------------- |
 | **Audio abspielen**       | ▶ Button oder Leertaste (bei ausgewaehlter Zeile) |
 | **Projekt-Playback**      | ▶/⏸/⏹ spielt vorhandene DE-Dateien der Reihe nach |
+| **Review-Sprache wechseln** | 🇬🇧 Review öffnen → Umschalter EN-Audio / DE-Audio nutzen (DE deaktiviert sich bei fehlender Datei) |
 | **Zur nächsten Nummer**   | ▲/▼ neben ▶/⏹ springen eine Zeile weiter oder zurück und halten Nummer, Dateiname und Ordner direkt unter dem Tabellenkopf sichtbar; das Mausrad markiert nur die Zeile in der Bildschirmmitte, ohne die Position zu verändern. Schnelle Klicks funktionieren weiterhin zuverlässig |
 | **Audio im Textfeld**     | `Ctrl + Leertaste` |
 | **Text kopieren**         | 📋 Button neben Textfeld |

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -1203,6 +1203,17 @@
         <div class="dialog english-review-dialog">
             <button class="dialog-close-btn" type="button" onclick="closeEnglishReview()" aria-label="Dialog schließen">×</button>
             <h3 id="englishReviewTitle">🇬🇧 EN-Review</h3>
+            <div class="english-review-language-toggle" role="radiogroup" aria-label="Audio-Auswahl">
+                <span class="english-review-language-label">Audio:</span>
+                <label class="english-review-language-option" for="englishReviewLangEn">
+                    <input type="radio" name="englishReviewLanguage" id="englishReviewLangEn" value="en" checked>
+                    EN-Audio
+                </label>
+                <label class="english-review-language-option" for="englishReviewLangDe">
+                    <input type="radio" name="englishReviewLanguage" id="englishReviewLangDe" value="de">
+                    DE-Audio
+                </label>
+            </div>
             <div class="english-review-content">
                 <section class="english-review-current" aria-labelledby="englishReviewCurrentLabel">
                     <h4 id="englishReviewCurrentLabel">Aktuelle Datei</h4>


### PR DESCRIPTION
## Summary
- add an EN/DE audio toggle to the English review dialog with EN selected by default
- track the chosen review language, reload audio per selection, and surface status messages when files are missing
- document the new toggle in the README and CHANGELOG

## Testing
- node --experimental-vm-modules --unhandled-rejections=warn node_modules/jest/bin/jest.js --runTestsByPath tests/ensurePlaybackOrder.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e38d0112d88327abc7ad416cdcf079