### PR TITLE
Add structured project loading steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 🛠️ Patch in 1.40.439
+* `web/hla_translation_tool.html` zeigt unter dem Ladebalken eine strukturierte Schritt-Liste für Projektwechsel an.
+* `web/src/style.css` gestaltet die neue Fortschrittsliste mit Statusfarben, Symbolspalte und Zeitstempeln.
+* `web/src/projectSwitch.js` führt eine Fortschrittsverwaltung ein, misst jeden Ladeschritt mit `performance.now()` und räumt die Liste nach Abschluss wieder leer.
+* `tests/testHelpers.js` stellt DOM-Hilfen für das Overlay bereit und alle Projektwechsel-Tests passen sich an die erweiterte Struktur an.
+* `README.md` dokumentiert den schrittweisen Projektwechsel inklusive Nutzerhinweis, `CHANGELOG.md` vermerkt die neue Anzeige.
 ## 🛠️ Patch in 1.40.438
 * `web/src/main.js` schützt den Sprecher-Ersetzen-Button vor unsicheren Kontexten, prüft die Web-Speech-Unterstützung und fängt Startfehler der Spracherkennung mit aussagekräftigen Logs sowie Toasts ab.
 * `README.md` und `CHANGELOG.md` dokumentieren den abgesicherten Web-Speech-Fallback für „Sprecher ersetzen“.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,9 @@ Eine vollständige **Offline‑Web‑App** zum Verwalten und Übersetzen aller A
 * **Grüne Rahmen** für **100 %**‑Projekte & vollständig übersetzte Ordner
 * **Grüne Haken** für abgeschlossene Kapitel
 * **Dateizeilen‑Badges:** Übersetzt / Ignoriert / Offen
+* **Schrittweiser Projektwechsel:** Das Ladeoverlay listet alle Teilschritte mit Statussymbolen und Laufzeit auf, damit klar ist, welcher Abschnitt gerade arbeitet oder bereits abgeschlossen ist.
+
+> ℹ️ **Hinweis:** Während ein Projekt lädt, bleibt die Liste sichtbar und zeigt laufende (⏳) sowie fertige (✔️) Schritte samt Dauer. Sobald der Wechsel fertig ist, verschwindet das Overlay wieder und die Liste wird automatisch geleert.
 
 </details>
 

--- a/tests/loadProjectDataMissingProject.test.js
+++ b/tests/loadProjectDataMissingProject.test.js
@@ -2,10 +2,11 @@
 // Prüft, ob loadProjectData bei fehlendem Projekt mit Fehlermeldung abbricht
 const fs = require('fs');
 const path = require('path');
