### PR TITLE
Entferne removeDeAudioCache aus dem Dubbing-Frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.429
+* `web/src/dubbing.js` entfernt den Helfer `removeDeAudioCache`, sodass alle Löschroutinen direkt auf die bestehenden Cache-APIs zugreifen.
+* `README.md` und `CHANGELOG.md` erwähnen die Bereinigung des DE-Audio-Caches ohne den zusätzlichen Wrapper.
 ## 🛠️ Patch in 1.40.428
 * `web/src/main.js` entfernt den Ordner-Umbenennungs-Workflow inklusive Datenbankanpassung und verlässt sich wieder auf Dateisystem-Umbenennungen.
 * `README.md` und `CHANGELOG.md` vermerken den Wegfall des speziellen Ordner-Umbenennungs-Dialogs.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Live-Suche nach Projektwechsel funktionsfähig:** `switchProjectSafe` ruft `initializeEventListeners` erneut auf
 * **Fallback ohne `switchProjectSafe`:** Sollte das Skript fehlen, öffnen Klicks Projekte direkt über `selectProject`
 * **Synchronisierte Projektreparatur:** `repairProjectIntegrity` wartet auf alle Speicherzugriffe und aktualisiert den In-Memory-Cache sofort
+* **Verschlankter DE-Audio-Cache:** Der frühere Helfer `removeDeAudioCache` entfällt; Löschroutinen greifen direkt auf `deleteDeAudioCacheEntry` oder den lokalen Cache zu und sparen doppelten Wartungscode
 * **Gemeinsame Projektlisten-Aktualisierung:** Der neue Helfer `replaceProjectList` hält `projects` und `window.projects` identisch, sodass Reparaturläufe keine Platzhalter verlieren und `selectProject` sofort wieder funktioniert
 * **Projektliste ohne Auto-Auswahl:** `loadProjects` nimmt optional `skipSelect` entgegen; `reloadProjectList` lädt dadurch nur die Liste und öffnet kein altes Projekt
 * **Fehlerfreier Projektwechsel:** `switchProjectSafe` lädt vor dem Öffnen die Projektliste neu und vermeidet so die Meldung „Projekte konnten nicht geladen werden“

--- a/web/src/dubbing.js
+++ b/web/src/dubbing.js
@@ -3,22 +3,12 @@ const API = "https://api.elevenlabs.io/v1";
 const storage = window.storage;
 let csvLineEnding = (typeof storage !== "undefined" && storage.getItem("hla_lineEnding")) || (typeof global !== "undefined" && global.csvLineEnding) || "LF";
 
-// Hilfsfunktionen, um den DE-Audio-Cache konsistent zu pflegen
 function writeDeAudioCache(key, value) {
     if (!key) return;
     if (typeof setDeAudioCacheEntry === 'function') {
         setDeAudioCacheEntry(key, value);
     } else {
         deAudioCache[key] = value;
-    }
-}
-
-function removeDeAudioCache(key) {
-    if (!key) return;
-    if (typeof deleteDeAudioCacheEntry === 'function') {
-        deleteDeAudioCacheEntry(key);
-    } else {
-        delete deAudioCache[key];
     }
 }
 


### PR DESCRIPTION
## Summary
- entferne den nicht mehr benötigten Helper `removeDeAudioCache` aus `web/src/dubbing.js`
- dokumentiere die Bereinigung des DE-Audio-Caches in README und CHANGELOG

## Testing
- not run (nicht angefordert)


------
https://chatgpt.com/codex/tasks/task_e_68e3a2ced6748327bd64fd87668a01ae