### PR TITLE
Absicherung der Web-Speech-Funktion beim Sprecher-Ersetzen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 🛠️ Patch in 1.40.438
+* `web/src/main.js` schützt den Sprecher-Ersetzen-Button vor unsicheren Kontexten, prüft die Web-Speech-Unterstützung und fängt Startfehler der Spracherkennung mit aussagekräftigen Logs sowie Toasts ab.
+* `README.md` und `CHANGELOG.md` dokumentieren den abgesicherten Web-Speech-Fallback für „Sprecher ersetzen“.
 ## 🛠️ Patch in 1.40.437
 * `web/src/actions/projectEvaluate.js` entfernt den Aufruf `scoreVisibleLines` und konzentriert sich auf das Übernehmen vorhandener GPT-Ergebnisse.
 * `web/src/main.js` streicht die dynamische Initialisierung von `scoreVisibleLines` und lädt nur noch `applyEvaluationResults` nach.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Prompt-Vorschau:** Vor dem eigentlichen Versand zeigt ein Dialog den kompletten Prompt an. Erst nach Klick auf "Senden" wird die Anfrage gestellt und die Antwort im selben Fenster angezeigt
 * **Bewertung per Einfügen-Knopf:** Nach dem Versand erscheint ein zusätzlicher Knopf, der Score, Kommentar und Vorschlag in die Tabelle übernimmt
 * **Vorab-Dialog für GPT:** Vor dem Start zeigt ein Fenster, wie viele Zeilen und Sprecher enthalten sind
+* **Sprecher ersetzen mit Web-Speech-Fallback:** Der Mikrofon-Knopf prüft sichere Kontexte sowie Browser-Unterstützung und blendet bei fehlender Web-Speech-API einen deutschen Hinweis samt Toast ein, statt unkontrolliert zu scheitern.
 * **Unbewertete Zeilen:** Noch nicht bewertete Zeilen zeigen eine graue 0
 * **Score-Spalte nach Version:** Die farbige Bewertung steht direkt vor dem EN-Text
 * **Anpassbarer Bewertungs-Prompt:** Der Text liegt in `prompts/gpt_score.txt`; jede Bewertung liefert nun immer auch einen Verbesserungsvorschlag


### PR DESCRIPTION
## Summary
- sichern den Sprecher-Ersetzen-Button gegen unsichere Kontexte ab und prüfen die Verfügbarkeit der Web-Speech-API vor dem Zugriff
- protokollieren Fehler der Spracherkennung, fangen fehlgeschlagene Starts mit Toast-Hinweisen ab und dispatchen ein Ereignis für erkannte Sprecher
- dokumentieren den Web-Speech-Fallback in README und CHANGELOG

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e4cf2ffd488327833b98af8d565336