### PR TITLE
Remove legacy canvas zoom helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.436
+* `web/src/main.js` entfernt den obsoleten Canvas-Zoom-Helfer `zoomCanvasToRange` aus dem Wellenformbereich.
+* `README.md` und `CHANGELOG.md` erwähnen, dass der frühere Canvas-Zoom-Helfer nicht mehr bereitsteht.
 ## 🛠️ Patch in 1.40.435
 * `web/src/main.js` entfernt den ungenutzten UI-Helfer `hideErrorBanner` und exportiert nur noch `showErrorBanner` für Wiederholungsaktionen.
 * `README.md` und `CHANGELOG.md` dokumentieren, dass das Ausblenden-Banner nicht mehr separat verfügbar ist.

--- a/README.md
+++ b/README.md
@@ -1310,6 +1310,7 @@ verwendet werden, um optionale Downloads zu überspringen.
   * **`loadMigration()`** – UI-Helfer, der den Import startet und Statusmeldungen anzeigt.
   * **Entfernt:** Der frühere UI-Helfer `switchStorageDirection` entfällt; Speichermodus-Wechsel erfolgen direkt über `switchStorage`.
   * **Entfernt:** Der UI-Helfer `hideErrorBanner` steht nicht mehr zur Verfügung; Fehlversuche lassen das Banner nach dem Wiederholungsversuch automatisch ausgeblendet.
+  * **Entfernt:** Der veraltete Canvas-Zoom-Helfer `zoomCanvasToRange` entfällt; die Wellenform verlässt sich auf den Standardzoom und die dynamische Größenanpassung.
   * **`cleanupProject.js`** – nutzt `removeUnknownFileIds`, um Datei-IDs mit einer Liste aus der Oberfläche abzugleichen und unbekannte Einträge zu entfernen. Aufruf: `node utils/cleanupProject.js <projekt.json> <ids.json>`.
   * **`removeUnknownFileIds(project, ids, logFn)`** – Hilfsfunktion, die alle Dateien mit unbekannter ID entfernt und jede Entfernung protokolliert.
   * **Entfernt:** Die frühere Hilfsfunktion `syncProjectData` steht nicht mehr zur Verfügung, da ihre Aufgaben vollständig von `repairFileExtensions` abgedeckt werden.

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -579,19 +579,6 @@ function scheduleWaveformUpdate() {
     }, 120);
 }
 
-// Zoomt eine Canvas auf den angegebenen Bereich
-function zoomCanvasToRange(canvas, startMs, endMs, totalMs) {
-    if (!canvas) return;
-    const ratio = (endMs - startMs) / totalMs;
-    const scale = Math.min(10, 1 / ratio);
-    const selWidth = canvas.width * ratio * scale;
-    const container = canvas.parentElement;
-    const cWidth = container ? container.clientWidth : canvas.width;
-    const offset = -startMs / totalMs * canvas.width * scale + (cWidth - selWidth) / 2;
-    canvas.style.transformOrigin = '0 0';
-    canvas.style.transform = `translateX(${offset}px) scaleX(${scale})`;
-}
-
 // Setzt den Zoom einer Canvas zurück
 function resetCanvasZoom(canvas) {
     if (canvas) canvas.style.transform = '';


### PR DESCRIPTION
## Summary
- remove the unused `zoomCanvasToRange` helper from the waveform handling code
- document the removal in the README and CHANGELOG

## Testing
- npm test *(fails: known DOM-dependent suites require `document.querySelector`, `cancelTranslationQueue`, etc. in the current headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d2b51994832782772e53c330627d