### PR TITLE
Entferne Studio-Overlay aus Dubbing-Modul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.432
+* `web/src/dubbing.js` entfernt den nicht mehr verwendeten Studio-Hinweis (`showStudioOverlay`/`closeStudioOverlay`) samt `window`-Exporten.
+* `README.md` und `CHANGELOG.md` vermerken den Wegfall des separaten Studio-Overlays.
 ## 🛠️ Patch in 1.40.431
 * `web/src/main.js` entfernt den lokalen Suchindex samt globalem Reset, da die Projektübersicht keine Volltextsuche mehr anbietet.
 * `web/src/localIndex.js` entfällt vollständig; der eigenständige Index wird nicht mehr gebündelt.

--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ Seit Patch 1.40.89 verhindert der Dateiwchter einen Abbruch, wenn die Datei kurz
 Seit Patch 1.40.90 prüft das Tool nach dem Schließen des "Alles gesendet"-Fensters automatisch, ob neue Dub-Dateien erkannt wurden. So erscheint der grüne Haken auch dann, wenn der Dateiwächter bereits vorher reagiert hat.
 Seit Patch 1.40.91 löst der Dateiwächter den manuellen Import nur noch aus, wenn keine Zuordnung zu offenen Jobs möglich ist.
 Seit Patch 1.40.92 bricht der Dateiwächter nach 10 s ohne stabile Datei mit einer Fehlermeldung ab.
-Seit Patch 1.40.93 schließen sich nach erfolgreichem Import das Fenster „Alles gesendet“, der Studio-Hinweis und das Dubbing-Protokoll automatisch.
+Seit Patch 1.40.93 schließen sich nach erfolgreichem Import das Fenster „Alles gesendet“, der Studio-Hinweis und das Dubbing-Protokoll automatisch. Seit Version 1.40.432 entfällt der separate Studio-Hinweis vollständig, weil die ElevenLabs-Seite ohne zusätzliches Overlay geöffnet wird.
 Seit Patch 1.40.94 funktioniert die Untertitel-Suche über die Lupe wieder korrekt.
 Seit Patch 1.40.95 lädt die OT-Suche fehlende Text-Utilities automatisch nach.
 Seit Patch 1.40.96 meldet die Untertitel-Suche nun fehlende Text-Utilities.

--- a/web/src/dubbing.js
+++ b/web/src/dubbing.js
@@ -309,30 +309,6 @@ async function playDubPreview() {
     audio.play();
 }
 
-// Zeigt einen Hinweis an, dass das Studio geöffnet wurde
-function showStudioOverlay() {
-    const ov = document.createElement('div');
-    ov.className = 'dialog-overlay hidden';
-    ov.id = 'studioNoticeDialog';
-    ov.innerHTML = `
-        <div class="dialog">
-            <h3>🎧 ElevenLabs Studio</h3>
-            <p>Das Studio ist in einem neuen Tab geöffnet.<br>
-               Klicken Sie dort auf „Generate Audio" und danach auf OK.</p>
-            <div class="dialog-buttons">
-                <button class="btn btn-success" onclick="closeStudioOverlay()">OK</button>
-            </div>
-        </div>`;
-    document.body.appendChild(ov);
-    ov.classList.remove('hidden');
-}
-
-// Schließt den Studio-Hinweis
-function closeStudioOverlay() {
-    const ov = document.getElementById('studioNoticeDialog');
-    if (ov) ov.remove();
-}
-
 // Zeigt ein Dialogfenster, das auf die manuelle Datei wartet
 // und blendet dabei Ordnername sowie EN- und DE-Text ein
 // ID der Datei, auf deren Download gewartet wird
@@ -1362,8 +1338,6 @@ if (typeof module !== 'undefined' && module.exports) {
         closeDubTooltip,
         escCloseDubTooltip,
         playDubPreview,
-        showStudioOverlay,
-        closeStudioOverlay,
         showDownloadWaitDialog,
         updateDownloadWaitDialog,
         closeDownloadWaitDialog,
@@ -1407,8 +1381,6 @@ if (typeof window !== 'undefined') {
     window.closeDubTooltip = closeDubTooltip;
     window.escCloseDubTooltip = escCloseDubTooltip;
     window.playDubPreview = playDubPreview;
-    window.showStudioOverlay = showStudioOverlay;
-    window.closeStudioOverlay = closeStudioOverlay;
     window.showDownloadWaitDialog = showDownloadWaitDialog;
     window.updateDownloadWaitDialog = updateDownloadWaitDialog;
     window.closeDownloadWaitDialog = closeDownloadWaitDialog;


### PR DESCRIPTION
## Zusammenfassung
- entferne die ungenutzten Funktionen `showStudioOverlay` und `closeStudioOverlay` aus `web/src/dubbing.js` inklusive der globalen `window`-Zuweisungen.
- räume die Exportliste im Dubbing-Modul auf, sodass keine leeren Einträge zurückbleiben.
- aktualisiere README und CHANGELOG, um den Wegfall des Studio-Overlays zu dokumentieren.

## Tests
- `npm test` *(schlägt aktuell fehl, weil zahlreiche bestehende Jest-Suites in dieser Umgebung ohne DOM-API laufen und deshalb `document.querySelector` nicht verfügbar ist; unverändert durch diesen Patch)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b86f88e88327a166f0dec50574e6