### PR TITLE
Remove hideErrorBanner helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.435
+* `web/src/main.js` entfernt den ungenutzten UI-Helfer `hideErrorBanner` und exportiert nur noch `showErrorBanner` für Wiederholungsaktionen.
+* `README.md` und `CHANGELOG.md` dokumentieren, dass das Ausblenden-Banner nicht mehr separat verfügbar ist.
 ## 🛠️ Patch in 1.40.434
 * `electron/preload.cjs` entfernt den nicht mehr genutzten `deleteBookmark`-Bridge-Aufruf aus der Video-API.
 * `electron/main.js` streicht den IPC-Handler `delete-bookmark`, da das Löschen clientseitig erfolgt.

--- a/README.md
+++ b/README.md
@@ -1309,6 +1309,7 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`importLocalStorageFromOpfs()`** – liest die Datei `hla_daten.json` aus dem OPFS, ersetzt den aktuellen LocalStorage und gibt die Anzahl der geladenen Einträge zurück.
   * **`loadMigration()`** – UI-Helfer, der den Import startet und Statusmeldungen anzeigt.
   * **Entfernt:** Der frühere UI-Helfer `switchStorageDirection` entfällt; Speichermodus-Wechsel erfolgen direkt über `switchStorage`.
+  * **Entfernt:** Der UI-Helfer `hideErrorBanner` steht nicht mehr zur Verfügung; Fehlversuche lassen das Banner nach dem Wiederholungsversuch automatisch ausgeblendet.
   * **`cleanupProject.js`** – nutzt `removeUnknownFileIds`, um Datei-IDs mit einer Liste aus der Oberfläche abzugleichen und unbekannte Einträge zu entfernen. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.
   * **`removeUnknownFileIds(project, ids, logFn)`** – Hilfsfunktion, die alle Dateien mit unbekannter ID entfernt und jede Entfernung protokolliert.
   * **Entfernt:** Die frühere Hilfsfunktion `syncProjectData` steht nicht mehr zur Verfügung, da ihre Aufgaben vollständig von `repairFileExtensions` abgedeckt werden.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -18490,11 +18490,6 @@ function quickAddLevel(chapterName) {
             banner.classList.remove('hidden');
         }
 
-        function hideErrorBanner() {
-            const banner = document.getElementById('errorBanner');
-            if (banner) banner.classList.add('hidden');
-        }
-
         // Zeigt ein modales Dialogfenster mit HTML-Inhalt an
         function showModal(html) {
             const ov = document.createElement('div');
@@ -18610,7 +18605,7 @@ function quickAddLevel(chapterName) {
             saveCurrentProject();
         }
 
-        window.ui = { getActiveDubItem, markDubAsReady, notify: showToast, showModal, showInputDialog, setActiveDubItem, showErrorBanner, hideErrorBanner, toggleEmoCompletion, showZipImportDialog, handleZipImport };
+        window.ui = { getActiveDubItem, markDubAsReady, notify: showToast, showModal, showInputDialog, setActiveDubItem, showErrorBanner, toggleEmoCompletion, showZipImportDialog, handleZipImport };
 
         function updateCounts() {
             const fileCount = document.getElementById('fileCount');


### PR DESCRIPTION
## Summary
- remove the unused hideErrorBanner helper from the web UI bootstrap and drop its window.ui export
- document the removal in the README helper overview and in the changelog

## Testing
- npm test *(fails: jsdom is not available for DOM-specific helpers in the current Node test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c98dbc5c8327aed97fc50a3e5b4f