### PR TITLE
Remove restoreVersion helper from history utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 🛠️ Patch in 1.40.426
+* `historyUtils.js` entfernt den Helfer `restoreVersion` und verweist ausschließlich auf `switchVersion` zum Wiederherstellen von Dateien.
+* `tests/historyFunctions.test.js` ersetzen die Wiederherstellungsprüfung durch `switchVersion` und prüfen den leeren Verlauf nach dem Tausch.
+* `README.md` und `CHANGELOG.md` dokumentieren den Wegfall von `restoreVersion` zugunsten von `switchVersion`.
+
 ## 🛠️ Patch in 1.40.425
 * `web/hla_translation_tool.html` ergänzt im EN-Review-Dialog eine Radiogruppe für EN- und DE-Audio, die EN standardmäßig aktiviert.
 * `web/src/main.js` verwaltet die neue Review-Sprache, reagiert auf Umschalter, lädt DE-Audios über Cache und Dateisystem nach und meldet fehlende Dateien pro Sprache.

--- a/README.md
+++ b/README.md
@@ -1292,6 +1292,8 @@ verwendet werden, um optionale Downloads zu überspringen.
 * **`list-sound-backups()`** – listet vorhandene ZIP-Sicherungen auf.
 * **`delete-sound-backup(name)`** – entfernt ein ZIP-Backup.
 * **`saveDeHistoryBuffer(relPath, data)`** – legt einen Buffer als neue History-Version ab.
+* **`switchVersion(historyRoot, relPath, name, targetRoot, limit)`** – stellt eine gespeicherte Version im Zielordner bereit, verschiebt vorher die aktuelle Datei in die Historie und entfernt den genutzten Eintrag.
+* **Entfernt:** Der frühere Helfer `restoreVersion` entfällt zugunsten von `switchVersion`.
 * **`chooseExisting(base, names)`** – liefert den ersten existierenden Ordnernamen und wirft einen Fehler bei leerer Liste.
 * **`copyDubbedFile(originalPath, tempDubPath)`** – verschiebt eine heruntergeladene Dub-Datei in den deutschen Ordnerbaum.
 * **`extractRelevantFolder(parts)`** – gibt den relevanten Abschnitt eines Dateipfades ab "vo" oder ohne führendes "sounds" zurück (siehe `web/src/pathUtils.js`). Der frühere zweite Parameter mit dem vollständigen Pfad entfällt; das Array der Ordnerteile reicht aus.

--- a/historyUtils.js
+++ b/historyUtils.js
@@ -57,15 +57,6 @@ function listVersions(historyRoot, relPath) {
     return fs.readdirSync(historyDir).filter(f => !fs.statSync(path.join(historyDir, f)).isDirectory()).sort().reverse();
 }
 
-// Stellt eine Version wieder im Zielordner her
-function restoreVersion(historyRoot, relPath, name, targetRoot) {
-    const source = path.join(historyRoot, relPath, name);
-    const target = path.join(targetRoot, relPath);
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.copyFileSync(source, target);
-    return target;
-}
-
 // Tauscht die aktuelle Datei mit einer History-Version aus und aktualisiert die Historie
 function switchVersion(historyRoot, relPath, name, targetRoot, limit = 10) {
     const source = path.join(historyRoot, relPath, name);
@@ -81,4 +72,4 @@ function switchVersion(historyRoot, relPath, name, targetRoot, limit = 10) {
     return target;
 }
 
-module.exports = { saveVersion, listVersions, restoreVersion, switchVersion, saveBufferVersion };
+module.exports = { saveVersion, listVersions, switchVersion, saveBufferVersion };

--- a/tests/historyFunctions.test.js
+++ b/tests/historyFunctions.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { saveVersion, listVersions, restoreVersion, switchVersion, saveBufferVersion } = require('../historyUtils');
+const { saveVersion, listVersions, switchVersion, saveBufferVersion } = require('../historyUtils');
 
 describe('history utils', () => {
     test('keeps maximal zehn Versionen', () => {
@@ -17,7 +17,7 @@ describe('history utils', () => {
         expect(list.length).toBe(10);
     });
 
-    test('restores a version correctly', () => {
+    test('switchVersion stellt eine gespeicherte Version wieder her', () => {
         const historyRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hist-'));
         const targetRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'de-'));
         const source = path.join(historyRoot, 'src.wav');
@@ -25,9 +25,11 @@ describe('history utils', () => {
         const relPath = 'a/b.wav';
         saveVersion(historyRoot, relPath, source, 10);
         const name = listVersions(historyRoot, relPath)[0];
-        restoreVersion(historyRoot, relPath, name, targetRoot);
+        switchVersion(historyRoot, relPath, name, targetRoot);
         const restored = fs.readFileSync(path.join(targetRoot, relPath), 'utf8');
         expect(restored).toBe('abc');
+        const remainingHistory = listVersions(historyRoot, relPath);
+        expect(remainingHistory.length).toBe(0);
     });
 
     test('switchVersion tauscht Dateien und aktualisiert die Historie', () => {


### PR DESCRIPTION
## Summary
- entferne den Hilfsaufruf `restoreVersion` aus `historyUtils.js` und exportiere nur noch `switchVersion`
- aktualisiere die History-Tests, damit sie den Tausch über `switchVersion` prüfen und den geleerten Verlauf verifizieren
- dokumentiere in README und CHANGELOG, dass `restoreVersion` entfällt und `switchVersion` die Wiederherstellung übernimmt

## Testing
- npm test *(schlägt in der vorhandenen Testumgebung wegen fehlender DOM-/Electron-APIs fehl)*

------
https://chatgpt.com/codex/tasks/task_e_68e393de18bc83278e1abff04c023687