+const { getProjectLoadingOverlayMarkup } = require('./testHelpers');
 
 test('loadProjectData bricht bei fehlendem Projekt ab', async () => {
   // Overlay simulieren, um Spinner zu prüfen
-  document.body.innerHTML = '<div id="projectLoadingOverlay"></div>';
+  document.body.innerHTML = getProjectLoadingOverlayMarkup({ hidden: false });
 
   // Projekte sind leer, Nachladen bringt nichts
   window.projects = [];

--- a/tests/projectSwitchClearGptState.test.js
+++ b/tests/projectSwitchClearGptState.test.js
@@ -2,10 +2,11 @@
 // Testet, ob beim Projektwechsel der GPT-Zustand geleert wird
 const fs = require('fs');
 const path = require('path');
+const { setupProjectLoadingOverlay } = require('./testHelpers');
 
 test('switchProjectSafe setzt gptEvaluationResults auf null', async () => {
     // Overlay für den Ladebalken bereitstellen
-    document.body.innerHTML = '<div id="projectLoadingOverlay" class="hidden"></div>';
+    setupProjectLoadingOverlay();
 
     // GPT-Zustand und Reset-Funktion simulieren
     gptEvaluationResults = { score: 99 };
@@ -25,6 +26,9 @@ test('switchProjectSafe setzt gptEvaluationResults auf null', async () => {
     window.resumeAutosave = jest.fn(async () => {});
     window.cancelGptRequests = jest.fn();
     window.reloadProjectList = jest.fn(async () => {});
+    window.scanEnOrdner = jest.fn(async () => {});
+    window.updateAllProjectsAfterScan = jest.fn();
+    window.updateFileAccessStatus = jest.fn();
 
     // switchProjectSafe aus projectSwitch.js laden
     const psCode = fs.readFileSync(path.join(__dirname, '../web/src/projectSwitch.js'), 'utf8');

--- a/tests/projectSwitchReinitializeListeners.test.js
+++ b/tests/projectSwitchReinitializeListeners.test.js
@@ -2,10 +2,11 @@
 // Stellt sicher, dass switchProjectSafe Event-Listener neu setzt
 const fs = require('fs');
 const path = require('path');
+const { setupProjectLoadingOverlay } = require('./testHelpers');
 
 test('switchProjectSafe initialisiert Listener neu', async () => {
   // Platzhalter für Overlay
-  document.body.innerHTML = '<div id="projectLoadingOverlay" class="hidden"></div>';
+  setupProjectLoadingOverlay();
 
   // Benötigte Helferfunktionen bereitstellen
   window.pauseAutosave = jest.fn(async () => {});

--- a/tests/projectSwitchReloadAfterError.test.js
+++ b/tests/projectSwitchReloadAfterError.test.js
@@ -2,9 +2,10 @@
 // Prüft, ob bei "Projekt nicht gefunden" die Liste neu geladen und erneut versucht wird
 const fs = require('fs');
 const path = require('path');
+const { setupProjectLoadingOverlay } = require('./testHelpers');
 
 test('switchProjectSafe lädt nach Fehler die Projektliste neu', async () => {
-  document.body.innerHTML = '<div id="projectLoadingOverlay" class="hidden"></div>';
+  setupProjectLoadingOverlay();
 
   let ersterAufruf = true;
   window.pauseAutosave = jest.fn(async () => {});
@@ -24,6 +25,9 @@ test('switchProjectSafe lädt nach Fehler die Projektliste neu', async () => {
   window.resumeAutosave = jest.fn(async () => {});
   window.cancelGptRequests = jest.fn();
   window.clearGptState = jest.fn();
+  window.scanEnOrdner = jest.fn(async () => {});
+  window.updateAllProjectsAfterScan = jest.fn();
+  window.updateFileAccessStatus = jest.fn();
 
   const psCode = fs.readFileSync(path.join(__dirname, '../web/src/projectSwitch.js'), 'utf8');
   eval(psCode);

--- a/tests/projectSwitchReloadBeforeLoad.test.js
+++ b/tests/projectSwitchReloadBeforeLoad.test.js
@@ -2,10 +2,11 @@
 // Testet, dass beim Projektwechsel die Liste vor dem Öffnen aktualisiert wird
 const fs = require('fs');
 const path = require('path');
+const { setupProjectLoadingOverlay } = require('./testHelpers');
 
 test('switchProjectSafe lädt Liste vor dem Projekt ohne Fehler', async () => {
   // Overlay für den Ladebalken bereitstellen
-  document.body.innerHTML = '<div id="projectLoadingOverlay" class="hidden"></div>';
+  setupProjectLoadingOverlay();
 
   const aufrufReihenfolge = [];
 
@@ -21,6 +22,9 @@ test('switchProjectSafe lädt Liste vor dem Projekt ohne Fehler', async () => {
   window.cancelGptRequests = jest.fn();
   window.clearGptState = jest.fn();
   window.loadProjectData = jest.fn(async () => { aufrufReihenfolge.push('loadProjectData'); });
+  window.scanEnOrdner = jest.fn(async () => {});
+  window.updateAllProjectsAfterScan = jest.fn();
+  window.updateFileAccessStatus = jest.fn();
 
   // loadProjects wirft Fehler, falls skipSelect nicht true ist
   window.loadProjects = jest.fn(async (skipSelect) => {

--- a/tests/projectSwitchReloadEnglishError.test.js
+++ b/tests/projectSwitchReloadEnglishError.test.js
@@ -2,10 +2,11 @@
 // Prüft, ob "Project not found" korrekt behandelt wird
 const fs = require('fs');
 const path = require('path');
+const { setupProjectLoadingOverlay } = require('./testHelpers');
 
 test('switchProjectSafe lädt nach englischer Fehlermeldung die Projektliste neu', async () => {
   // Platzhalter-Overlay, damit setBusy funktioniert
-  document.body.innerHTML = '<div id="projectLoadingOverlay" class="hidden"></div>';
+  setupProjectLoadingOverlay();
 
   let ersterAufruf = true;
   window.pauseAutosave = jest.fn(async () => {});
@@ -25,6 +26,9 @@ test('switchProjectSafe lädt nach englischer Fehlermeldung die Projektliste neu
   window.resumeAutosave = jest.fn(async () => {});
   window.cancelGptRequests = jest.fn();
   window.clearGptState = jest.fn();
+  window.scanEnOrdner = jest.fn(async () => {});
+  window.updateAllProjectsAfterScan = jest.fn();
+  window.updateFileAccessStatus = jest.fn();
 
   const psCode = fs.readFileSync(path.join(__dirname, '../web/src/projectSwitch.js'), 'utf8');
   eval(psCode);

--- a/tests/projectSwitchReloadListPersistent.test.js
+++ b/tests/projectSwitchReloadListPersistent.test.js
@@ -2,9 +2,10 @@
 // Prüft, ob bei dauerhaft fehlendem Projekt die Liste erneut geladen wird
 const fs = require('fs');
 const path = require('path');
+const { setupProjectLoadingOverlay } = require('./testHelpers');
 
 test('switchProjectSafe lädt Liste bei dauerhaft fehlendem Projekt erneut', async () => {
-  document.body.innerHTML = '<div id="projectLoadingOverlay" class="hidden"></div>';
+  setupProjectLoadingOverlay();
 
   window.pauseAutosave = jest.fn(async () => {});
   window.flushPendingWrites = jest.fn(async () => {});
@@ -18,6 +19,9 @@ test('switchProjectSafe lädt Liste bei dauerhaft fehlendem Projekt erneut', asy
   window.resumeAutosave = jest.fn(async () => {});
   window.cancelGptRequests = jest.fn();
   window.clearGptState = jest.fn();
+  window.scanEnOrdner = jest.fn(async () => {});
+  window.updateAllProjectsAfterScan = jest.fn();
+  window.updateFileAccessStatus = jest.fn();
 
   const psCode = fs.readFileSync(path.join(__dirname, '../web/src/projectSwitch.js'), 'utf8');
   eval(psCode);

--- a/tests/projectSwitchReloadMissingProject.test.js
+++ b/tests/projectSwitchReloadMissingProject.test.js
@@ -2,9 +2,10 @@
 // Testet, ob ein fehlendes Projekt nach Reparatur erneut geladen wird
 const fs = require('fs');
 const path = require('path');
+const { setupProjectLoadingOverlay } = require('./testHelpers');
 
 test('switchProjectSafe lädt fehlendes Projekt erneut', async () => {
-  document.body.innerHTML = '<div id="projectLoadingOverlay" class="hidden"></div>';
+  setupProjectLoadingOverlay();
 
   let loadCount = 0;
   window.pauseAutosave = jest.fn(async () => {});
@@ -19,6 +20,9 @@ test('switchProjectSafe lädt fehlendes Projekt erneut', async () => {
   window.resumeAutosave = jest.fn(async () => {});
   window.cancelGptRequests = jest.fn();
   window.clearGptState = jest.fn();
+  window.scanEnOrdner = jest.fn(async () => {});
+  window.updateAllProjectsAfterScan = jest.fn();
+  window.updateFileAccessStatus = jest.fn();
 
   const psCode = fs.readFileSync(path.join(__dirname, '../web/src/projectSwitch.js'), 'utf8');
   eval(psCode);

--- a/tests/resetGlobalStateProjects.test.js
+++ b/tests/resetGlobalStateProjects.test.js
@@ -2,6 +2,7 @@
 // Prüft, dass resetGlobalState die Projektliste in-place leert und Fenster-Referenzen behält
 const fs = require('fs');
 const path = require('path');
+const { getProjectLoadingOverlayMarkup } = require('./testHelpers');
 
 describe('resetGlobalState synchronisiert projects', () => {
   beforeEach(() => {
@@ -11,7 +12,7 @@ describe('resetGlobalState synchronisiert projects', () => {
       <div id="folderProgress"></div>
       <div id="emoProgress"></div>
       <div id="folderGrid" style="display: none"></div>
-      <div id="projectLoadingOverlay" class="hidden"></div>
+      ${getProjectLoadingOverlayMarkup()}
     `;
     window.storage = window.localStorage;
     window.showToast = jest.fn();

--- a/tests/testHelpers.js
+++ b/tests/testHelpers.js
@@ -1,0 +1,23 @@
+// Gemeinsame DOM-Helfer für Tests
+
+function getProjectLoadingOverlayMarkup({ hidden = true } = {}) {
+  const hiddenClass = hidden ? 'hidden' : '';
+  return `
+    <div id="projectLoadingOverlay" class="${hiddenClass}">
+      <div class="loading-box">
+        <div class="progress-bar"><div class="progress-fill"></div></div>
+        <span id="projectLoadingText">Projekt wird geladen...</span>
+        <ul id="projectLoadingSteps" class="loading-steps"></ul>
+      </div>
+    </div>
+  `;
+}
+
+function setupProjectLoadingOverlay(extraHtml = '') {
+  document.body.innerHTML = getProjectLoadingOverlayMarkup() + extraHtml;
+}
+
+module.exports = {
+  getProjectLoadingOverlayMarkup,
+  setupProjectLoadingOverlay
+};

--- a/tests/translationCallbackDuringReset.test.js
+++ b/tests/translationCallbackDuringReset.test.js
@@ -2,6 +2,7 @@
 // Prüft, dass verspätete Übersetzungsrückläufer während eines Resets keine Projekte speichern
 const fs = require('fs');
 const path = require('path');
+const { getProjectLoadingOverlayMarkup } = require('./testHelpers');
 
 describe('Übersetzungs-Rückläufer während Reset', () => {
   let storageMock;
@@ -38,7 +39,7 @@ describe('Übersetzungs-Rückläufer während Reset', () => {
       <div id="folderProgress"></div>
       <div id="emoProgress"></div>
       <div id="folderGrid" style="display: none"></div>
-      <div id="projectLoadingOverlay" class="hidden"></div>
+      ${getProjectLoadingOverlayMarkup()}
     `;
 
     window.showToast = jest.fn();

--- a/web/hla_translation_tool.html
+++ b/web/hla_translation_tool.html
@@ -26,6 +26,7 @@
         <div class="loading-box">
             <div class="progress-bar"><div class="progress-fill"></div></div>
             <span id="projectLoadingText">Projekt wird geladen...</span>
+            <ul id="projectLoadingSteps" class="loading-steps"></ul>
         </div>
     </div>
     <div id="errorBanner" class="error-banner hidden">

--- a/web/src/projectSwitch.js
+++ b/web/src/projectSwitch.js
@@ -18,6 +18,102 @@ const ui = {
   progress: (d, t) => {}
 };
 
+// Verwaltet die strukturierte Schritt-Anzeige im Ladeoverlay
+class LadeSchrittVerwaltung {
+  constructor() {
+    this.schritte = new Map();
+  }
+
+  liste() {
+    return document.getElementById('projectLoadingSteps');
+  }
+
+  start(titel) {
+    const container = this.liste();
+    if (!container) return null;
+    const eintrag = document.createElement('li');
+    eintrag.className = 'loading-step loading-step--running';
+
+    const symbol = document.createElement('span');
+    symbol.className = 'loading-step__icon';
+    symbol.textContent = '⏳';
+
+    const text = document.createElement('span');
+    text.className = 'loading-step__label';
+    text.textContent = titel;
+
+    const zeit = document.createElement('span');
+    zeit.className = 'loading-step__time';
+    zeit.textContent = '';
+
+    eintrag.append(symbol, text, zeit);
+    container.appendChild(eintrag);
+
+    const id = Symbol(titel);
+    this.schritte.set(id, { start: performance.now(), element: eintrag, icon: symbol, time: zeit });
+    return id;
+  }
+
+  abschliessen(id, status = 'ok', fehler = null) {
+    if (!id || !this.schritte.has(id)) return;
+    const daten = this.schritte.get(id);
+    this.schritte.delete(id);
+    const dauer = performance.now() - daten.start;
+    daten.element.classList.remove('loading-step--running');
+    if (status === 'error') {
+      daten.element.classList.add('loading-step--error');
+      daten.icon.textContent = '⚠️';
+      if (fehler) {
+        daten.element.setAttribute('data-error', String(fehler));
+      }
+    } else {
+      daten.element.classList.add('loading-step--done');
+      daten.icon.textContent = '✔️';
+    }
+    daten.time.textContent = this.formatiereDauer(dauer);
+  }
+
+  formatiereDauer(ms) {
+    if (!Number.isFinite(ms) || ms < 0) return '';
+    if (ms < 1000) {
+      return `${ms.toFixed(0)} ms`;
+    }
+    if (ms < 60000) {
+      return `${(ms / 1000).toFixed(1)} s`;
+    }
+    const minuten = Math.floor(ms / 60000);
+    const sekunden = Math.round((ms % 60000) / 1000);
+    const sekundenText = String(sekunden).padStart(2, '0');
+    return `${minuten}:${sekundenText} min`;
+  }
+
+  leeren() {
+    const container = this.liste();
+    if (container) {
+      container.innerHTML = '';
+    }
+    this.schritte.clear();
+  }
+}
+
+const ladeSchritte = new LadeSchrittVerwaltung();
+
+// Hilfsfunktion zum Erfassen eines asynchronen Schritts mit Zeitmessung
+async function verfolgeSchritt(titel, aktion, { ignoriereFehler = false } = {}) {
+  const id = ladeSchritte.start(titel);
+  try {
+    const ergebnis = await aktion();
+    ladeSchritte.abschliessen(id);
+    return ergebnis;
+  } catch (err) {
+    ladeSchritte.abschliessen(id, 'error', err);
+    if (ignoriereFehler) {
+      return undefined;
+    }
+    throw err;
+  }
+}
+
 /**
  * Blendet einen globalen Ladebalken ein oder aus,
  * um weitere Projektwechsel während des Ladens zu verhindern.
@@ -26,6 +122,7 @@ function setBusy(aktiv) {
   const overlay = document.getElementById('projectLoadingOverlay');
   if (!overlay) return; // Falls Oberfläche fehlt, nichts tun
   overlay.classList.toggle('hidden', !aktiv);
+  ladeSchritte.leeren();
 }
 
 /**
@@ -39,13 +136,11 @@ function switchProjectSafe(projectId) {
     try {
       // Autosave kurz anhalten
       if (!autosavePaused) {
-        await pauseAutosave();
+        await verfolgeSchritt('Autosave pausieren', () => pauseAutosave());
         autosavePaused = true;
       }
       // Ausstehende Schreibvorgänge abwarten
-      try {
-        await flushPendingWrites(3000);
-      } catch {}
+      await verfolgeSchritt('Schreibpuffer leeren', () => flushPendingWrites(3000), { ignoriereFehler: true });
       // GPT-Anfragen sofort abbrechen und verworfene Jobs protokollieren
       if (window.cancelGptRequests) window.cancelGptRequests('Projektwechsel');
       // Laufende Ladevorgänge abbrechen
@@ -54,21 +149,25 @@ function switchProjectSafe(projectId) {
       }
       projectAbort = new AbortController();
       // Event-Listener und Caches zurücksetzen
-      detachAllEventListeners();
+      await verfolgeSchritt('Event-Listener lösen', async () => {
+        detachAllEventListeners();
+      });
       if (typeof window.cancelTranslationQueue === 'function') {
-        window.cancelTranslationQueue('Projektwechsel');
+        await verfolgeSchritt('Übersetzungswarteschlange stoppen', () => window.cancelTranslationQueue('Projektwechsel'));
       }
-      clearInMemoryCachesHard();
+      await verfolgeSchritt('Caches leeren', async () => {
+        clearInMemoryCachesHard();
+      });
       // Offenes Projekt schließen
-      try { await closeProjectData(); } catch {}
+      await verfolgeSchritt('Projekt schließen', () => closeProjectData(), { ignoriereFehler: true });
       // Projektliste aktualisieren, ohne automatisch ein Projekt zu öffnen
-      await reloadProjectList(true);
+      await verfolgeSchritt('Projektliste aktualisieren', () => reloadProjectList(true));
       // GPT-Zustände und UI leeren
       if (window.clearGptState) window.clearGptState();
       // Neues Projekt laden und auf Promise warten
       let geladen = false;
       try {
-        await loadProjectData(projectId, { signal: projectAbort.signal });
+        await verfolgeSchritt('Projekt laden', () => loadProjectData(projectId, { signal: projectAbort.signal }));
         geladen = true;
       } catch (err) {
         // Wenn das Projekt fehlt, zunächst Reparaturversuch starten
@@ -77,11 +176,11 @@ function switchProjectSafe(projectId) {
         if (/(nicht gefunden|not found)/i.test(msg)) {
           const adapter = getStorageAdapter('current');
           try {
-            await repairProjectIntegrity(adapter, projectId, ui);
+            await verfolgeSchritt('Projekt reparieren', () => repairProjectIntegrity(adapter, projectId, ui));
           } catch {}
           // Danach Liste neu laden und erneut versuchen
-          await reloadProjectList(true);
-          await loadProjectData(projectId, { signal: projectAbort.signal });
+          await verfolgeSchritt('Projektliste aktualisieren', () => reloadProjectList(true));
+          await verfolgeSchritt('Projekt laden', () => loadProjectData(projectId, { signal: projectAbort.signal }));
           geladen = true;
         } else {
           throw err; // Unbekannter Fehler wird nach außen gereicht
@@ -90,18 +189,18 @@ function switchProjectSafe(projectId) {
       if (currentSession !== mySession || !geladen) return;
       // Direkt im Anschluss verwaiste Einträge reparieren
       const adapter = getStorageAdapter('current');
-      const neuAngelegt = await repairProjectIntegrity(adapter, projectId, ui);
+      const neuAngelegt = await verfolgeSchritt('Projektintegrität prüfen', () => repairProjectIntegrity(adapter, projectId, ui));
       if (neuAngelegt) {
         // Projekt wurde angelegt: Liste neu laden und Projekt erneut öffnen
-        await reloadProjectList(true);
-        await loadProjectData(projectId, { signal: projectAbort.signal });
+        await verfolgeSchritt('Projektliste aktualisieren', () => reloadProjectList(true));
+        await verfolgeSchritt('Projekt laden', () => loadProjectData(projectId, { signal: projectAbort.signal }));
         if (currentSession !== mySession) return;
       }
       // Nach erfolgreichem Laden alle relevanten Ordner scannen
       if (window.electronAPI?.scanFolders) {
         // Electron-Umgebung: Scan über die Hauptanwendung
-        const data = await window.electronAPI.scanFolders();
-        await verarbeiteGescannteDateien(data.enFiles);
+        const data = await verfolgeSchritt('Ordner scannen (Electron)', () => window.electronAPI.scanFolders());
+        await verfolgeSchritt('EN-Dateien verarbeiten', () => verarbeiteGescannteDateien(data.enFiles));
         data.deFiles.forEach(f => {
           if (typeof setDeAudioCacheEntry === 'function') {
             setDeAudioCacheEntry(f.fullPath, `sounds/DE/${f.fullPath}`);
@@ -111,23 +210,29 @@ function switchProjectSafe(projectId) {
         });
       } else {
         // Browser-Fallback: lokale Ordner direkt scannen
-        await scanEnOrdner();
+        await verfolgeSchritt('EN-Ordner scannen', () => scanEnOrdner());
         if (typeof scanDeOrdner === 'function') {
-          await scanDeOrdner();
+          await verfolgeSchritt('DE-Ordner scannen', () => scanDeOrdner());
         }
       }
       // Anschließend Projekte und Zugriffsstatus aktualisieren
-      updateAllProjectsAfterScan();
-      updateFileAccessStatus();
+      await verfolgeSchritt('Projektstatus aktualisieren', async () => {
+        updateAllProjectsAfterScan();
+        updateFileAccessStatus();
+      });
       // Nach dem Laden Toolbar-Knöpfe neu verbinden
-      window.initToolbarButtons?.(); // bindet alle Listener der Werkzeugleiste erneut
-      window.initVideoManager?.(); // richtet den Video-Manager nach jedem Wechsel neu ein
+      await verfolgeSchritt('Toolbar neu verbinden', async () => {
+        window.initToolbarButtons?.(); // bindet alle Listener der Werkzeugleiste erneut
+        window.initVideoManager?.(); // richtet den Video-Manager nach jedem Wechsel neu ein
+      });
       // Event-Listener wie die Live-Suche neu setzen
-      window.initializeEventListeners?.();
+      await verfolgeSchritt('Event-Listener reinitialisieren', async () => {
+        window.initializeEventListeners?.();
+      });
     } finally {
       // Autosave wieder aktivieren
       if (autosavePaused) {
-        await resumeAutosave();
+        await verfolgeSchritt('Autosave fortsetzen', () => resumeAutosave());
         autosavePaused = false;
       }
       if (currentSession === mySession) setBusy(false);

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -4686,3 +4686,55 @@ th:nth-child(8) {
     width: 50%;
     animation: loadingBar 1s linear infinite;
 }
+/* Strukturierte Schritt-Liste im Ladeoverlay */
+.loading-steps {
+    margin-top: 16px;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 220px;
+    overflow-y: auto;
+    padding: 0;
+}
+.loading-step {
+    display: grid;
+    grid-template-columns: 24px 1fr auto;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.35);
+    color: #f0f0f0;
+    font-size: 14px;
+}
+.loading-step__icon {
+    font-size: 16px;
+    text-align: center;
+    color: #ffb74d;
+}
+.loading-step__label {
+    text-align: left;
+}
+.loading-step__time {
+    font-variant-numeric: tabular-nums;
+    font-size: 12px;
+    color: #bdbdbd;
+    min-width: 64px;
+    text-align: right;
+}
+.loading-step--running .loading-step__icon {
+    color: #ffb74d;
+}
+.loading-step--done {
+    background: rgba(46, 125, 50, 0.35);
+}
+.loading-step--done .loading-step__icon {
+    color: #81c784;
+}
+.loading-step--error {
+    background: rgba(183, 28, 28, 0.4);
+}
+.loading-step--error .loading-step__icon {
+    color: #ef5350;
+}


### PR DESCRIPTION
## Zusammenfassung
- ergänze die Projekt-Overlay-Ansicht um eine strukturierte Schritt-Liste samt Styling
- erweitere switchProjectSafe um eine Fortschrittsverwaltung mit Zeitmessung und setze die neue Liste in allen Kernschritten ein
- passe die Projektwechsel-Tests mit einem gemeinsamen Overlay-Helfer an und dokumentiere die Funktion in README sowie CHANGELOG

## Tests
- npm test -- projectSwitch
- npm test -- loadProjectDataMissingProject
- npm test -- translationCallbackDuringReset

------
https://chatgpt.com/codex/tasks/task_e_68e50448e310832781c3ecc7c07023ac